### PR TITLE
fix: delete cm5 wiringX

### DIFF
--- a/docs/compute-module/cm5/radxa-os/app-dev/wiringx.md
+++ b/docs/compute-module/cm5/radxa-os/app-dev/wiringx.md
@@ -1,5 +1,0 @@
----
-sidebar_position: 1
----
-
-# WiringX 使用

--- a/i18n/en/docusaurus-plugin-content-docs/current/compute-module/cm5/radxa-os/app-dev/wiringx.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/compute-module/cm5/radxa-os/app-dev/wiringx.md
@@ -1,5 +1,0 @@
----
-sidebar_position: 1
----
-
-# WiringX


### PR DESCRIPTION
###### Description of changes

<!--
Please briefly describe changes made in this PR.
-->

Delete wiringX of Radxa CM5 as it is not currently ported.