### PR TITLE
fix: fix the imagesearch and chatdoc docker name in casaos

### DIFF
--- a/docs/common/ai/_casaos_app_install.mdx
+++ b/docs/common/ai/_casaos_app_install.mdx
@@ -16,7 +16,7 @@ radxa 目前已将 `Stable Diffusion`, `whisper`, `chatdoc`, `imagesearch` 四�
 
 ![casaos_2.webp](/img/general-tutorial/tpu_ai/casaos_2.webp)
 
-### 安装 radxa stable diffusion 文生图 App
+### 安装 radxa Stable Diffusion 文/图生图 App
 
 - 填入 radxa stable diffusion 容器安装所需信息
 
@@ -70,7 +70,7 @@ radxa 目前已将 `Stable Diffusion`, `whisper`, `chatdoc`, `imagesearch` 四�
   | **Container Devices** | /dev                              |
   | **CPU Shares**        | Medium                            |
 
-### 安装 radxa whisper 语音识别总结 App
+### 安装 radxa Whisper 语音识别总结 App
 
 - 填入 radxa whisper 容器安装所需信息
 
@@ -91,7 +91,7 @@ radxa 目前已将 `Stable Diffusion`, `whisper`, `chatdoc`, `imagesearch` 四�
 
   |                       | radxa ImageSearch                      |
   | --------------------- | -------------------------------------- |
-  | **Docker Image**      | radxazifeng278/radxa_chatdoc_app:0.1.0 |
+  | **Docker Image**      | radxazifeng278/radxa_imgsearch_app:0.1.0 |
   | **Title**             | Image_Search                           |
   | **Web UI port**       | 8007                                   |
   | **Host Port**         | 8007                                   |
@@ -110,7 +110,7 @@ radxa 目前已将 `Stable Diffusion`, `whisper`, `chatdoc`, `imagesearch` 四�
 
   |                       | radxa Chatdoc                            |
   | --------------------- | ---------------------------------------- |
-  | **Docker Image**      | radxazifeng278/radxa_imgsearch_app:0.1.0 |
+  | **Docker Image**      | radxazifeng278/radxa_chatdoc_app:0.1.0	 |
   | **Title**             | chatdoc                                  |
   | **Web UI port**       | 8009                                     |
   | **Host Port**         | 8009                                     |

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_casaos_app_install.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_casaos_app_install.mdx
@@ -13,7 +13,7 @@ Here, we'll explain how to install radxa large model Apps on CasaOS. Third-party
 
 ![casaos_2.webp](/img/general-tutorial/tpu_ai/casaos_2.webp)
 
-### Install radxa stable diffusion Literature Image App
+### Install radxa Stable Diffusion App
 
 - Fill in the required information for installing radxa stable diffusion container
 
@@ -67,7 +67,7 @@ Here, we'll explain how to install radxa large model Apps on CasaOS. Third-party
   | **Container Devices** | /dev                              |
   | **CPU Shares**        | Medium                            |
 
-### Install radxa whisper Speech Recognition Summary App
+### Install radxa Whisper Speech Recognition Summary App
 
 - Fill in the required information for installing radxa whisper container
 
@@ -82,13 +82,13 @@ Here, we'll explain how to install radxa large model Apps on CasaOS. Third-party
   | **Container Devices** | /dev                                   |
   | **CPU Shares**        | Medium                                 |
 
-### Install radxa ImageSearch Image Search App
+### Install radxa ImageSearch App
 
 - Fill in the required information for installing radxa ImageSearch container
 
   |                       | radxa ImageSearch                      |
   | --------------------- | -------------------------------------- |
-  | **Docker Image**      | radxazifeng278/radxa_chatdoc_app:0.1.0 |
+  | **Docker Image**      | radxazifeng278/radxa_imgsearch_app:0.1.0 |
   | **Title**             | Image_Search                           |
   | **Web UI port**       | 8007                                   |
   | **Host Port**         | 8007                                   |
@@ -97,7 +97,7 @@ Here, we'll explain how to install radxa large model Apps on CasaOS. Third-party
   | **Container Devices** | /dev                                   |
   | **CPU Shares**        | Medium                                 |
 
-### Install radxa chatdoc Document Chat App
+### Install radxa Chatdoc Document Chat App
 
 **Before installing chatdoc, it is necessary to refer to [Memory Allocation Modification Tool](../local-ai-deploy/ai-tools/memory_allocate) to modify the memory allocation of SG2300X**
 
@@ -107,7 +107,7 @@ Recommended allocation -NPU 7168, -VPU 2048, -VPP 3072
 
   |                       | radxa Chatdoc                            |
   | --------------------- | ---------------------------------------- |
-  | **Docker Image**      | radxazifeng278/radxa_imgsearch_app:0.1.0 |
+  | **Docker Image**      | radxazifeng278/radxa_chatdoc_app:0.1.0	 |
   | **Title**             | chatdoc                                  |
   | **Web UI port**       | 8009                                     |
   | **Host Port**         | 8009                                     |


### PR DESCRIPTION
fix the imagesearch and chatdoc docker name in casaos
