### PR TITLE
Add note about I2C pull-ups

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/hardware-design/hardware-interface.md
@@ -37,6 +37,8 @@ Radxa ZERO 3 provides a 40-pin GPIO header, which is compatible with most SBC ac
 
 :::caution
 Pin 3 and Pin 5 add extra pull-up resistors for I2C device power supply, so they work abnormally when used as GPIOs.
+This applies to Pin 27 and Pin 28 as well.
+The resistance is 2.2kΩ according to the schematic.
 :::
 
 | GPIO number | Function5   |  Function4   |    Function3    |  Function2   | Function1 |               Pin#               |              Pin#               | Function1 |                 Function2                 | Function3 |  Function4  | Function5    | GPIO number |


### PR DESCRIPTION
There are pull-up resistors also I2C3. Also add note about the resistance value.

###### Description of changes

<!--
Please briefly describe changes made in this PR.
-->

* Add note about I2C pull-up resistors also being present on I2C4.
* Add note about the resistance being 2.2kOhm


EDIT: Please confirm the validity of these sgtatements before merging. I belive them to be correct. I even tested communicating with a device that doesn't have any i2c pull-ups using both I2C3 and I2C4 and it worked well. The info is taken from the schematic.