### PR TITLE
docs: fix wrong docker path name

### DIFF
--- a/docs/common/ai/_casaos_intro.mdx
+++ b/docs/common/ai/_casaos_intro.mdx
@@ -111,7 +111,7 @@ CasaOS 系统界面
   ln -s /data/docker /var/lib
   ```
 
-  此时软链接就创建完成，输入命令 `ls -l /vae/lib/docker` 可以查看软链接的链接地址
+  此时软链接就创建完成，输入命令 `ls -l /var/lib/docker` 可以查看软链接的链接地址
 
   ```bash
   $ ls -l /var/lib/docker


### PR DESCRIPTION
docs: fix wrong docker path name