### PR TITLE
Patches removed for rkdeveloptool

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptool.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptool.mdx
@@ -31,9 +31,6 @@ sudo apt-get update
 sudo apt-get install -y libudev-dev libusb-1.0-0-dev dh-autoreconf pkg-config libusb-1.0 build-essential git wget
 git clone https://github.com/rockchip-linux/rkdeveloptool
 cd rkdeveloptool
-wget https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-wget https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-git am *.patch
 autoreconf -i
 ./configure
 make -j $(nproc)
@@ -49,9 +46,6 @@ Please install [Homebrew](https://brew.sh/) first, then run the following comman
 brew install automake autoconf libusb pkg-config git wget
 git clone https://github.com/rockchip-linux/rkdeveloptool
 cd rkdeveloptool
-wget https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-wget https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-git am *.patch
 autoreconf -i
 ./configure
 make -j $(nproc)


### PR DESCRIPTION
This patch does not needed anymore.  Patch 73 was merged and patch 85 was already fixed in another commit. So this steps can be removed from wiki.