### PR TITLE
docs: Outdated command correction

### DIFF
--- a/docs/common/dev/_rkdeveloptool.mdx
+++ b/docs/common/dev/_rkdeveloptool.mdx
@@ -29,9 +29,6 @@ sudo apt-get update
 sudo apt-get install -y libudev-dev libusb-1.0-0-dev dh-autoreconf pkg-config libusb-1.0 build-essential git wget
 git clone https://github.com/rockchip-linux/rkdeveloptool
 cd rkdeveloptool
-wget https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-wget https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-git am *.patch
 autoreconf -i
 ./configure
 make -j $(nproc)
@@ -47,9 +44,6 @@ sudo cp rkdeveloptool /usr/local/sbin/
 brew install automake autoconf libusb pkg-config git wget
 git clone https://github.com/rockchip-linux/rkdeveloptool
 cd rkdeveloptool
-wget https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-wget https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-git am *.patch
 autoreconf -i
 ./configure
 make -j $(nproc)

--- a/docs/common/dev/_rkdeveloptoolV2.mdx
+++ b/docs/common/dev/_rkdeveloptoolV2.mdx
@@ -25,14 +25,6 @@ rkdeveloptool 可以被认为是[开源版本](https://opensource.rock-chips.com
             <br />
             cd rkdeveloptool
             <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-            <br />
-            git am *.patch
-            <br />
             autoreconf -i
             <br />
             ./configure
@@ -54,14 +46,6 @@ rkdeveloptool 可以被认为是[开源版本](https://opensource.rock-chips.com
             git clone https://github.com/rockchip-linux/rkdeveloptool
             <br />
             cd rkdeveloptool
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-            <br />
-            git am *.patch
             <br />
             autoreconf -i
             <br />
@@ -99,14 +83,6 @@ rkdeveloptool 可以被认为是[开源版本](https://opensource.rock-chips.com
         git clone https://github.com/rockchip-linux/rkdeveloptool
         <br />
         cd rkdeveloptool
-        <br />
-        wget
-        https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-        <br />
-        wget
-        https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-        <br />
-        git am *.patch
         <br />
         autoreconf -i
         <br />

--- a/docs/common/dev/_rkdeveloptoolV3.mdx
+++ b/docs/common/dev/_rkdeveloptoolV3.mdx
@@ -25,12 +25,6 @@ rkdeveloptool 可以被认为是[开源版本](https://opensource.rock-chips.com
             <br />
             cd rkdeveloptool
             <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-            <br />
             git am *.patch
             <br />
             autoreconf -i
@@ -54,14 +48,6 @@ rkdeveloptool 可以被认为是[开源版本](https://opensource.rock-chips.com
             git clone https://github.com/rockchip-linux/rkdeveloptool
             <br />
             cd rkdeveloptool
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-            <br />
-            git am *.patch
             <br />
             autoreconf -i
             <br />
@@ -99,14 +85,6 @@ rkdeveloptool 可以被认为是[开源版本](https://opensource.rock-chips.com
         git clone https://github.com/rockchip-linux/rkdeveloptool
         <br />
         cd rkdeveloptool
-        <br />
-        wget
-        https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-        <br />
-        wget
-        https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-        <br />
-        git am *.patch
         <br />
         autoreconf -i
         <br />

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV2.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV2.mdx
@@ -25,14 +25,6 @@ If your operating system does not provide rkdeveloptool, you will need to compil
             <br />
             cd rkdeveloptool
             <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-            <br />
-            git am *.patch
-            <br />
             autoreconf -i
             <br />
             ./configure
@@ -54,14 +46,6 @@ If your operating system does not provide rkdeveloptool, you will need to compil
             git clone https://github.com/rockchip-linux/rkdeveloptool
             <br />
             cd rkdeveloptool
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-            <br />
-            git am *.patch
             <br />
             autoreconf -i
             <br />
@@ -101,14 +85,6 @@ If your operating system does not provide rkdeveloptool, you will need to compil
         git clone https://github.com/rockchip-linux/rkdeveloptool
         <br />
         cd rkdeveloptool
-        <br />
-        wget
-        https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-        <br />
-        wget
-        https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-        <br />
-        git am *.patch
         <br />
         autoreconf -i
         <br />

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV3.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV3.mdx
@@ -25,14 +25,6 @@ If your operating system does not provide rkdeveloptool, you will need to compil
             <br />
             cd rkdeveloptool
             <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-            <br />
-            git am *.patch
-            <br />
             autoreconf -i
             <br />
             ./configure
@@ -54,14 +46,6 @@ If your operating system does not provide rkdeveloptool, you will need to compil
             git clone https://github.com/rockchip-linux/rkdeveloptool
             <br />
             cd rkdeveloptool
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-            <br />
-            wget
-            https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-            <br />
-            git am *.patch
             <br />
             autoreconf -i
             <br />
@@ -101,14 +85,6 @@ If your operating system does not provide rkdeveloptool, you will need to compil
         git clone https://github.com/rockchip-linux/rkdeveloptool
         <br />
         cd rkdeveloptool
-        <br />
-        wget
-        https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/73.patch
-        <br />
-        wget
-        https://patch-diff.githubusercontent.com/raw/rockchip-linux/rkdeveloptool/pull/85.patch
-        <br />
-        git am *.patch
         <br />
         autoreconf -i
         <br />


### PR DESCRIPTION
The original repository has merged related branches, no need to manually patch.

- https://github.com/rockchip-linux/rkdeveloptool/pull/73 merged
- https://github.com/rockchip-linux/rkdeveloptool/pull/85 closed, been instead of https://github.com/rockchip-linux/rkdeveloptool/pull/57