### PR TITLE
fix: modify rock5t emmc boot system

### DIFF
--- a/docs/rock5/rock5t/getting-started/install-os/emmc_boot.md
+++ b/docs/rock5/rock5t/getting-started/install-os/emmc_boot.md
@@ -2,9 +2,9 @@
 sidebar_position: 3
 ---
 
-# 安装系统到 eMMC 模块
+# 安装系统到 eMMC
 
-若您的瑞莎 ROCK 5T 板载 eMMC 模块，您可以在 MicroSD 卡启动主板的情况下，使用 `dd` 命令将系统镜像写入 eMMC 模块。
+若您的瑞莎 ROCK 5T 板载 eMMC，您可以在 MicroSD 卡启动主板的情况下，使用 `dd` 命令将系统镜像写入 eMMC。
 
 :::tip 注意事项
 安装系统会格式化 eMMC 模块，如果有重要数据请提前备份！
@@ -44,6 +44,8 @@ sidebar_position: 3
 ```
 sudo apt install wget
 wget [url]
+# 示例
+wget https://github.com/radxa-build/rock-5t/releases/download/rsdk-b2/rock-5t_bookworm_kde_b2.output.img.xz
 ```
 
 参数解释：其中 `[url]` 需要替换成实际的系统镜像文件下载链接。
@@ -61,6 +63,20 @@ wget [url]
 :::tip 说明
 下载的系统镜像文件是压缩包，需要解压后才能使用。
 :::
+
+### 解压系统镜像
+
+使用 `unxz` 命令解压系统镜像文件。
+
+<NewCodeBlock tip="radxa@device$" type="device">
+```
+sudo apt install xz-utils
+unxz [image_path]
+# 示例
+unxz ~/rock-5t_bookworm_kde_b2.output.img.xz
+```
+</NewCodeBlock>
+参数解释：其中 `[image_path]` 需要替换成实际的系统镜像文件路径。
 
 ### 写入系统镜像
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/getting-started/install-os/emmc_boot.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/getting-started/install-os/emmc_boot.md
@@ -2,11 +2,11 @@
 sidebar_position: 3
 ---
 
-# Install OS to eMMC Module
+# Install the system to eMMC
 
-If your Radxa ROCK 5T has an onboard eMMC module, you can use the `dd` command to write the system image to the eMMC module while booting from a MicroSD card.
+If your Radxa ROCK 5T has an onboard eMMC, you can use the `dd` command to write the system image to the eMMC while booting from a MicroSD card.
 
-:::tip Note
+:::tip Important Notes
 Installing the system will format the eMMC module. Please back up any important data in advance!
 
 If your system cannot currently boot from a MicroSD card, you can refer to the [Install OS to MicroSD Card](./boot_from_sd_card.md) tutorial.
@@ -17,13 +17,13 @@ If your system cannot currently boot from a MicroSD card, you can refer to the [
 You will need the following hardware:
 
 - Board: Radxa ROCK 5T
-- System boot media: MicroSD card
+- Boot medium: MicroSD card
 - Power adapter: Standard DC 12V/2A power adapter (DC-5525 interface)
 
-We need to boot the board system from a MicroSD card, download the system image file after entering the board system, and then use the `dd` command to write the system image to the eMMC module.
+We will boot the system from the MicroSD card, download the system image file after entering the system, and then use the `dd` command to write the system image to the eMMC module.
 
 :::tip Recommended Accessories
-Radxa ROCK 5T only supports 12V power input. A current of 2A or higher is recommended to ensure stable operation of all peripherals.
+Radxa ROCK 5T only supports 12V power input, and a current of 2A or higher is recommended to ensure stable operation of all peripherals.
 
 - [Radxa DC12 36W Power Adapter](https://radxa.com/products/accessories/power-dc12-36w) (Recommended)
 - [Radxa DC12 60W Power Adapter](https://radxa.com/products/accessories/power-dc12-60w)
@@ -32,25 +32,28 @@ Radxa ROCK 5T only supports 12V power input. A current of 2A or higher is recomm
 
 ## Download System Image
 
-You can download the system image file by visiting the [Resource Download Center](../../download) page on the board.
+You can download the system image file by visiting the [Resource Download Center](../../download) page on your board.
 
-:::tip Download Suggestions
-We provide the following methods to download the system image file to the board. You can choose the appropriate method according to your actual situation:
+:::tip Download Recommendations
+We provide the following methods to download the system image file to your board. Please choose the appropriate method based on your situation:
 
-- Download using `wget` command
+- Using `wget` command
 
-You can copy the system image file link from the [Resource Download Center](../../download) page and use the `wget` command to download it on the board.
+You can copy the system image file link from the [Resource Download Center](../../download) page and use the `wget` command on your board to download it.
 
 ```
 sudo apt install wget
 wget [url]
+# Example
+wget https://github.com/radxa-build/rock-5t/releases/download/rsdk-b2/rock-5t_bookworm_kde_b2.output.img.xz
 ```
 
-Parameter explanation: Replace `[url]` with the actual system image file download link.
+Parameter explanation: Replace `[url]` with the actual system image download link.
 
 - PC Download
 
-You can download the system image file on your PC by visiting the [Resource Download Center](../../download) page, and then transfer the system image file to the board via USB flash drive, FTP, SCP, etc.
+You can download the system image file from the [Resource Download Center](../../download) page on your PC, then transfer it to the board using a USB drive, FTP, SCP, or other methods.
+
 :::
 
 ## Install System
@@ -58,15 +61,29 @@ You can download the system image file on your PC by visiting the [Resource Down
 Use the `dd` command to install the system image to the eMMC module.
 
 :::tip Note
-The downloaded system image file is a compressed package and needs to be extracted before use.
+The downloaded system image file is compressed and needs to be extracted before use.
 :::
+
+### Extract System Image
+
+Use the `unxz` command to extract the system image file.
+
+<NewCodeBlock tip="radxa@device$" type="device">
+```
+sudo apt install xz-utils
+unxz [image_path]
+# Example
+unxz ~/rock-5t_bookworm_kde_b2.output.img.xz
+```
+</NewCodeBlock>
+Parameter explanation: Replace `[image_path]` with the actual path to the system image file.
 
 ### Write System Image
 
-Use the `dd` command to write the extracted system image file to the eMMC module.
+Use the `dd` command to write the extracted system image to the eMMC module.
 
 :::danger
-When using the `dd` command, make sure to select the correct device file, otherwise it may format the wrong device, resulting in data loss!
+When using the `dd` command, make sure to select the correct device file to avoid formatting the wrong device and causing data loss!
 :::
 
 <NewCodeBlock tip="radxa@device$" type="device">
@@ -75,14 +92,14 @@ sudo dd if=[image_path] of=/dev/mmcblk0 bs=4M status=progress
 ```
 </NewCodeBlock>
 Parameter explanation:
-- `if`: Specify the input file, replace `[image_path]` with the path to the extracted system image file
-- `of`: Specify the output device, replace `/dev/mmcblk0` with the device file corresponding to the eMMC module (please modify according to the actual device)
+- `if`: Specify the input file. Replace `[image_path]` with the path to the extracted system image file
+- `of`: Specify the output device. Replace `/dev/mmcblk0` with the device file corresponding to your eMMC module (please modify according to your actual device)
 - `bs`: Block size, recommended 4M
 - `status=progress`: Show write progress
 
 ### Verify System Image
 
-After writing the system image, you can use the `fdisk` command to view the partition information of the target boot medium to confirm whether the system image was written successfully.
+After writing the system image, you can use the `fdisk` command to view the partition information of the boot medium to confirm if the system image was written successfully.
 
 <NewCodeBlock tip="radxa@device$" type="device">
 ```
@@ -90,7 +107,7 @@ sudo fdisk -l /dev/mmcblk0
 ```
 </NewCodeBlock>
 
-If the system is successfully written, the terminal will output partition information similar to the following:
+If the system was written successfully, the terminal will output partition information similar to the following:
 
 ```
 Disk /dev/mmcblk0: 119.15 GiB, 127934660608 bytes, 31234048 sectors
@@ -107,13 +124,13 @@ Device Start End Sectors Size Type
 /dev/mmcblk0p3 679936 31234014 30554079 116.6G EFI System
 ```
 
-## Boot System
+## Boot the System
 
-After completing the system installation, power off the board, unplug the MicroSD card, and then reconnect the power adapter. The system will automatically boot from the eMMC module.
+After completing the system installation, power off the board, remove the MicroSD card, and then reconnect the power adapter. The system will automatically boot from the eMMC module.
 
 ## System Information
 
-When using our provided system image, you need to log in to the system using the username and password we set for the first time.
+When using our provided system image, you will need to log in with the following default credentials:
 
 - Debian Linux
 


### PR DESCRIPTION
###### 修改 ROCK5T eMMC 启动教程

- 板载 eMMC 去掉模块描述
- 增加解压系统镜像的步骤
- 增加解压和下载系统镜像的命令示例

<!--
Please briefly describe changes made in this PR.
-->
