### PR TITLE
fix: modify e20c debian system link

### DIFF
--- a/docs/e/e20c/download.md
+++ b/docs/e/e20c/download.md
@@ -12,9 +12,9 @@ istoreos:
 
 [istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://dl.radxa.com/rock2/images/istoreos/istoreos-22.03.6-2024062810-e20c-squashfs.img.gz)
 
-debian xfce:
+debian cli:
 
-[rock-2_bullseye_xfce_b1.output.img.xz](https://github.com/radxa-build/rock-2/releases/download/b1/rock-2_bullseye_xfce_b1.output.img.xz)
+[rock-2_bullseye_cli_b1.output.img.xz](https://github.com/radxa-build/rock-2/releases/download/b1/rock-2_bullseye_cli_b1.output.img.xz)
 
 Flippy OpenWrt:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
@@ -12,9 +12,9 @@ istoreos:
 
 [istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://dl.radxa.com/rock2/images/istoreos/istoreos-22.03.6-2024062810-e20c-squashfs.img.gz)
 
-debian xfce:
+debian cli:
 
-[rock-2_bullseye_xfce_b1.output.img.xz](https://github.com/radxa-build/rock-2/releases/download/b1/rock-2_bullseye_xfce_b1.output.img.xz)
+[rock-2_bullseye_cli_b1.output.img.xz](https://github.com/radxa-build/rock-2/releases/download/b1/rock-2_bullseye_cli_b1.output.img.xz)
 
 Flippy OpenWrt:
 


### PR DESCRIPTION
###### 修改 E20C 的系统镜像链接

- xfce 系统镜像链接改成cli 系统镜像链接

<!--
Please briefly describe changes made in this PR.
-->

Closes #863 