### PR TITLE
fix: modify e24c debian image link

### DIFF
--- a/docs/e/e24c/download.md
+++ b/docs/e/e24c/download.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 
 ### Debian
 
-[Debian](https://github.com/radxa-build/radxa-rk3528/releases/download/rsdk-t2/radxa-rk3528_bookworm_cli_t2.output.img.xz) 镜像系统文件 : 解压后可直接写入SD卡/eMMC/SSD
+[Debian](https://github.com/radxa-build/radxa-rk3528/releases/download/rsdk-t2/radxa-rk3528_bookworm_kde_t2.output.img.xz) 镜像系统文件 : 解压后可直接写入SD卡/eMMC/SSD
 
 ### OpenWrt
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e24c/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e24c/download.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 
 ### Debian
 
-[Debian](https://github.com/radxa-build/radxa-rk3528/releases/download/rsdk-t2/radxa-rk3528_bookworm_cli_t2.output.img.xz) System Image: Can be directly written to SD card/eMMC/SSD after extraction
+[Debian](https://github.com/radxa-build/radxa-rk3528/releases/download/rsdk-t2/radxa-rk3528_bookworm_kde_t2.output.img.xz) System Image: Can be directly written to SD card/eMMC/SSD after extraction
 
 ### OpenWrt
 


### PR DESCRIPTION
###### 修改 E24C Debian 镜像的下载链接
- CLI 镜像下载链接改成 KDE 镜像链接
<!--
Please briefly describe changes made in this PR.
-->
