### PR TITLE
fix: delete cubie a7a cannot boot system tip

### DIFF
--- a/docs/cubie/a7a/download.md
+++ b/docs/cubie/a7a/download.md
@@ -17,7 +17,7 @@ sidebar_position: 8
 
 #### 通用系统镜像
 
-目前仅支持 MicroSD 卡/ eMMC 模块启动系统，UFS 模块和 NVMe SSD 目前正在适配中！
+目前仅支持 MicroSD 卡/ eMMC 模块 / UFS 模块启动系统，NVMe SSD 目前正在适配中！
 
 - [Radxa Cubie A7A Debian 11](https://github.com/radxa-build/radxa-cubie-a7a/releases/download/rsdk-b1/radxa-cubie-a7a_bullseye_kde_b1.output_512.img.xz)
 

--- a/docs/cubie/a7a/getting-started/quickly_start.md
+++ b/docs/cubie/a7a/getting-started/quickly_start.md
@@ -45,9 +45,7 @@ Cubie A7A 主板兼容 PD 协议的 5V 电源输入，建议电流 3A 以上，�
 - [安装系统到 MicroSD 卡](./install-system/sd_system)
 
 :::tip 安装系统到其它启动介质
-目前支持 MicroSD 卡、eMMC 模块启动系统。
-
-UFS 模块：目前无法正常识别，正在适配中。
+目前支持 MicroSD 卡、eMMC 模块、UFS 模块启动系统。
 
 NVMe SSD：目前正常识别，可作为拓展存储空间，无法作为启动介质。
 

--- a/docs/cubie/a7a/hardware-use/emmc-ufs-com.md
+++ b/docs/cubie/a7a/hardware-use/emmc-ufs-com.md
@@ -6,10 +6,6 @@ sidebar_position: 2
 
 瑞莎 Cubie A7A 板载 eMMC / UFS 二合一模块接口，支持安装 eMMC 或 UFS 模块，可以用于系统启动盘或扩展存储空间。
 
-:::danger 注意
-目前 UFS 模块无法识别，正在适配中！
-:::
-
 ## 使用指南
 
 eMMC 模块适用于小容量存储（8-128GB）, UFS 模块适用于大容量存储（64GB-1TB）。

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/download.md
@@ -17,7 +17,7 @@ Please select the appropriate system image for your system boot medium:
 
 #### Generic System Image
 
-Currently, only MicroSD cards and eMMC modules are supported for system boot. UFS modules and NVMe SSDs are under development!
+Currently, only MicroSD cards, eMMC modules and UFS modules are supported for system boot. NVMe SSDs are under development!
 
 - [Radxa Cubie A7A Debian 11](https://github.com/radxa-build/radxa-cubie-a7a/releases/download/rsdk-b1/radxa-cubie-a7a_bullseye_kde_b1.output_512.img.xz)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/getting-started/quickly_start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/getting-started/quickly_start.md
@@ -45,9 +45,7 @@ You can install the system by following the tutorials below, based on your boot 
 - [Install System to MicroSD Card](./install-system/sd_system)
 
 :::tip Installing System to Other Boot Media
-Currently supports booting from MicroSD card and eMMC module.
-
-UFS Module: Currently not properly recognized, adaptation in progress.
+Currently supports booting from MicroSD card, eMMC module and UFS module.
 
 NVMe SSD: Currently recognized and can be used as expanded storage, but cannot be used as boot media.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/hardware-use/emmc-ufs-com.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/hardware-use/emmc-ufs-com.md
@@ -6,10 +6,6 @@ sidebar_position: 2
 
 The Radxa Cubie A7A features an onboard eMMC/UFS combo module interface that supports installing either eMMC or UFS modules, which can be used as a system boot drive or for expanded storage.
 
-:::danger Note
-UFS module support is currently unavailable and is being adapted!
-:::
-
 ## User Guide
 
 eMMC modules are suitable for smaller capacity storage (8-128GB), while UFS modules are ideal for larger capacity storage (64GB-1TB).


### PR DESCRIPTION
###### 删除 Cubie A7A 不能通过 UFS 启动系统提示 

<!--
Please briefly describe changes made in this PR.
-->
