### PR TITLE
fix: delete a7z wired network tutorial and picture display

### DIFF
--- a/docs/cubie/a7z/system-config/README.md
+++ b/docs/cubie/a7z/system-config/README.md
@@ -6,26 +6,4 @@ sidebar_position: 2
 
 对瑞莎 Cubie A7A 系统中常用的功能进行使用说明。
 
-#### [串口调试](/cubie/a7a/system-config/uart_debug)
-
-主要介绍 Cubie A7A 串口调试的接线和使用方法。
-
-#### [网络配置](/cubie/a7a/system-config/web-config)
-
-主要介绍终端命令行下的网络配置方法。
-
-#### [SSH 远程](/cubie/a7a/system-config/ssh_remote)
-
-主要介绍 Cubie A7A 通过 SSH 远程登录的使用方法。
-
-#### [应用使用](/cubie/a7a/system-config/app_usage)
-
-主要介绍 Cubie A7A 通过 dpkg 和 apt 安装应用的方法。
-
-#### [VNC 远程](/cubie/a7a/system-config/vnc_remote)
-
-主要介绍 Cubie A7A 通过 VNC 远程登录的使用方法。
-
-#### [音频管理](/cubie/a7a/system-config/audio_usage)
-
-主要介绍 Cubie A7A 音频的使用方法。
+<DocCardList />

--- a/docs/cubie/a7z/system-config/wifi_usage.md
+++ b/docs/cubie/a7z/system-config/wifi_usage.md
@@ -6,4 +6,4 @@ import WIFI_USAGE from '../../../common/radxa-os/system-config/\_wifi_usage.mdx'
 
 # 无线网络
 
-<WIFI_USAGE />
+<WIFI_USAGE board="cubie-a7z" debian_version="debian11" />

--- a/docs/cubie/a7z/system-config/wired_network.md
+++ b/docs/cubie/a7z/system-config/wired_network.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 2
----
-
-import WiredNetwork from '../../../common/radxa-os/system-config/\_wired_network.mdx';
-
-# 有线网络
-
-<WiredNetwork />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/system-config/wifi_usage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/system-config/wifi_usage.md
@@ -6,4 +6,4 @@ import WIFI_USAGE from '../../../common/radxa-os/system-config/\_wifi_usage.mdx'
 
 # WiFi Usage
 
-<WIFI_USAGE />
+<WIFI_USAGE board="cubie-a7z" debian_version="debian11" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/system-config/wired_network.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/system-config/wired_network.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 2
----
-
-import WiredNetwork from '../../../common/radxa-os/system-config/\_wired_network.mdx';
-
-# Wired Network
-
-<WiredNetwork />


### PR DESCRIPTION
###### 修改说明
- 删除 Cubie A7Z 的有线网络教程
- 修复 Cubie A7Z 无线网络图片显示问题
<!--
Please briefly describe changes made in this PR.
-->
