### PR TITLE
Fix the inconsistency of configuring waveshare 3.5inch display

### DIFF
--- a/docs/common/accessories/_waveshare-35-display.mdx
+++ b/docs/common/accessories/_waveshare-35-display.mdx
@@ -25,10 +25,10 @@
 
 - 配置显示
 
-- 备份 /usr/share/X11/xorg.conf.d/20-modesetting.conf
+- 备份 `/usr/share/X11/xorg.conf.d/20-modesetting.conf`
 
 ```
-sudo cp /usr/share/X11/xorg.conf.d/20-modesetting.conf /usr/share/X11/xorg.conf.d/20-modesetting.conf.bak
+sudo mv /usr/share/X11/xorg.conf.d/20-modesetting.conf /usr/share/X11/xorg.conf.d/20-modesetting.conf.bak
 ```
 
 - 在 `/etc/X11/xorg.conf.d` 下添加一个配置文件 `20-modesetting.conf`，内容如下：

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/peripherals/waveshare-35-display.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/peripherals/waveshare-35-display.md
@@ -23,10 +23,10 @@ Connect the screen with the development board as follows:
 
 ## Config the display
 
-- backup /usr/share/X11/xorg.conf.d/20-modesetting.conf
+- backup `/usr/share/X11/xorg.conf.d/20-modesetting.conf`
 
 ```
-sudo cp /usr/share/X11/xorg.conf.d/20-modesetting.conf /usr/share/X11/xorg.conf.d/20-modesetting.conf.bak
+sudo mv /usr/share/X11/xorg.conf.d/20-modesetting.conf /usr/share/X11/xorg.conf.d/20-modesetting.conf.bak
 ```
 
 - Add a configuration file `20-modesetting.conf` under `/etc/X11/xorg.conf.d` with the following contents:

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_waveshare-35-display.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_waveshare-35-display.mdx
@@ -25,10 +25,10 @@ Exit and reboot after enabling the successful display of [*] {props.overlays_tit
 
 - Configuration Display
 
-- Backup /usr/share/X11/xorg.conf.d/20-modesetting.conf
+- Backup `/usr/share/X11/xorg.conf.d/20-modesetting.conf`
 
 ```
-sudo cp /usr/share/X11/xorg.conf.d/20-modesetting.conf /usr/share/X11/xorg.conf.d/20-modesetting.conf.bak
+sudo mv /usr/share/X11/xorg.conf.d/20-modesetting.conf /usr/share/X11/xorg.conf.d/20-modesetting.conf.bak
 ```
 
 - Add a configuration file `20-modesetting.conf` under `/etc/X11/xorg.conf.d` with the following contents:


### PR DESCRIPTION

    Fix the inconsistency of configuring waveshare 3.5inch display
    
    Fixes: 063ee1aae5b4 ("fix: follow the latest Radxa OS to update xorg.conf.d path")
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>