### PR TITLE
fix: dragon q6a burn spi fw docs

### DIFF
--- a/docs/dragon/q6a/low-dev/spi_fw.md
+++ b/docs/dragon/q6a/low-dev/spi_fw.md
@@ -202,6 +202,6 @@ sudo edl-ng --memory=spinor rawprogram rawprogram0.xml patch0.xml --loader=prog_
 
 ## FAQ
 
-- 若提示 Unable to loda DLL 'libusb-1.0'
+- 若提示 Unable to load DLL 'libusb-1.0'
 
 安装 [vc_redist](https://aka.ms/vs/17/release/vc_redist.x64.exe)

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/low-dev/spi_fw.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/low-dev/spi_fw.md
@@ -202,6 +202,6 @@ Erasing the SPI boot firmware will prevent the device from booting. You will nee
 
 ## FAQ
 
-- If it prompts "Unable to loda DLL 'libusb-1.0'"
+- If it prompts "Unable to load DLL 'libusb-1.0'"
 
 Install [vc_redist](https://aka.ms/vs/17/release/vc_redist.x64.exe)


### PR DESCRIPTION
###### 修改说明
- 增加 Dragon Q6A 擦除 SPI 启动固件的步骤
- 优化原有教程格式
<!--
Please briefly describe changes made in this PR.
-->
