### PR TITLE
docs: add rock4 debian 12 system image link

### DIFF
--- a/docs/rock4/rock4ab-se/download.md
+++ b/docs/rock4/rock4ab-se/download.md
@@ -10,17 +10,29 @@ sidebar_position: 2
 
 #### Linux
 
-- [Radxa ROCK 4A Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4a/releases/download/test-build-1/rock-pi-4a_debian_bullseye-test_kde_t1.img.xz)
+- Debian 11
 
-- [Radxa ROCK 4A+ Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4a-plus/releases/download/20230601-0150/rock-pi-4a-plus_debian_bullseye_kde_b14.img.xz)
+  - [Radxa ROCK 4A Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4a/releases/download/test-build-1/rock-pi-4a_debian_bullseye-test_kde_t1.img.xz)
 
-- [Radxa ROCK 4B Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4b/releases/download/20230601-0206/rock-pi-4b_debian_bullseye_kde_b32.img.xz)
+  - [Radxa ROCK 4A+ Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4a-plus/releases/download/20230601-0150/rock-pi-4a-plus_debian_bullseye_kde_b14.img.xz)
 
-- [Radxa ROCK 4B+ Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4b-plus/releases/download/rsdk-t2/rock-pi-4b-plus_bullseye_kde_t2.output.img.xz)
+  - [Radxa ROCK 4B Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4b/releases/download/20230601-0206/rock-pi-4b_debian_bullseye_kde_b32.img.xz)
 
-- [Radxa ROCK 4SE Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-4se/releases/download/b38/rock-4se_debian_bullseye_kde_b38.img.xz)
+  - [Radxa ROCK 4B+ Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4b-plus/releases/download/rsdk-t2/rock-pi-4b-plus_bullseye_kde_t2.output.img.xz)
 
-- [Radxa ROCK 4B+ Debian 12 Desktop Linux 6.1](https://github.com/radxa-build/rock-pi-4b-plus/releases/download/rsdk-b1/rock-pi-4b-plus_bookworm_kde_b1.output_512.img.xz)
+  - [Radxa ROCK 4SE Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-4se/releases/download/b38/rock-4se_debian_bullseye_kde_b38.img.xz)
+
+- Debian 12
+
+  - [Radxa ROCK 4A Debian 12 BOOKWORM KDE R3](https://github.com/radxa-build/rock-pi-4b/releases/download/rsdk-r3/rock-pi-4b_bookworm_kde_r3.output_4096.img.xz)
+
+  - [Radxa ROCK 4A+ Debian 12 BOOKWORM KDE R4](https://github.com/radxa-build/rock-pi-4b-plus/releases/download/rsdk-r4/rock-pi-4b-plus_bookworm_kde_r4.output_512.img.xz)
+
+  - [Radxa ROCK 4B Debian 12 BOOKWORM KDE R3](https://github.com/radxa-build/rock-pi-4b/releases/download/rsdk-r3/rock-pi-4b_bookworm_kde_r3.output_4096.img.xz)
+
+  - [Radxa ROCK 4B+ Debian 12 BOOKWORM KDE R4](https://github.com/radxa-build/rock-pi-4b-plus/releases/download/rsdk-r4/rock-pi-4b-plus_bookworm_kde_r4.output_512.img.xz)
+
+  - [Radxa ROCK 4SE Debian 12 BOOKWORM KDE R3](https://github.com/radxa-build/rock-4se/releases/download/rsdk-r3/rock-4se_bookworm_kde_r3.output_512.img.xz)
 
 #### Android
 

--- a/docs/rock4/rock4c+/download.md
+++ b/docs/rock4/rock4c+/download.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 100
+---
+
+# 资源下载汇总
+
+## Linux 系统镜像
+
+- [Radxa ROCK 4C+ Debian 12 BOOKWORM KDE R1](https://github.com/radxa-build/rock-4c-plus/releases/download/rsdk-r1/rock-4c-plus_bookworm_kde_r1.output_512.img.xz)

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4ab-se/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4ab-se/download.md
@@ -10,17 +10,29 @@ sidebar_position: 2
 
 #### Linux
 
-- [Radxa ROCK 4A Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4a/releases/download/test-build-1/rock-pi-4a_debian_bullseye-test_kde_t1.img.xz)
+- Debian 11
 
-- [Radxa ROCK 4A+ Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4a-plus/releases/download/20230601-0150/rock-pi-4a-plus_debian_bullseye_kde_b14.img.xz)
+  - [Radxa ROCK 4A Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4a/releases/download/test-build-1/rock-pi-4a_debian_bullseye-test_kde_t1.img.xz)
 
-- [Radxa ROCK 4B Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4b/releases/download/20230601-0206/rock-pi-4b_debian_bullseye_kde_b32.img.xz)
+  - [Radxa ROCK 4A+ Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4a-plus/releases/download/20230601-0150/rock-pi-4a-plus_debian_bullseye_kde_b14.img.xz)
 
-- [Radxa ROCK 4B+ Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4b-plus/releases/download/rsdk-t2/rock-pi-4b-plus_bullseye_kde_t2.output.img.xz)
+  - [Radxa ROCK 4B Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4b/releases/download/20230601-0206/rock-pi-4b_debian_bullseye_kde_b32.img.xz)
 
-- [Radxa ROCK 4SE Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-4se/releases/download/b38/rock-4se_debian_bullseye_kde_b38.img.xz)
+  - [Radxa ROCK 4B+ Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-pi-4b-plus/releases/download/rsdk-t2/rock-pi-4b-plus_bullseye_kde_t2.output.img.xz)
 
-- [Radxa ROCK 4B+ Debian 12 Desktop Linux 6.1](https://github.com/radxa-build/rock-pi-4b-plus/releases/download/rsdk-b1/rock-pi-4b-plus_bookworm_kde_b1.output_512.img.xz)
+  - [Radxa ROCK 4SE Debian 11 Desktop Linux 5.10](https://github.com/radxa-build/rock-4se/releases/download/b38/rock-4se_debian_bullseye_kde_b38.img.xz)
+
+- Debian 12
+
+  - [Radxa ROCK 4A Debian 12 BOOKWORM KDE R3](https://github.com/radxa-build/rock-pi-4b/releases/download/rsdk-r3/rock-pi-4b_bookworm_kde_r3.output_4096.img.xz)
+
+  - [Radxa ROCK 4A+ Debian 12 BOOKWORM KDE R4](https://github.com/radxa-build/rock-pi-4b-plus/releases/download/rsdk-r4/rock-pi-4b-plus_bookworm_kde_r4.output_512.img.xz)
+
+  - [Radxa ROCK 4B Debian 12 BOOKWORM KDE R3](https://github.com/radxa-build/rock-pi-4b/releases/download/rsdk-r3/rock-pi-4b_bookworm_kde_r3.output_4096.img.xz)
+
+  - [Radxa ROCK 4B+ Debian 12 BOOKWORM KDE R4](https://github.com/radxa-build/rock-pi-4b-plus/releases/download/rsdk-r4/rock-pi-4b-plus_bookworm_kde_r4.output_512.img.xz)
+
+  - [Radxa ROCK 4SE Debian 12 BOOKWORM KDE R3](https://github.com/radxa-build/rock-4se/releases/download/rsdk-r3/rock-4se_bookworm_kde_r3.output_512.img.xz)
 
 #### Android
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/download.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 100
+---
+
+# Resource Download Summary
+
+## Linux System Image
+
+- [Radxa ROCK 4C+ Debian 12 BOOKWORM KDE R1](https://github.com/radxa-build/rock-4c-plus/releases/download/rsdk-r1/rock-4c-plus_bookworm_kde_r1.output_512.img.xz)


### PR DESCRIPTION
###### PR 说明
- 增加 ROCK4 的 Debian 12 镜像下载链接
<!--
Please briefly describe changes made in this PR.
-->
