### PR TITLE
docs(accessories): fix Penta SATA HAT Chinese documentation

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/README.md
+++ b/docs/accessories/storage/penta-sata-hat/README.md
@@ -1,90 +1,90 @@
-- 准备
+---
+sidebar_position: 1
+---
 
-  1. 下图显示了 Radxa M.2 拓展板和包含的部件
+# 瑞莎 Penta SATA HAT
 
-  <img
-  src="/img/accessories/storage/m2-extension-board-03.webp"
-  alt="m.2 extension board package"
-  style={{ width: "80%" }}
-  />
+瑞莎 ROCK Penta SATA HAT 是为 ROCK 系列设计的扩展板。它利用 ROCK 系列的高速 PCIe 总线，提供基于 ROCK 系列的完整 NAS 解决方案。
 
-  2. 请先区分 IPEX 线缆的正反面，如图所示
+![Radxa Penta SATA HAT](/img/accessories/storage/penta-sata-hat-01.webp)
 
-  **我们为 {props.product} 提供的 IPEX 线的两端方向是相同的。**
+目前支持的瑞莎 ROCK 系列产品：
 
-  <img
-  src="/img/accessories/storage/m2-extension-board-04.webp"
-  alt="cable"
-  style={{ width: "80%" }}
-  />
+- ROCK 2A
+- ROCK 2F
+- ROCK 3A
+- ROCK 3C
+- ROCK 4A / 4B
+- ROCK 4A+ / 4B+
+- ROCK 4SE
+- ROCK 5A
+- ROCK 5C
 
-  3. 请注意， **环扣** 需要卡入连接器
+目前支持的树莓派型号：
 
-  <img
-  src="/img/accessories/storage/ekey-to-mkey-01.webp"
-  alt=""
-  style={{ width: "80%" }}
-  />
+- Raspberry Pi 5
 
-- 安装
+## 特性
 
-  1. M.2 E 键转 M.2 M 键板，带 IPEX 电缆。 **注意这里安装的 IPEX 线是正面朝上的，环扣需要卡在接口上，确保固定。**
+- 最多支持 5 个 HDD/SSD，支持 2.5 英寸或 3.5 英寸 SSD，最高 100T 存储容量
+- 4 个 SATA + 1 个带电源的 eSATA
+- 利用 ROCK 系列和树莓派的 PCIe 总线
+- 支持外部标准 ATX 电源为硬盘和 SBC 本身供电
+- 12V DC 电源输入用于 2.5/3.5 英寸硬盘和 SBC 本身供电（极性：中心正极）
+- 支持硬盘休眠模式
+- 支持软件 RAID 0/1/5
+- 可选 PWM 控制风扇用于硬盘散热
+- 可选 OLED 显示屏显示 IP/存储信息
 
-  <img
-  src="/img/accessories/storage/m2-extension-board-02.webp"
-  alt="step 1"
-  style={{ width: "80%" }}
-  />
+:::tip
+如果您在 Penta SATA HAT 上使用大容量 3.5 英寸机械硬盘，需要查看硬盘规格以确定硬盘的峰值电流。我们建议使用峰值电流小于 1.7A 的硬盘。
+:::
 
-  2. M.2 扩展板，带 IPEX 电缆。 **注意这里安装的 IPEX 线是正面朝上的，环扣需要卡在接口上，确保固定。**
+## 包装清单
 
-  <img
-  src="/img/accessories/storage/m2-extension-board-01.webp"
-  alt="step 2"
-  style={{ width: "80%" }}
-  />
+- 瑞莎 ROCK Penta SATA HAT
+- 固定用铜柱
+- 转接板
+- IPEX 线缆
 
-  3. 请将产品附带的 M2.5x18+6 铜柱和 M2.5x5 铜柱安装在 {props.product} 上，如图所示。
+- **支持 ROCK 5A 的 Penta SATA HAT 套件**
 
-  <img src={props.step3_img} alt="step 3" style={{ width: "80%" }} />
+  ![Radxa Penta SATA HAT](/img/accessories/storage/penta-sata-hat-02.webp)
 
-  4. 请将 IPEX 线缆的一端连接到 M.2 E key to M Key board，另一端连接到 M.2 Extension Board 并将 M.2 E key to M key board 安装到 {props.product} M.2 E 连接器，如图所示。
+- **支持 ROCK 3A / 4A / 4B / 4A+ / 4B+ / 4SE 的 Penta SATA HAT**
 
-  <img src={props.step4_img} alt="step 4" style={{ width: "80%" }} />
+  ![Radxa Penta SATA HAT](/img/accessories/storage/penta-sata-hat-03.webp)
 
-  5. 最后，使用 M2.5x5+5 铜柱组装 M.2 扩展板。
+- **支持 ROCK 3C 的 Penta SATA HAT**
 
-  <img src={props.step5_img} alt="step 5" style={{ width: "80%" }} />
+  ![Radxa Penta SATA HAT](/img/accessories/storage/penta-sata-hat-04.webp)
 
-- 查看挂载情况
+## 40 针引脚定义
 
-  1. 可以通过`lsblk`查看 SSD 卡是否被识别。
+| 描述          | 功能    | 引脚# | 引脚# | 功能 | 描述       |
+| ------------- | ------- | ----- | ----- | ---- | ---------- |
+|               |         | 1     | 2     | VCC  |            |
+| OLED I2C      | I2C_SDA | 3     | 4     | VCC  |            |
+| OLED I2C      | I2C_SCL | 5     | 6     | GND  |            |
+|               |         | 7     | 8     |      |            |
+|               | GND     | 9     | 10    |      |            |
+| top board key | GPIO    | 11    | 12    |      |            |
+|               |         | 13    | 14    | GND  |            |
+|               |         | 15    | 16    | GPIO | reset OLED |
+|               |         | 17    | 18    |      |            |
+|               |         | 19    | 20    | GND  |            |
+|               |         | 21    | 22    |      |            |
+|               |         | 23    | 24    |      |            |
+|               | GND     | 25    | 26    |      |            |
+|               |         | 27    | 28    |      |            |
+|               |         | 29    | 30    | GND  |            |
+|               |         | 31    | 32    |      |            |
+| tb-fan speed  | PWM     | 33    | 34    | GND  |            |
+|               |         | 35    | 36    |      |            |
+|               |         | 37    | 38    |      |            |
+|               | GND     | 39    | 40    |      |            |
 
-    <pre>
-      radxa@{props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT mmcblk0
-      179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part /config └─mmcblk0p2
-      179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk mmcblk0boot1 179:64 0
-      4M 1 disk zram0 254:0 0 3.8G 0 disk [SWAP] nvme0n1 259:0 0 238.5G 0 disk
-    </pre>
-
-  2. 这时你可以看到，系统已经识别出 SSD(**nvme0n1**)。
-     | top board key | GPIO | 11 | 12 | | |
-     | | | 13 | 14 | GND | |
-     | | | 15 | 16 | GPIO | reset OLED |
-     | | | 17 | 18 | | |
-     | | | 19 | 20 | GND | |
-     | | | 21 | 22 | | |
-     | | | 23 | 24 | | |
-     | | GND | 25 | 26 | | |
-     | | | 27 | 28 | | |
-     | | | 29 | 30 | GND | |
-     | | | 31 | 32 | | |
-     | tb-fan speed | PWM | 33 | 34 | GND | |
-     | | | 35 | 36 | | |
-     | | | 37 | 38 | | |
-     | | GND | 39 | 40 | | |
-
-## 2x5 针 Pinout
+## 2x5 针引脚定义
 
 | Pin | Signal   | Pin | Signal     |
 | --- | -------- | --- | ---------- |
@@ -94,6 +94,6 @@
 | 7   | GND      | 8   | PWM_33     |
 | 9   | GND      | 10  | NC         |
 
-## 使用指南
+## 用户指南
 
 <DocCardList />

--- a/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -14,7 +14,7 @@ Radxa Penta SATA HAT 有一个 2x5 的座子，座子的信号如下：
 | 7   | GND      | 8   | PWM_33     |
 | 9   | GND      | 10  | NC         |
 
-这个座子可以用来链接顶板，顶板上有一个 0.91 寸的 OLED 显示屏和一个 4010 风扇，显示屏可以显示 IP 地址和存储信息等，风扇用于散热。
+这个座子可以用来连接顶板，顶板上有一个 0.91 寸的 OLED 显示屏和一个 4010 风扇，显示屏可以显示 IP 地址和存储信息等，风扇用于散热。
 
 ![SATA HAT top board](/img/accessories/storage/penta/sata-hat-top-board.webp)
 


### PR DESCRIPTION
- Rewrite README.md content based on English version (was incorrectly showing M.2 Extension Board content)
- Add complete product introduction, feature list, and package list
- Fix all image link paths to match English version
- Correct image alt text descriptions
- Fix typo in sata-hat-top-board.md (链接→连接)
- Unify pin definition table format

###### Description of changes

<!--
Please briefly describe changes made in this PR.
-->
