### PR TITLE
fix: correct c200-orin Jetpack version

### DIFF
--- a/docs/som/nx/orin-nx/c200-orin/download.md
+++ b/docs/som/nx/orin-nx/c200-orin/download.md
@@ -17,7 +17,7 @@ sidebar_position: 150
 
 :::
 
-- [Jetson Orin Nano 镜像（Jetpack 6.2）：适用于 Radxa C200 Orin 开发套件](https://developer.nvidia.com/downloads/embedded/L4T/r36_Release_v4.4/jp62-r1-orin-nano-sd-card-image.zip)
+- [Jetson Orin Nano 镜像（Jetpack 6.2.1）：适用于 Radxa C200 Orin 开发套件](https://developer.nvidia.com/downloads/embedded/L4T/r36_Release_v4.4/jp62-r1-orin-nano-sd-card-image.zip)
 
 ## 硬件设计
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/orin-nx/c200-orin/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/orin-nx/c200-orin/download.md
@@ -17,7 +17,7 @@ For BIOS firmware flashing, please refer to one of the following tutorials:
 
 :::
 
-- [Jetson Orin Nano Image (Jetpack 6.2): For Radxa C200 Orin Development Kit](https://developer.nvidia.com/downloads/embedded/L4T/r36_Release_v4.4/jp62-r1-orin-nano-sd-card-image.zip)
+- [Jetson Orin Nano Image (Jetpack 6.2.1): For Radxa C200 Orin Development Kit](https://developer.nvidia.com/downloads/embedded/L4T/r36_Release_v4.4/jp62-r1-orin-nano-sd-card-image.zip)
 
 ## Hardware Design
 


### PR DESCRIPTION
###### Description of changes

Micro sd card image is called:
jp62-r1-orin-nano-sd-card-image.zip
The string `jp62-r1` refers to Jetpack 6.2.1[0].

[0]: https://developer.nvidia.com/embedded/jetpack-sdk-621