### PR TITLE
feat: correct c200-orin jetson linux version

### DIFF
--- a/docs/som/nx/orin-nx/c200-orin/low-level-dev/prebuild-image.md
+++ b/docs/som/nx/orin-nx/c200-orin/low-level-dev/prebuild-image.md
@@ -40,7 +40,7 @@ FC REC 引脚和 GND 引脚位置可以参考 [GPIO 接口文档](../../c200-ori
 <NewCodeBlock tip="Ubuntu 22.04" type="host">
 
 ```
-wget https://developer.download.nvidia.com/embedded/L4T/r36_Release_v4.3/release/Jetson_Linux_R36.4.3_aarch64.tbz2 -O Jetson_Linux_aarch64.tbz2
+wget https://developer.download.nvidia.com/embedded/L4T/r36_Release_v4.4/release/Jetson_Linux_R36.4.4_aarch64.tbz2 -O Jetson_Linux_aarch64.tbz2
 tar -xf Jetson_Linux_aarch64.tbz2
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/orin-nx/c200-orin/low-level-dev/prebuild-image.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/orin-nx/c200-orin/low-level-dev/prebuild-image.md
@@ -40,7 +40,7 @@ Download the NVIDIA L4T source package.
 <NewCodeBlock tip="Ubuntu 22.04" type="host">
 
 ```
-wget https://developer.download.nvidia.com/embedded/L4T/r36_Release_v4.3/release/Jetson_Linux_R36.4.3_aarch64.tbz2 -O Jetson_Linux_aarch64.tbz2
+wget https://developer.download.nvidia.com/embedded/L4T/r36_Release_v4.4/release/Jetson_Linux_R36.4.4_aarch64.tbz2 -O Jetson_Linux_aarch64.tbz2
 tar -xf Jetson_Linux_aarch64.tbz2
 ```
 


### PR DESCRIPTION


###### Description of changes
The latest Jetson Linux version used for flashing is 36.4.4[[0]].

[0]: https://github.com/radxa/c200-bootupd/commit/d68df022c342956beda47d28657b3568f9a61be4