### PR TITLE
docs: add openwrt guides and sync english docs

### DIFF
--- a/docs/common/other-system/openwrt/_argon-theme.mdx
+++ b/docs/common/other-system/openwrt/_argon-theme.mdx
@@ -1,0 +1,29 @@
+## Argon 主题
+
+如需美化 LuCI 界面，可安装 Argon 主题。
+
+### 使用 apk 从 GitHub 安装 Argon
+
+OpenWrt 新版本已使用 `apk` 作为包管理工具。  
+如果软件包来自 GitHub Release，而不是 OpenWrt 官方软件源，可先下载对应的 `.apk` 文件，再使用 `apk` 安装。
+
+```bash
+cd /tmp
+wget https://github.com/jerrykuku/luci-theme-argon/releases/download/v2.4.3/luci-theme-argon-2.4.3-r20250722.apk
+apk add --allow-untrusted ./luci-theme-argon-2.4.3-r20250722.apk
+```
+
+### 切换主题
+
+安装完成后，可执行以下命令切换到 Argon 主题：
+
+```bash
+uci set luci.main.mediaurlbase='/luci-static/argon'
+uci commit luci
+/etc/init.d/uhttpd restart
+```
+
+### 主题配置说明
+
+`luci-app-argon-config` 当前 GitHub Release 仍主要提供 `.ipk` 包，不一定适用于使用 `apk` 的系统。  
+如果你的系统仅支持 `apk`，建议先只安装主题本体；若后续发布了对应的 `.apk` 包，再按相同方式安装。

--- a/docs/common/other-system/openwrt/_mainline-install.mdx
+++ b/docs/common/other-system/openwrt/_mainline-install.mdx
@@ -1,0 +1,123 @@
+import Etcher from "../../general/_etcherV2.mdx";
+import Rkdevtool from "../../dev/_rkdevtoolV3.mdx";
+
+## OpenWrt 主线安装
+
+本文档将介绍如何把 OpenWrt 主线镜像安装到 {props.product}。
+
+## 镜像下载
+
+请到 <a href={props?.download_page ?? "../download"}>资源下载页面</a> 下载对应的镜像文件。
+
+推荐镜像文件名：
+
+{props.image_name}
+
+:::warning
+请确认下载的镜像文件名与产品型号一致，避免误刷其他型号镜像，下载完成后需要先解压文件再进行后续操作。
+:::
+
+## 安装系统
+
+<Tabs queryString="target">
+
+<TabItem
+  value="microsd"
+  label="安装系统到 microSD 卡"
+  default={props.show_emmc === false}
+>
+
+### 准备工作
+
+- 1x microSD 卡
+- 1x microSD 读卡器
+- 1x 电源适配器（推荐使用 {props.power}）
+
+### 安装系统
+
+<Etcher model={props.model} />
+
+### 启动系统
+
+- 将写好镜像的 microSD 卡插入 {props.product} 的 MicroSD 卡槽
+- 连接 {props.power} 并启动系统
+
+</TabItem>
+
+<TabItem
+  value="emmc"
+  label="安装系统到 eMMC"
+  attributes={{ className: props.show_emmc === false && "tab_none" }}
+>
+
+### 准备工作
+
+- USB 数据线
+- x86 PC
+- 已解压的镜像文件
+- 带 eMMC 的 {props.product}
+
+### 进入 Maskrom 模式
+
+{props?.maskrom_page ? (
+
+{" "}
+
+<p>
+  请参考 <a href={props.maskrom_page}>Maskrom 操作说明</a>。
+</p>
+) : (<p>请根据对应产品文档进入 Maskrom 模式。</p>
+)}
+
+### Windows
+
+<Rkdevtool
+  emmc={false}
+  pcie={false}
+  sata={false}
+  rkdevtool_emmc_img={
+    props?.rkdevtool_emmc_img ?? "/img/rkdevtool/emmc-path.webp"
+  }
+>
+  {props.children}
+</Rkdevtool>
+
+### Linux
+
+{props?.linux_page ? (
+
+{" "}
+
+<p>
+  请参考 <a href={props.linux_page}>Linux 刷机说明</a>。
+</p>
+) : (<p>请根据对应产品文档使用 `rkdeveloptool` 或 `upgrade_tool` 进行刷机。</p>
+)}
+
+</TabItem>
+
+</Tabs>
+
+## 系统登录
+
+- 默认管理地址通常为 `192.168.1.1`
+- 默认用户名通常为 `root`
+- 首次登录后请按页面提示设置密码
+
+## 存储扩容
+
+如 OpenWrt 主线镜像首次启动后根分区未占满整盘，建议优先参考 OpenWrt 官方扩容说明：
+
+- <a href="https://openwrt.org/docs/guide-user/advanced/expand_root">
+    Expanding root partition and filesystem
+  </a>
+
+:::tip
+不同产品的系统盘节点、分区号和扩容方式可能不同，请不要直接复用其他产品的分区命令。
+:::
+
+## 常见问题
+
+- 设备无法识别：检查是否正确进入 Maskrom 模式，或更换数据线与 USB 接口。
+- 刷写失败：检查镜像格式、下载完整性与设备型号是否匹配。
+- 无法访问管理页面：检查默认 IP、网口连接方式与主机网段配置。

--- a/docs/e/e20c/other-os/README.md
+++ b/docs/e/e20c/other-os/README.md
@@ -5,3 +5,5 @@ sidebar_position: 5
 # 其他系统
 
 介绍非 RadxaOS 的其他系统。
+
+<DocCardList />

--- a/docs/e/e20c/other-os/openwrt/README.md
+++ b/docs/e/e20c/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/e/e20c/other-os/openwrt/argon-theme.md
+++ b/docs/e/e20c/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/e/e20c/other-os/openwrt/install-os.md
+++ b/docs/e/e20c/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa E20C"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_e20c-ext4-sysupgrade.img.gz"
+  power="合适的电源适配器"
+  model="e20c"
+  maskrom_page="../../getting-started/install-os/maskrom/"
+  linux_page="../../getting-started/install-os/maskrom/linux_macos"
+/>

--- a/docs/e/e52c/other-os/README.md
+++ b/docs/e/e52c/other-os/README.md
@@ -5,3 +5,5 @@ sidebar_position: 5
 # 其他系统
 
 介绍非 RadxaOS 的其他系统。
+
+<DocCardList />

--- a/docs/e/e52c/other-os/openwrt/README.md
+++ b/docs/e/e52c/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/e/e52c/other-os/openwrt/argon-theme.md
+++ b/docs/e/e52c/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/e/e52c/other-os/openwrt/install-os.md
+++ b/docs/e/e52c/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa E52C"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_e52c-ext4-sysupgrade.img.gz"
+  power="合适的电源适配器"
+  model="e52c"
+  maskrom_page="../../getting-started/install-os/maskrom/"
+  linux_page="../../getting-started/install-os/maskrom/linux_macos"
+/>

--- a/docs/rock2/rock2a/other-os/openwrt/README.md
+++ b/docs/rock2/rock2a/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock2/rock2a/other-os/openwrt/argon-theme.md
+++ b/docs/rock2/rock2a/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock2/rock2a/other-os/openwrt/install-os.md
+++ b/docs/rock2/rock2a/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 2A"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_2a-ext4-sysupgrade.img.gz"
+  power="合适的电源适配器"
+  model="rock2a"
+  maskrom_page="../../getting-started/install-os/maskrom/"
+  linux_page="../../getting-started/install-os/maskrom/linux"
+/>

--- a/docs/rock2/rock2f/other-os/README.md
+++ b/docs/rock2/rock2f/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# 其他系统
+
+介绍非 Radxa OS 的其他系统，例如 OpenWrt
+
+<DocCardList />

--- a/docs/rock2/rock2f/other-os/openwrt/README.md
+++ b/docs/rock2/rock2f/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock2/rock2f/other-os/openwrt/argon-theme.md
+++ b/docs/rock2/rock2f/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock2/rock2f/other-os/openwrt/install-os.md
+++ b/docs/rock2/rock2f/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 2F"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_2f-ext4-sysupgrade.img.gz"
+  power="合适的电源适配器"
+  model="rock2f"
+  maskrom_page="../../getting-started/install-os/maskrom/"
+  linux_page="../../getting-started/install-os/maskrom/linux"
+/>

--- a/docs/rock3/rock3a/other-os/openwrt/README.md
+++ b/docs/rock3/rock3a/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock3/rock3a/other-os/openwrt/argon-theme.md
+++ b/docs/rock3/rock3a/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock3/rock3a/other-os/openwrt/install-os.md
+++ b/docs/rock3/rock3a/other-os/openwrt/install-os.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 3A"
+  download_page="../../getting-started/download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_3a-ext4-sysupgrade.img.gz"
+  power="合适的电源适配器"
+  model="rock3a"
+  linux_page="../../low-level-dev/rkdeveloptool"
+/>

--- a/docs/rock3/rock3b/other-os/openwrt/README.md
+++ b/docs/rock3/rock3b/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock3/rock3b/other-os/openwrt/argon-theme.md
+++ b/docs/rock3/rock3b/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock3/rock3b/other-os/openwrt/install-os.md
+++ b/docs/rock3/rock3b/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 3B"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_3b-ext4-sysupgrade.img.gz"
+  power="合适的电源适配器"
+  model="rock3b"
+  maskrom_page="../../low-level-dev/maskrom/"
+  linux_page="../../low-level-dev/maskrom/linux"
+/>

--- a/docs/rock3/rock3c/other-os/README.md
+++ b/docs/rock3/rock3c/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# 其他系统
+
+介绍非 Radxa OS 的其他系统，例如 OpenWrt
+
+<DocCardList />

--- a/docs/rock3/rock3c/other-os/openwrt/README.md
+++ b/docs/rock3/rock3c/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock3/rock3c/other-os/openwrt/argon-theme.md
+++ b/docs/rock3/rock3c/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock3/rock3c/other-os/openwrt/install-os.md
+++ b/docs/rock3/rock3c/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 3C"
+  download_page="../../getting-started/download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_3c-ext4-sysupgrade.img.gz"
+  power="合适的电源适配器"
+  model="rock3c"
+  maskrom_page="../../low-level-dev/3c-maskrom"
+  linux_page="../../low-level-dev/3c-maskrom"
+/>

--- a/docs/rock4/rock4c+/other-os/README.md
+++ b/docs/rock4/rock4c+/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# 其他系统
+
+介绍非 Radxa OS 的其他系统，例如 OpenWrt
+
+<DocCardList />

--- a/docs/rock4/rock4c+/other-os/openwrt/README.md
+++ b/docs/rock4/rock4c+/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock4/rock4c+/other-os/openwrt/argon-theme.md
+++ b/docs/rock4/rock4c+/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock4/rock4c+/other-os/openwrt/install-os.md
+++ b/docs/rock4/rock4c+/other-os/openwrt/install-os.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 4C+"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_4c_plus-ext4-sysupgrade.img.gz"
+  power="合适的电源适配器"
+  model="rock4c+"
+  linux_page="../../low-level-dev/rkdeveloptool"
+/>

--- a/docs/rock4/rock4d/other-os/openwrt/README.md
+++ b/docs/rock4/rock4d/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock4/rock4d/other-os/openwrt/argon-theme.md
+++ b/docs/rock4/rock4d/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock4/rock4d/other-os/openwrt/install-os.md
+++ b/docs/rock4/rock4d/other-os/openwrt/install-os.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 4D"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_4d-ext4-sysupgrade.img.gz"
+  power="合适的电源适配器"
+  model="rock4d"
+  maskrom_page="../../hardware-use/maskrom"
+/>

--- a/docs/rock5/rock5a/other-os/openwrt/README.md
+++ b/docs/rock5/rock5a/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock5/rock5a/other-os/openwrt/argon-theme.md
+++ b/docs/rock5/rock5a/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock5/rock5a/other-os/openwrt/install-os.md
+++ b/docs/rock5/rock5a/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 5A"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5a-ext4-sysupgrade.img.gz"
+  power="合适的 USB Type-C 电源适配器"
+  model="rock5a"
+  maskrom_page="../../low-level-dev/maskrom/"
+  linux_page="../../low-level-dev/maskrom/linux"
+/>

--- a/docs/rock5/rock5b/other-os/openwrt/README.md
+++ b/docs/rock5/rock5b/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock5/rock5b/other-os/openwrt/argon-theme.md
+++ b/docs/rock5/rock5b/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock5/rock5b/other-os/openwrt/install-os.md
+++ b/docs/rock5/rock5b/other-os/openwrt/install-os.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 5B / 5B+"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5b-ext4-sysupgrade.img.gz 或 openwrt-25.12.0-rockchip-armv8-radxa_rock_5b_plus-ext4-sysupgrade.img.gz"
+  power="合适的 USB Type-C 电源适配器"
+  model="rock5b"
+  maskrom_page="../../low-level-dev/install-os/rkdevtool_maskrom"
+/>

--- a/docs/rock5/rock5c/other-os/openwrt/README.md
+++ b/docs/rock5/rock5c/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock5/rock5c/other-os/openwrt/argon-theme.md
+++ b/docs/rock5/rock5c/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock5/rock5c/other-os/openwrt/install-os.md
+++ b/docs/rock5/rock5c/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 5C / 5C Lite"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5c-ext4-sysupgrade.img.gz 或 openwrt-25.12.0-rockchip-armv8-radxa_rock_5c_lite-ext4-sysupgrade.img.gz"
+  power="合适的 USB Type-C 电源适配器"
+  model="rock5c"
+  maskrom_page="../../low-level-dev/maskrom/"
+  linux_page="../../low-level-dev/maskrom/linux"
+/>

--- a/docs/rock5/rock5itx/other-os/openwrt/README.md
+++ b/docs/rock5/rock5itx/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock5/rock5itx/other-os/openwrt/argon-theme.md
+++ b/docs/rock5/rock5itx/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock5/rock5itx/other-os/openwrt/install-os.md
+++ b/docs/rock5/rock5itx/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 5 ITX"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5_itx-ext4-sysupgrade.img.gz"
+  power="合适的电源适配器"
+  model="rock5itx"
+  maskrom_page="../../low-level-dev/maskrom/"
+  linux_page="../../low-level-dev/maskrom/linux"
+/>

--- a/docs/rock5/rock5t/other-os/openwrt/README.md
+++ b/docs/rock5/rock5t/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rock5/rock5t/other-os/openwrt/argon-theme.md
+++ b/docs/rock5/rock5t/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rock5/rock5t/other-os/openwrt/install-os.md
+++ b/docs/rock5/rock5t/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK 5T"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5t-ext4-sysupgrade.img.gz"
+  power="合适的 USB Type-C 电源适配器"
+  model="rock5t"
+  maskrom_page="../../low-level-dev/maskrom/"
+  linux_page="../../low-level-dev/maskrom/linux"
+/>

--- a/docs/rockpi/rockpie/other-os/README.md
+++ b/docs/rockpi/rockpie/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# 其他系统
+
+介绍非 Radxa OS 的其他系统，例如 OpenWrt
+
+<DocCardList />

--- a/docs/rockpi/rockpie/other-os/openwrt/README.md
+++ b/docs/rockpi/rockpie/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rockpi/rockpie/other-os/openwrt/argon-theme.md
+++ b/docs/rockpi/rockpie/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rockpi/rockpie/other-os/openwrt/install-os.md
+++ b/docs/rockpi/rockpie/other-os/openwrt/install-os.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK Pi E"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_pi_e-ext4-sysupgrade.img.gz"
+  power="合适的 USB Type-C 电源适配器"
+  model="rockpie"
+/>

--- a/docs/rockpi/rockpis/other-os/README.md
+++ b/docs/rockpi/rockpis/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# 其他系统
+
+介绍非 Radxa OS 的其他系统，例如 OpenWrt
+
+<DocCardList />

--- a/docs/rockpi/rockpis/other-os/openwrt/README.md
+++ b/docs/rockpi/rockpis/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/rockpi/rockpis/other-os/openwrt/argon-theme.md
+++ b/docs/rockpi/rockpis/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/rockpi/rockpis/other-os/openwrt/install-os.md
+++ b/docs/rockpi/rockpis/other-os/openwrt/install-os.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ROCK Pi S"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_pi_s-ext4-sysupgrade.img.gz"
+  power="合适的 USB Type-C 电源适配器"
+  model="rockpis"
+/>

--- a/docs/zero/zero3/other-os/openwrt/README.md
+++ b/docs/zero/zero3/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt 系统
+
+主要介绍 OpenWrt 系统如何安装与使用
+
+<DocCardList />

--- a/docs/zero/zero3/other-os/openwrt/argon-theme.md
+++ b/docs/zero/zero3/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon 主题
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon 主题
+
+<ArgonTheme />

--- a/docs/zero/zero3/other-os/openwrt/install-os.md
+++ b/docs/zero/zero3/other-os/openwrt/install-os.md
@@ -1,0 +1,19 @@
+---
+sidebar_position: 1
+title: 系统安装
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# 系统安装
+
+<OpenWrtMainline
+  product="Radxa ZERO 3W / ZERO 3E"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_zero_3w-ext4-sysupgrade.img.gz
+openwrt-25.12.0-rockchip-armv8-radxa_zero_3e-ext4-sysupgrade.img.gz"
+  power="5V/2A 电源适配器"
+  model="zero3"
+  maskrom_page="../../low-level-dev/install-os-on-emmc"
+  linux_page="../../low-level-dev/rkdeveloptool"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/other-system/openwrt/_argon-theme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/other-system/openwrt/_argon-theme.mdx
@@ -1,0 +1,29 @@
+## Argon Theme
+
+To customize the LuCI interface, you can install the Argon theme.
+
+### Install Argon with apk from GitHub
+
+Recent OpenWrt versions use `apk` as the package manager.  
+If the package comes from a GitHub Release instead of the official OpenWrt feed, download the `.apk` file first and then install it with `apk`.
+
+```bash
+cd /tmp
+wget https://github.com/jerrykuku/luci-theme-argon/releases/download/v2.4.3/luci-theme-argon-2.4.3-r20250722.apk
+apk add --allow-untrusted ./luci-theme-argon-2.4.3-r20250722.apk
+```
+
+### Switch the Theme
+
+After installation, run the following commands to switch LuCI to Argon:
+
+```bash
+uci set luci.main.mediaurlbase='/luci-static/argon'
+uci commit luci
+/etc/init.d/uhttpd restart
+```
+
+### Theme Configuration
+
+`luci-app-argon-config` is still mainly released as an `.ipk` package upstream, so it may not be suitable for systems that only use `apk`.  
+On `apk`-based systems, install the theme itself first, then add the configuration app later if an `.apk` release becomes available.

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/other-system/openwrt/_mainline-install.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/other-system/openwrt/_mainline-install.mdx
@@ -1,0 +1,128 @@
+import Etcher from "../../general/_etcherV2.mdx";
+import Rkdevtool from "../../dev/_rkdevtoolV3.mdx";
+
+## OpenWrt Mainline Installation
+
+This document describes how to install an OpenWrt mainline image on {props.product}.
+
+## Image Download
+
+Please go to <a href={props?.download_page ?? "../download"}>Resource Download</a> to download the corresponding image.
+
+Recommended image filename:
+
+{props.image_name}
+
+:::warning
+Make sure the downloaded image matches your product model. Extract the image before continuing.
+:::
+
+## Install the System
+
+<Tabs queryString="target">
+
+<TabItem
+  value="microsd"
+  label="Install system to microSD card"
+  default={props.show_emmc === false}
+>
+
+### Preparation
+
+- 1x microSD card
+- 1x microSD card reader
+- 1x power adapter (recommended: {props.power})
+
+### Install the System
+
+<Etcher model={props.model} />
+
+### Boot the System
+
+- Insert the flashed microSD card into the microSD slot on {props.product}
+- Power on the board with {props.power}
+
+</TabItem>
+
+<TabItem
+  value="emmc"
+  label="Install system to eMMC"
+  attributes={{ className: props.show_emmc === false && "tab_none" }}
+>
+
+### Preparation
+
+- USB data cable
+- x86 PC
+- Extracted image file
+- {props.product} with eMMC
+
+### Enter Maskrom Mode
+
+{props?.maskrom_page ? (
+
+{" "}
+
+<p>
+  Please refer to <a href={props.maskrom_page}>Maskrom Guide</a>.
+</p>
+) : (<p>
+  Please follow the corresponding product documentation to enter Maskrom mode.
+</p>
+)}
+
+### Windows
+
+<Rkdevtool
+  emmc={false}
+  pcie={false}
+  sata={false}
+  rkdevtool_emmc_img={
+    props?.rkdevtool_emmc_img ?? "/img/rkdevtool/emmc-path.webp"
+  }
+>
+  {props.children}
+</Rkdevtool>
+
+### Linux
+
+{props?.linux_page ? (
+
+{" "}
+
+<p>
+  Please refer to <a href={props.linux_page}>Linux flashing guide</a>.
+</p>
+) : (<p>
+  Please use `rkdeveloptool` or `upgrade_tool` according to the corresponding
+  product documentation.
+</p>
+)}
+
+</TabItem>
+
+</Tabs>
+
+## Log In
+
+- The default management address is usually `192.168.1.1`
+- The default username is usually `root`
+- Set the password when prompted on first login
+
+## Storage Expansion
+
+If the root partition does not occupy the whole storage on first boot, refer to the official OpenWrt guide first:
+
+- <a href="https://openwrt.org/docs/guide-user/advanced/expand_root">
+    Expanding root partition and filesystem
+  </a>
+
+:::tip
+Storage device names, partition numbers, and expansion steps may vary by product. Do not directly reuse partition commands from another board.
+:::
+
+## Frequently Asked Questions
+
+- Device not detected: check whether the board has entered Maskrom mode, and try another cable or USB port.
+- Flashing failed: check the image format, file integrity, and model match.
+- LuCI is not reachable: check the default IP, Ethernet port, and host network settings.

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/other-os/README.md
@@ -9,3 +9,5 @@ Introduces other System except RadxaOS and iStoreOS.
 Debian cli:
 
 Please go to [Download](../download) page to download debian cli image,
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa E20C"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_e20c-ext4-sysupgrade.img.gz"
+  power="a suitable power adapter"
+  model="e20c"
+  maskrom_page="../../getting-started/install-os/maskrom/"
+  linux_page="../../getting-started/install-os/maskrom/linux_macos"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/other-os/README.md
@@ -5,3 +5,5 @@ sidebar_position: 5
 # Other System
 
 Introduces other System except RadxaOS and iStoreOS.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa E52C"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_e52c-ext4-sysupgrade.img.gz"
+  power="a suitable power adapter"
+  model="e52c"
+  maskrom_page="../../getting-started/install-os/maskrom/"
+  linux_page="../../getting-started/install-os/maskrom/linux_macos"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2a/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2a/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2a/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2a/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2a/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2a/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 2A"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_2a-ext4-sysupgrade.img.gz"
+  power="a suitable power adapter"
+  model="rock2a"
+  maskrom_page="../../getting-started/install-os/maskrom/"
+  linux_page="../../getting-started/install-os/maskrom/linux"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2f/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2f/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# Other System
+
+Introduces other systems than Radxa OS, such as OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2f/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2f/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2f/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2f/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2f/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock2/rock2f/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 2F"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_2f-ext4-sysupgrade.img.gz"
+  power="a suitable power adapter"
+  model="rock2f"
+  maskrom_page="../../getting-started/install-os/maskrom/"
+  linux_page="../../getting-started/install-os/maskrom/linux"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/README.md
@@ -6,4 +6,4 @@ sidebar_position: 45
 
 Introduces other systems than Radxa OS, such as Android.
 
-<!-- <DocCardList /> -->
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/openwrt/install-os.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 3A"
+  download_page="../../getting-started/download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_3a-ext4-sysupgrade.img.gz"
+  power="a suitable power adapter"
+  model="rock3a"
+  linux_page="../../low-level-dev/rkdeveloptool"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 3B"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_3b-ext4-sysupgrade.img.gz"
+  power="a suitable power adapter"
+  model="rock3b"
+  maskrom_page="../../low-level-dev/maskrom/"
+  linux_page="../../low-level-dev/maskrom/linux"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# Other System
+
+Introduces other systems than Radxa OS, such as OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 3C"
+  download_page="../../getting-started/download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_3c-ext4-sysupgrade.img.gz"
+  power="a suitable power adapter"
+  model="rock3c"
+  maskrom_page="../../low-level-dev/3c-maskrom"
+  linux_page="../../low-level-dev/3c-maskrom"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# Other System
+
+Introduces other systems than Radxa OS, such as OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/other-os/openwrt/install-os.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 4C+"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_4c_plus-ext4-sysupgrade.img.gz"
+  power="a suitable power adapter"
+  model="rock4c+"
+  linux_page="../../low-level-dev/rkdeveloptool"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/other-os/openwrt/install-os.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 4D"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_4d-ext4-sysupgrade.img.gz"
+  power="a suitable power adapter"
+  model="rock4d"
+  maskrom_page="../../hardware-use/maskrom"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 5A"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5a-ext4-sysupgrade.img.gz"
+  power="a suitable USB Type-C power adapter"
+  model="rock5a"
+  maskrom_page="../../low-level-dev/maskrom/"
+  linux_page="../../low-level-dev/maskrom/linux"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/other-os/README.md
@@ -6,4 +6,4 @@ sidebar_position: 8
 
 Introduces other systems than Radxa OS, such as Android.
 
-<!-- <DocCardList /> -->
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/other-os/openwrt/install-os.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 5B / 5B+"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5b-ext4-sysupgrade.img.gz or openwrt-25.12.0-rockchip-armv8-radxa_rock_5b_plus-ext4-sysupgrade.img.gz"
+  power="a suitable USB Type-C power adapter"
+  model="rock5b"
+  maskrom_page="../../low-level-dev/install-os/rkdevtool_maskrom"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 5C / 5C Lite"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5c-ext4-sysupgrade.img.gz or openwrt-25.12.0-rockchip-armv8-radxa_rock_5c_lite-ext4-sysupgrade.img.gz"
+  power="a suitable USB Type-C power adapter"
+  model="rock5c"
+  maskrom_page="../../low-level-dev/maskrom/"
+  linux_page="../../low-level-dev/maskrom/linux"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 5 ITX"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5_itx-ext4-sysupgrade.img.gz"
+  power="a suitable power adapter"
+  model="rock5itx"
+  maskrom_page="../../low-level-dev/maskrom/"
+  linux_page="../../low-level-dev/maskrom/linux"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/other-os/README.md
@@ -6,4 +6,4 @@ sidebar_position: 8
 
 Introduces other systems than Radxa OS, such as Android.
 
-<!-- <DocCardList /> -->
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/other-os/openwrt/install-os.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK 5T"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5t-ext4-sysupgrade.img.gz"
+  power="a suitable USB Type-C power adapter"
+  model="rock5t"
+  maskrom_page="../../low-level-dev/maskrom/"
+  linux_page="../../low-level-dev/maskrom/linux"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# Other System
+
+Introduces other systems than Radxa OS, such as OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/other-os/openwrt/install-os.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK Pi E"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_pi_e-ext4-sysupgrade.img.gz"
+  power="a suitable USB Type-C power adapter"
+  model="rockpie"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# Other System
+
+Introduces other systems than Radxa OS, such as OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/other-os/openwrt/install-os.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ROCK Pi S"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_pi_s-ext4-sysupgrade.img.gz"
+  power="a suitable USB Type-C power adapter"
+  model="rockpis"
+/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/README.md
@@ -6,4 +6,4 @@ sidebar_position: 45
 
 Introduces other systems than Radxa OS, such as Android, Yocto and Buildroot.
 
-<!-- <DocCardList /> -->
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/openwrt/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/openwrt/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# OpenWrt
+
+Introduces how to install and use OpenWrt.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/openwrt/argon-theme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/openwrt/argon-theme.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: Argon Theme
+---
+
+import ArgonTheme from '../../../../common/other-system/openwrt/\_argon-theme.mdx';
+
+# Argon Theme
+
+<ArgonTheme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/openwrt/install-os.md
@@ -1,0 +1,19 @@
+---
+sidebar_position: 1
+title: Install OS
+---
+
+import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-install.mdx';
+
+# Install OS
+
+<OpenWrtMainline
+  product="Radxa ZERO 3W / ZERO 3E"
+  download_page="../../download"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_zero_3w-ext4-sysupgrade.img.gz
+openwrt-25.12.0-rockchip-armv8-radxa_zero_3e-ext4-sysupgrade.img.gz"
+  power="5V/2A power adapter"
+  model="zero3"
+  maskrom_page="../../low-level-dev/install-os-on-emmc"
+  linux_page="../../low-level-dev/rkdeveloptool"
+/>


### PR DESCRIPTION
## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [x] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
