### PR TITLE
docs(q6a): add hardware encoder FAQ

### DIFF
--- a/docs/dragon/q6a/faq.md
+++ b/docs/dragon/q6a/faq.md
@@ -121,3 +121,18 @@ vim /usr/share/glib-2.0/schemas/org.gnome.settings-daemon.plugins.power.gschema.
 </NewCodeBlock>
 
 修改文件中的 `sleep-inactive-ac-timeout` 和 `sleep-inactive-battery-timeout` 参数默认值为 `0`，然后重启系统即可使更改生效。
+
+## 为什么调用硬件编码器会导致 Q6A 直接重启？
+
+在使用硬件编码器前，需要先在 BIOS 中启用相关配置：
+
+`Hypervisor Settings -> Hypervisor Override in UEFI Setup`
+
+开机时按 `F2` 即可进入 UEFI Setup。
+
+如果没有启用该选项，调用硬件编码器时系统可能会直接重启。
+
+启用硬件编码器后，会有以下影响：
+
+- 系统会以 `EL2` 而不是 `EL1` 启动，此时**可以**使用 KVM
+- `/dev/mtd0` 会消失，因此不能直接在板子上更新 SPI 固件

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/faq.md
@@ -119,3 +119,18 @@ vim /usr/share/glib-2.0/schemas/org.gnome.settings-daemon.plugins.power.gschema.
 </NewCodeBlock>
 
 Modify the `sleep-inactive-ac-timeout` and `sleep-inactive-battery-timeout` parameters in the file to have a default value of `0`, then restart the system for the changes to take effect.
+
+## Why does Q6A reboot immediately when using the hardware encoder?
+
+Before using the hardware encoder, you need to enable the following option in BIOS:
+
+`Hypervisor Settings -> Hypervisor Override in UEFI Setup`
+
+You can enter UEFI Setup by pressing `F2` during boot.
+
+If this option is not enabled, calling the hardware encoder may cause the system to reboot immediately.
+
+After enabling the hardware encoder, the following changes apply:
+
+- The system boots in `EL2` instead of `EL1`, and KVM **can** be used
+- `/dev/mtd0` disappears, so you cannot update the SPI firmware directly on the board


### PR DESCRIPTION
## Summary
- add a Q6A FAQ entry for hardware encoder reboot behavior
- document the required BIOS setting before using the hardware encoder
- note the EL2/KVM behavior and loss of /dev/mtd0 after enabling it