### PR TITLE
chore(pre-commit): warn on agent doc drift locally

### DIFF
--- a/.github/agent-reading-guide.md
+++ b/.github/agent-reading-guide.md
@@ -52,5 +52,6 @@
 - 规范：`AGENT-DOC-SPEC.md`
 - 页面模板：`.github/agent-doc-page-template.md`
 - 校验脚本：`scripts/agent-doc-lint.sh`
-- 漂移门禁：`scripts/agent-doc-drift-guard.sh`
+- 漂移校验：`scripts/agent-doc-drift-guard.sh`
+  本地 pre-commit 仅警告；CI 仍按阻塞模式执行
 - 翻译占位门禁：`scripts/agent-doc-translation-guard.sh`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -113,7 +113,8 @@
 
 - Agent 文档规范：`AGENT-DOC-SPEC.md`
 - 增量校验脚本：`scripts/agent-doc-lint.sh`
-- 漂移门禁脚本：`scripts/agent-doc-drift-guard.sh`
+- 漂移校验脚本：`scripts/agent-doc-drift-guard.sh`
+  pre-commit 默认只警告；CI 直接执行脚本时仍会阻塞
 - 翻译占位门禁脚本：`scripts/agent-doc-translation-guard.sh`
 - 页面模板：`.github/agent-doc-page-template.md`
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -148,6 +148,8 @@ repos:
         name: Agent doc drift guard
         language: system
         entry: scripts/agent-doc-drift-guard.sh
+        args:
+          - --warn-only
         pass_filenames: false
         files: '^(docs|i18n/en/docusaurus-plugin-content-docs/current)/.*\.(md|mdx)$'
         stages:

--- a/scripts/agent-doc-drift-guard.sh
+++ b/scripts/agent-doc-drift-guard.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+warn_only=false
+
+if [[ "${1:-}" == "--warn-only" ]]; then
+  warn_only=true
+  shift
+fi
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
@@ -61,7 +68,11 @@ new_docs_count="$(wc -l <"$new_docs_only_tmp" | awk '{print $1}')"
 new_i18n_count="$(wc -l <"$new_i18n_only_tmp" | awk '{print $1}')"
 
 if [[ "$new_docs_count" -gt 0 || "$new_i18n_count" -gt 0 ]]; then
-  echo "ERROR: new docs/i18n drift detected against baseline."
+  if [[ "$warn_only" == true ]]; then
+    echo "WARNING: new docs/i18n drift detected against baseline."
+  else
+    echo "ERROR: new docs/i18n drift detected against baseline."
+  fi
   if [[ "$new_docs_count" -gt 0 ]]; then
     echo
     echo "[new_docs_only]"
@@ -74,6 +85,10 @@ if [[ "$new_docs_count" -gt 0 || "$new_i18n_count" -gt 0 ]]; then
   fi
   echo
   echo "If this drift is intentional, update $BASELINE_FILE in the same PR."
+  if [[ "$warn_only" == true ]]; then
+    echo "agent-doc-drift-guard completed with warnings."
+    exit 0
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- make the local `agent-doc-drift-guard` pre-commit hook warn instead of blocking commits
- keep direct script execution in blocking mode for CI and manual checks
- update the related guidance to reflect the local warning behavior

## Testing
- pre-commit hooks during commit
- pre-push hooks during force-push