### PR TITLE
docs: fix zero install image download link

### DIFF
--- a/docs/zero/zero/getting-started/install-os.md
+++ b/docs/zero/zero/getting-started/install-os.md
@@ -38,7 +38,7 @@ import Etcher from '../../../common/general/\_etcher.mdx'
 
 ## 镜像下载
 
-请到 [资源下载汇总](./download) 下载对应的镜像文件
+请到 [资源下载汇总](../../download) 下载对应的镜像文件
 
 ## 安装系统
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero/getting-started/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero/getting-started/install-os.md
@@ -38,7 +38,7 @@ import Etcher from '../../../common/general/\_etcher.mdx'
 
 ## Image download
 
-Please go to [Download Summary](./download) to download the corresponding image file.
+Please go to [Download Summary](../../download) to download the corresponding image file.
 
 ## Installation system
 


### PR DESCRIPTION
## Summary
- fix the broken download link in ZERO install OS page
- sync the same fix to the English document

Fixes #1344