### PR TITLE
docs(dragon): add Q6A EDL button location link

### DIFF
--- a/docs/dragon/q6a/low-level-dev/edl-mode.md
+++ b/docs/dragon/q6a/low-level-dev/edl-mode.md
@@ -12,6 +12,8 @@ sidebar_position: 1
 
 具体操作步骤：
 
+EDL 按键位置可参考 [EDL 按键](../hardware-use/edl) 页面。
+
 ① ： 按住 EDL 按键
 
 ② ： 连接 12V Type-C 电源适配器（兼容 PD 协议）


### PR DESCRIPTION
## Summary\n- add a direct link from the Q6A EDL mode page to the EDL button location page\n- make it easier to find the physical EDL button before following the recovery steps\n\n## Why\nA docs issue reported that the EDL mode page should link to the hardware button location so users can locate the EDL button more quickly.\n\nFixes #1234\n\n## Validation\n- verified the new relative link resolves to the existing  page\n- kept the change docs-only and minimal