### PR TITLE
docs: clarify fastrpc RadxaOS prerequisite

### DIFF
--- a/docs/common/ai/_fastrpc_setup.mdx
+++ b/docs/common/ai/_fastrpc_setup.mdx
@@ -8,6 +8,10 @@ NPU 环境配置清单
 
 使用 radxa apt 源进行安装
 
+:::note 前置条件
+以下软件包依赖 Radxa 官方镜像里预置的 Radxa APT 源。请先确认设备运行的是对应机型的官方 RadxaOS 镜像；如果当前使用的是第三方 Ubuntu / Debian 镜像或自行更换过软件源，`fastrpc` / `fastrpc-test` 可能无法安装。
+:::
+
 <Tabs queryString="platform">
     <TabItem value="QCS6490" default={props.tag === "qcs6490"} attributes={{className: props.tag === "qcs9075" && "tab_none"}}>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_fastrpc_setup.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_fastrpc_setup.mdx
@@ -8,6 +8,10 @@ NPU Environment Configuration Checklist
 
 Install using radxa apt source
 
+:::note Prerequisite
+These packages depend on the Radxa APT source included in the official RadxaOS images. Before following the steps below, make sure the device is running the official RadxaOS image for the target board. If you are using a third-party Ubuntu/Debian image or have replaced the package sources, `fastrpc` / `fastrpc-test` may not be available.
+:::
+
 <Tabs queryString="platform">
     <TabItem value="QCS6490" default={props.tag === "qcs6490"} attributes={{className: props.tag === "qcs9075" && "tab_none"}}>
 


### PR DESCRIPTION
## Summary

Clarify the prerequisite for the Qualcomm `fastrpc` setup docs: the required packages come from the Radxa APT source included in the official RadxaOS images, so users on third-party Ubuntu/Debian images may not be able to install them. This change was prompted by a user report on the AIRbox Q900 `fastrpc-setup` page.

## Changes

- add a prerequisite note to the shared Chinese `fastrpc` setup partial
- add the matching prerequisite note to the English translation
- explain that `fastrpc` / `fastrpc-test` may be unavailable on non-RadxaOS images or after replacing package sources

## Testing

- `./scripts/agent-doc-lint.sh docs/common/ai/_fastrpc_setup.mdx i18n/en/docusaurus-plugin-content-docs/current/common/ai/_fastrpc_setup.mdx`
- `./scripts/agent-doc-translation-guard.sh`

Fixes #1404