### PR TITLE
docs: remove unsupported Android reference from Cubie A7S overview

### DIFF
--- a/docs/cubie/a7s/README.md
+++ b/docs/cubie/a7s/README.md
@@ -50,7 +50,7 @@ sidebar_position: 4
 | PCIe           | 1X FPC 接口 (PCIe 3.0 x1)<br />- 支持拓展 NVMe 固态硬盘                                                                                                          |
 | 其他接口       | 1X 风扇接口<br />1X USB BOOT 按键 <br />15-Pin 和 30-Pin GPIO 排针<br />- 支持 UART, I2C, I2S, PWM, GPIOs 等功能                                                 |
 | 供电方式       | USB Type-C (5V 电源输入)                                                                                                                                         |
-| 操作系统       | 支持 Debian, Android 13                                                                                                                                          |
+| 操作系统       | 支持 Debian                                                                                                                                                      |
 | 机械尺寸       | 51 毫米 x 51 毫米                                                                                                                                                |
 | 工作温度       | 0 - 60°C                                                                                                                                                         |
 
@@ -100,4 +100,4 @@ Cubie A7S 基于全志 A733 SoC，支持多种操作系统：
 - Debian Linux
 - Buildroot
 - Tina Linux
-- Android 13
+

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/README.md
@@ -50,7 +50,7 @@ For connectivity, it provides Gigabit Ethernet, Wi‑Fi 6, and Bluetooth 5.4. St
 | PCIe                  | 1× FPC connector (PCIe 3.0 x1)<br />- Supports NVMe SSD expansion                                                                                  |
 | Other I/O             | 1× fan header<br />1× USB BOOT button<br />15‑pin and 30‑pin GPIO headers<br />- UART, I2C, I2S, PWM, GPIOs, etc.                                  |
 | Power                 | USB Type‑C (5V input)                                                                                                                              |
-| OS                    | Debian, Android 13                                                                                                                                 |
+| OS                    | Debian                                                                                                                                             |
 | Dimensions            | 51 mm × 51 mm                                                                                                                                      |
 | Operating temperature | 0–60°C                                                                                                                                             |
 
@@ -100,4 +100,4 @@ Cubie A7S is based on the Allwinner A733 SoC and supports multiple operating sys
 - Debian Linux
 - Buildroot
 - Tina Linux
-- Android 13
+


### PR DESCRIPTION
## Summary

Fix the Cubie A7S overview page so it no longer claims Android 13 support. The issue report says A7S does not support Android, and the current README listed Android in both the spec table and the supported platforms section.

## Changes

- remove `Android 13` from `docs/cubie/a7s/README.md`
- remove the same unsupported reference from the English translation
- keep the change narrowly scoped to the A7S overview page

## Testing

- `./scripts/agent-doc-lint.sh docs/cubie/a7s/README.md i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/README.md` ✅
- `./scripts/agent-doc-translation-guard.sh` ✅
- `./scripts/agent-doc-drift-guard.sh` ⚠️ fails on current main baseline with unrelated pre-existing drift in `common/ai/_rknn_yolov8_multi_stream.mdx` and `rock5/rock5b/app-development/ai/yolov8-multi-stream.md`

Fixes #1422