### PR TITLE
docs: fix Moonlight zlib linker instructions

### DIFF
--- a/docs/common/dev/_moonlight.mdx
+++ b/docs/common/dev/_moonlight.mdx
@@ -19,7 +19,7 @@ sudo apt-get update
 sudo apt-get install libegl1-mesa-dev libgl1-mesa-dev libopus-dev libsdl2-dev libsdl2-ttf-dev libssl-dev \
 libavcodec-dev libavformat-dev libswscale-dev libva-dev libvdpau-dev libxkbcommon-dev wayland-protocols \
 libdrm-dev qt6-base-dev qt6-declarative-dev libqt6svg6-dev qml6-module-qtquick-controls qml6-module-qtquick-templates \
-qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window qml6-module-qtquick
+qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window qml6-module-qtquick zlib1g-dev
 ```
 
 ## 获取 Moonlight 源码
@@ -33,9 +33,11 @@ git submodule update --init --recursive
 ## 添加 rockchip-ffmpeg 路径及依赖参数
 
 ```bash
-echo 'LIBS += -L/usr/lib -lavcodec -lavutil -lavformat -lswscale' >> app/app.pro
-echo 'LIBS += -L/usr/lib -lavcodec -lavutil -lavformat -lswscale' >> moonlight-qt.pro
+echo 'LIBS += -L/usr/lib -lavcodec -lavutil -lavformat -lswscale -lz' >> app/app.pro
+echo 'LIBS += -L/usr/lib -lavcodec -lavutil -lavformat -lswscale -lz' >> moonlight-qt.pro
 ```
+
+如果链接阶段报错 `undefined reference to symbol 'inflateEnd'` 或 `DSO missing from command line`，请确认已经安装 `zlib1g-dev`，并且上面的 `LIBS +=` 行包含了 `-lz`。
 
 ## 编译 Moonlight
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_moonlight.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_moonlight.mdx
@@ -19,7 +19,7 @@ sudo apt-get update
 sudo apt-get install libegl1-mesa-dev libgl1-mesa-dev libopus-dev libsdl2-dev libsdl2-ttf-dev libssl-dev \
 libavcodec-dev libavformat-dev libswscale-dev libva-dev libvdpau-dev libxkbcommon-dev wayland-protocols \
 libdrm-dev qt6-base-dev qt6-declarative-dev libqt6svg6-dev qml6-module-qtquick-controls qml6-module-qtquick-templates \
-qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window qml6-module-qtquick
+qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window qml6-module-qtquick zlib1g-dev
 ```
 
 ## Clone Moonlight source code
@@ -33,9 +33,11 @@ git submodule update --init --recursive
 ## Add rockchip-ffmpeg path and dependency parameters
 
 ```bash
-echo 'LIBS += -L/usr/lib -lavcodec -lavutil -lavformat -lswscale' >> app/app.pro
-echo 'LIBS += -L/usr/lib -lavcodec -lavutil -lavformat -lswscale' >> moonlight-qt.pro
+echo 'LIBS += -L/usr/lib -lavcodec -lavutil -lavformat -lswscale -lz' >> app/app.pro
+echo 'LIBS += -L/usr/lib -lavcodec -lavutil -lavformat -lswscale -lz' >> moonlight-qt.pro
 ```
+
+If the linker reports `undefined reference to symbol 'inflateEnd'` or `DSO missing from command line`, make sure `zlib1g-dev` is installed and that the `LIBS +=` lines above include `-lz`.
 
 ## Compile Moonlight
 


### PR DESCRIPTION
## Summary

This docs-only fix updates the shared Moonlight build instructions to cover the linker error reported in #1317.

## Changes

- add `zlib1g-dev` to the documented build dependencies
- add `-lz` to the manual `LIBS +=` lines for `app/app.pro` and `moonlight-qt.pro`
- document the specific `inflateEnd` / `DSO missing from command line` linker symptom so users can verify the fix quickly
- update the matching English translation

## Validation

- reviewed the changed Markdown diff in both zh and en docs
- ran a small sanity check to confirm balanced code fences and the expected `zlib1g-dev` / `-lz` / error-text markers in both edited files

Fixes #1317
