### PR TITLE
docs(common): note Orion O6 EC UART baud exception

### DIFF
--- a/docs/common/general/_serial.mdx
+++ b/docs/common/general/_serial.mdx
@@ -21,6 +21,8 @@ import { Section, Image } from "@site/src/utils/docs";
 <Section compatible="cix" platform={props.platform}>
 基于 CIX 芯片的瑞莎产品，UART 默认配置为 115200n8，无流量控制。
 
+对于星睿 O6 的 EC UART，如使用 `edk2-cix` `1.0.0-1` 及更早版本，请改用 `460800n8` 连接；该例外仅适用于 EC 日志串口，不影响默认的 AP / 系统控制台 UART。
+
 </Section>
 
 <Section compatible="aml" platform={props.platform}>


### PR DESCRIPTION
## Summary

Add a small note to the shared serial console guide to document the Orion O6 EC UART baud-rate exception on older `edk2-cix` releases.

## Changes

- keep the default CIX UART guidance as `115200n8`
- add an Orion O6-specific note that the **EC UART** uses `460800n8` on `edk2-cix` `1.0.0-1` and earlier
- clarify that this exception only applies to the EC log console and does not change the default AP / system console UART settings

## Validation

- ran `git diff --check`
- ran a small sanity check to confirm the updated file contains the expected `edk2-cix`, `460800n8`, and AP/system-console clarification text

Fixes #875
