### PR TITLE
docs(rock4c+): fix broken before-start download link

### DIFF
--- a/docs/rock4/rock4c+/getting-started/before-start.md
+++ b/docs/rock4/rock4c+/getting-started/before-start.md
@@ -84,6 +84,6 @@ ROCK 4C+ 支持 LCD 显示功能。
 
 ## 系统安装
 
-首先，请从 [ROCK 4 官方镜像下载页](../../official-images)下载 ROCK 4C+ 的官方镜像。  
-然后，参照[操作系统安装指南](install-os)安装操作系统。  
+首先，请从 [ROCK 4C+ 资源下载页](../download)下载 ROCK 4C+ 的官方镜像。
+然后，参照[操作系统安装指南](install-os)安装操作系统。
 最后，将系统存储介质：microSD 卡或 eMMC 模块插入主板上的插口，并通过 Type-C 供电启动 ROCK 4C+。

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/getting-started/before-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/getting-started/before-start.md
@@ -82,6 +82,6 @@ Audio can be played through speaker or headphones using a standard 3.5mm jack.
 
 ## OS Installation
 
-First, please download the official images of ROCK 4C Plus on the [ROCK 4 Official Images Download](../../official-images).  
-Then, you can install the OS by referring the [OS Installation Guide](install-os).  
+First, please download the official images of ROCK 4C Plus from the [ROCK 4C+ Download Summary](../download).
+Then, you can install the OS by referring the [OS Installation Guide](install-os).
 Finally, insert the system storage media, microSD Card or eMMC Module into the socket on the board and power on ROCK 4C Plus by adapter with Type-C port.


### PR DESCRIPTION
## Summary

Fix the broken relative link on the ROCK 4C+ before-start page. The current page links to `../../official-images`, which resolves to a missing `/rock4/official-images` page instead of the product-specific ROCK 4C+ download page.

## Changes

- update the Chinese ROCK 4C+ before-start page to link to `../download`
- update the matching English translation to the same ROCK 4C+ download summary page
- keep the change narrowly scoped to this broken-link fix

## Testing

- `./scripts/agent-doc-lint.sh docs/rock4/rock4c+/getting-started/before-start.md i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/getting-started/before-start.md`
- `./scripts/agent-doc-translation-guard.sh`
- `git diff --check`
- `./scripts/agent-doc-drift-guard.sh` still fails on a clean clone of current `origin/main` due to pre-existing unrelated baseline drift in:
  - `common/ai/_rknn_yolov8_multi_stream.mdx`
  - `rock5/rock5b/app-development/ai/yolov8-multi-stream.md`

Fixes #983
