### PR TITLE
docs: clarify Cubie A7Z IMX214 validation notes

### DIFF
--- a/docs/cubie/a7z/accessories/camera-13m-214.md
+++ b/docs/cubie/a7z/accessories/camera-13m-214.md
@@ -20,7 +20,32 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
+
+## 已验证环境与常用管线
+
+以下说明基于 issue #1360 中确认过的 Cubie A7Z 实测结果整理，适合先做快速自检。
+
+- 已验证镜像：`radxa-a733_bullseye_kde_r2.output_512.img.xz`
+- 全分辨率预览：使用 `/dev/video1`，分辨率 `4208x3120`，并保持 `en-largemode=1`
+- 1080p 预览：使用 `/dev/video0`，分辨率 `1920x1080`，并使用 `en-largemode=0`
+- 当前软件流中，更低分辨率未在该 issue 对应环境下完成验证；如果直接切到更低分辨率，可能出现画面异常
+
+### 1080p 预览
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+## 排障
+
+- 如果系统中没有出现 `/dev/video*` 节点，请先确认使用的是最新可用官方镜像，再重新插拔并检查 FPC 排线是否压紧、方向是否正确
+- 如果需要先确认摄像头是否已经被内核识别，可运行 `v4l2-ctl --list-devices`
+- 如需复现本文档中的已验证结果，建议优先使用上方两条已验证管线，不要一开始就切换到未验证的低分辨率参数

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
@@ -20,7 +20,32 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
+
+## Verified setup and common pipelines
+
+The notes below summarize the Cubie A7Z results confirmed in issue #1360 and are intended as a quick validation baseline.
+
+- Verified image: `radxa-a733_bullseye_kde_r2.output_512.img.xz`
+- Full-resolution preview: use `/dev/video1` at `4208x3120` with `en-largemode=1`
+- 1080p preview: use `/dev/video0` at `1920x1080` with `en-largemode=0`
+- Lower resolutions were not fully validated in that software flow; switching directly to smaller resolutions may still produce abnormal output
+
+### 1080p preview
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+## Troubleshooting
+
+- If no `/dev/video*` nodes appear, first confirm that you are using a recent official image, then reseat the FPC cable and verify its orientation and latch state
+- To quickly confirm whether the camera has been detected by the kernel, run `v4l2-ctl --list-devices`
+- To reproduce the validated behavior documented here, start with the two verified pipelines above before trying unvalidated lower-resolution settings


### PR DESCRIPTION
## Summary

This docs-only update clarifies the validated Cubie A7Z + IMX214 setup discussed in #1360 so users have a cleaner baseline before debugging camera bring-up problems.

## Changes

- add the verified image name used in the issue discussion
- document the validated full-resolution preview pipeline on `/dev/video1`
- add the validated 1080p preview pipeline on `/dev/video0`
- add a short troubleshooting section for missing `/dev/video*` nodes and first-step validation
- sync the same clarification to the English page

## Testing

- `scripts/agent-doc-lint.sh docs/cubie/a7z/accessories/camera-13m-214.md i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md` ✅
- `git diff --check` ✅
- `scripts/agent-doc-drift-guard.sh` currently reports pre-existing baseline drift on unrelated paths (`common/ai/_rknn_yolov8_multi_stream.mdx`, `rock5/rock5b/app-development/ai/yolov8-multi-stream.md`), so it was not changed in this PR

Refs #1360