### PR TITLE
docs(q6a): clarify .img.xz flashing on download page

### DIFF
--- a/docs/dragon/q6a/download.md
+++ b/docs/dragon/q6a/download.md
@@ -21,6 +21,14 @@ sidebar_position: 150
 - [radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz](https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-r2/radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz)：适用于 MicroSD 卡 / U 盘 / eMMC / NVMe 启动系统
 - [radxa-dragon-q6a_noble_gnome_r2.output_4096.img.xz](https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-r2/radxa-dragon-q6a_noble_gnome_r2.output_4096.img.xz)：适用于 UFS 启动系统
 
+:::note 使用提示
+
+上述文件为 `.img.xz` 压缩镜像。如果所使用的烧录工具不支持直接写入 `.xz` 压缩包，请先解压得到 `.img` 文件，再进行烧录。
+
+如需完整步骤，可参考 [快速上手](./getting-started/quickly-start) 或 [安装系统](./getting-started/install-system/) 页面。
+
+:::
+
 :::tip 固件信息
 
 可以根据以下方式判断系统 SPI 固件版本信息：

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/download.md
@@ -21,6 +21,14 @@ This page hosts the latest official and test system images. Test releases begin 
 - [radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz](https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-r2/radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz): For booting from MicroSD card / USB drive / eMMC / NVMe
 - [radxa-dragon-q6a_noble_gnome_r2.output_4096.img.xz](https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-r2/radxa-dragon-q6a_noble_gnome_r2.output_4096.img.xz): For booting from UFS
 
+:::note Usage note
+
+The files above are compressed `.img.xz` system images. If your flashing tool cannot write `.xz` archives directly, extract the archive first to get the `.img` file, then flash that `.img` file.
+
+For the complete procedure, see [Quick Start](./getting-started/quickly-start) or [Install System](./getting-started/install-system/).
+
+:::
+
 :::tip Firmware Information
 
 You can determine the system SPI firmware version using the following methods:


### PR DESCRIPTION
## Summary

Add a small usage note to the Dragon Q6A download page so users know the published system images are compressed `.img.xz` archives and may need to be extracted first when using flashing tools that do not handle `.xz` directly.

## Changes

- add a usage note to `docs/dragon/q6a/download.md`
- add the matching English note to `i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/download.md`
- link readers to the existing Quick Start and Install System pages for full flashing steps

## Validation

- `./scripts/agent-doc-lint.sh docs/dragon/q6a/download.md i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/download.md`
- `./scripts/agent-doc-translation-guard.sh`
- `./scripts/agent-doc-drift-guard.sh` currently reports pre-existing baseline drift unrelated to this change:
  - `common/ai/_rknn_yolov8_multi_stream.mdx`
  - `rock5/rock5b/app-development/ai/yolov8-multi-stream.md`

Fixes #1408
