### PR TITLE
docs: clarify rockpi-penta support scope for Raspberry Pi 5

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -20,6 +20,8 @@ Radxa Penta SATA HAT 有一个 2x5 的座子，座子的信号如下：
 
 ## 软件支持
 
+注意：当前 `rockpi-penta` 软件包按 Radxa 的 Debian/Ubuntu 系统验证。若你在 Raspberry Pi 5 上使用 Debian Trixie，已知可能因为 `libgpiod` / GPIO 接口差异导致 `rockpi-penta.service` 无法正常驱动风扇或 OLED；这种组合目前不在本文档的支持范围内。
+
 为了让顶板的 OLED 显示屏和风扇正常工作，我们提供了 `rockpi-penta` 软件包，可以通过下面的命令安装。
 
 ```shell

--- a/docs/rock5/rock5a/getting-started/interface-usage/penta-sata-hat.md
+++ b/docs/rock5/rock5a/getting-started/interface-usage/penta-sata-hat.md
@@ -75,6 +75,8 @@ radxa@rock-5a:~$
 
 ## 软件支持
 
+注意：当前 `rockpi-penta` 软件包按 Radxa 的 Debian/Ubuntu 系统验证。若你在 Raspberry Pi 5 上使用 Debian Trixie，已知可能因为 `libgpiod` / GPIO 接口差异导致 `rockpi-penta.service` 无法正常驱动风扇或 OLED；这种组合目前不在本文档的支持范围内。
+
 为了让顶板的 OLED 显示屏和风扇正常工作，我们提供了 rockpi-penta 软件包，可以通过下面的命令安装。
 
 ```bash

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -20,6 +20,8 @@ This seat can be used to link to the top plate, which has a 0.91 inch OLED displ
 
 ## Software support
 
+Note: the current `rockpi-penta` package is validated on Radxa Debian/Ubuntu images. When running Debian Trixie on a Raspberry Pi 5, `rockpi-penta.service` is known to fail to drive the fan or OLED because of `libgpiod` / GPIO interface differences; that combination is currently outside the support scope of this guide.
+
 In order to get the top panel OLED display and fan working properly, we provide the `rockpi-penta` package, which can be installed with the following command.
 
 ```shell

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/getting-started/interface-usage/penta-sata-hat.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/getting-started/interface-usage/penta-sata-hat.md
@@ -77,6 +77,8 @@ radxa@rock-5a:~$
 
 ## Software Support
 
+Note: the current `rockpi-penta` package is validated on Radxa Debian/Ubuntu images. When running Debian Trixie on a Raspberry Pi 5, `rockpi-penta.service` is known to fail to drive the fan or OLED because of `libgpiod` / GPIO interface differences; that combination is currently outside the support scope of this guide.
+
 To make the OLED display and fan on the top panel work properly, we provide the rockpi-penta software package, which can be installed with the following commands.
 
 ```bash


### PR DESCRIPTION
Closing - we plan to update the software to add Raspberry Pi 5 support in the future.