### PR TITLE
docs(accessories): fix LCD 8 HD usage page links

### DIFF
--- a/docs/accessories/display/lcd-8-hd/lcd-8-hd-usage.md
+++ b/docs/accessories/display/lcd-8-hd/lcd-8-hd-usage.md
@@ -53,8 +53,9 @@ sidebar_position: 6
 
 3. 连接显示器或 USB 串口调试，通电进入系统
 
-4. 通过终端打开 `Radxa Display 8 HD` 的 overlay 选项，具体操作请参阅设备树设置。
-<!-- [设备树设置](/radxa-os/rsetup/devicetree)。 -->
+4. 通过终端打开 `Radxa Display 8 HD` 的 overlay 选项。不同板型的具体操作可参考：
+   - [ROCK 5A MIPI DSI 使用说明](../../../rock5/rock5a/getting-started/interface-usage/mipi-dsi)
+   - [ROCK 5B / 5B+ MIPI DSI 使用说明](../../../rock5/rock5b/getting-started/interface-usage/mipi-dsi)
 
 5. 重启 SBC 以启用 overlay，显示屏输出画面
 
@@ -158,8 +159,10 @@ Step 3：将卡扣向下按紧，固定排线
 
 4. 连接显示器或 USB 串口调试，通电进入系统
 
-5. 通过终端打开 `Radxa Display 8 HD` 的 overlay 选项，具体操作请参阅设备树设置。
-<!-- [设备树设置](/radxa-os/rsetup/devicetree)。 -->
+5. 通过终端打开 `Radxa Display 8 HD` 的 overlay 选项。不同板型的具体操作可参考：
+   - [ROCK 3A 显示屏使用说明](../../../rock3/rock3a/accessories/display)
+   - [ROCK 3C 显示配置说明](../../../rock3/rock3c/radxa-os/display)
+   - [ROCK 4SE DSI 使用说明](../../../rock4/rock4ab-se/getting-started/interface-usage/dsi)
 
 6. 重启 SBC 以启用 overlay，显示屏将会输出画面
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/display/lcd-8-hd/lcd-8-hd-usage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/display/lcd-8-hd/lcd-8-hd-usage.md
@@ -53,8 +53,9 @@ Recommended [Radxa PD 30W Adapter](../../power/pd_30w).
 
 3. Connect the monitor or USB serial port debugging, power into the system
 
-4. Enable the overlay option of `Radxa Display 8 HD' via the terminal, see Device Tree Settings.
-<!-- [Device Tree Settings](/radxa-os/rsetup/devicetree) for details. -->
+4. Enable the `Radxa Display 8 HD` overlay via the terminal. For the board-specific overlay steps, refer to:
+   - [ROCK 5A MIPI DSI](../../../rock5/rock5a/getting-started/interface-usage/mipi-dsi)
+   - [ROCK 5B / 5B+ MIPI DSI](../../../rock5/rock5b/getting-started/interface-usage/mipi-dsi)
 
 5. Reboot the SBC to apply overlay and the display will output a screen.
 
@@ -158,8 +159,10 @@ The physical connection diagram is referenced below:
 
 4. Connect the monitor or USB serial port debugging, power into the system
 
-5. Enable the overlay option of `Radxa Display 8 HD' via the terminal, see Device Tree Settings.
-<!-- [Device Tree Settings](/radxa-os/rsetup/devicetree) for details. -->
+5. Enable the `Radxa Display 8 HD` overlay via the terminal. For the board-specific overlay steps, refer to:
+   - [ROCK 3A display guide](../../../rock3/rock3a/accessories/display)
+   - [ROCK 3C display configuration](../../../rock3/rock3c/radxa-os/display)
+   - [ROCK 4SE DSI guide](../../../rock4/rock4ab-se/getting-started/interface-usage/dsi)
 
 6. Reboot the SBC to apply overlay and the display will output a screen.
 


### PR DESCRIPTION
## Summary
- replace the placeholder "Device Tree Settings" text on the LCD 8 HD usage page with direct board-specific guide links
- fix the mismatched backticks on the English page for `Radxa Display 8 HD`
- keep the Chinese and English pages aligned for the same setup steps

## Validation
- `scripts/agent-doc-lint.sh docs/accessories/display/lcd-8-hd/lcd-8-hd-usage.md i18n/en/docusaurus-plugin-content-docs/current/accessories/display/lcd-8-hd/lcd-8-hd-usage.md`
- verified each newly added relative link resolves to an existing doc source file

## Context
This is a small docs-only follow-up for the LCD 8 HD usage page issue: the page still had a broken inline code quote on the English side and did not provide clickable links for the overlay setup step.

Fixes #690
