### PR TITLE
docs: add AI Hub install note for openai-clip

### DIFF
--- a/docs/common/orion-common/app-dev/artificial-intelligence/_ai-hub.mdx
+++ b/docs/common/orion-common/app-dev/artificial-intelligence/_ai-hub.mdx
@@ -33,6 +33,12 @@ pip3 install -r requirements.txt
 
 </NewCodeBlock>
 
+:::tip 安装提示
+如果 `pip3 install -r requirements.txt` 在构建 `openai-clip` 时失败，而您当前并不需要运行 CLIP 相关 demo，可以先注释 `requirements.txt` 中对应的 `openai-clip` 依赖后再继续安装。
+
+如果必须使用 CLIP 模型，请尝试改用 [openai-clip 历史版本](https://pypi.org/project/openai-clip/#history)，并结合实际报错日志进一步排查。
+:::
+
 ## 下载整个仓库
 
 :::tip[建议]

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/orion-common/app-dev/artificial-intelligence/_ai-hub.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/orion-common/app-dev/artificial-intelligence/_ai-hub.mdx
@@ -21,11 +21,19 @@ Activate the virtual environment before running.
 <NewCodeBlock tip="O6 / O6N" type="device">
 
 ```bash
+cd ai_model_hub_25_Q3/
 python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
 pip3 install -r requirements.txt
 ```
 
 </NewCodeBlock>
+
+:::tip Installation note
+If `pip3 install -r requirements.txt` fails while building `openai-clip` and you do not need to run CLIP-related demos, comment out the `openai-clip` entry in `requirements.txt` before continuing.
+
+If you do need CLIP support, try an [older openai-clip release](https://pypi.org/project/openai-clip/#history) and continue troubleshooting with the full build log.
+:::
 
 ## Download the entire repository
 


### PR DESCRIPTION
## Summary

Add a small troubleshooting note to the Orion O6/O6N AI Hub setup docs for the known `openai-clip` build failure reported in #1200.

## Changes

- add a Chinese install note explaining that users who do not need CLIP demos can comment out `openai-clip` in `requirements.txt`
- add the same workaround note to the English page and point users to older `openai-clip` releases when CLIP support is required
- restore the missing `cd ai_model_hub_25_Q3/` and `source .venv/bin/activate` steps in the English environment setup snippet so it matches the Chinese flow

## Testing

- `./scripts/agent-doc-lint.sh docs/common/orion-common/app-dev/artificial-intelligence/_ai-hub.mdx i18n/en/docusaurus-plugin-content-docs/current/common/orion-common/app-dev/artificial-intelligence/_ai-hub.mdx`
- `./scripts/agent-doc-translation-guard.sh`

Fixes #1200