### PR TITLE
docs: clarify keyring behavior for auto login

### DIFF
--- a/docs/common/radxa-os/system-config/_auto_login.mdx
+++ b/docs/common/radxa-os/system-config/_auto_login.mdx
@@ -33,6 +33,16 @@ sudo rsetup
 
 进入 `Rsetup` 工具后，选择 `User Settings` -> `Configure auto login`选项，使能 `sddm.service`，然后按照 `Rsetup` 工具提示完成剩下操作。
 
+:::note 关于密钥环 / KWallet
+为避免自动登录场景下反复弹出密钥环解锁窗口，RadxaOS 桌面镜像默认不会预先启用用户的 KDE Wallet / Keyring。这样虽然更适合广告机、自启动程序等免密码登录场景，但也可能带来以下影响：
+
+- Chromium、Chrome 或其他 Electron 应用无法正常保存密码
+- 使用 SSH 公钥 / 私钥时，桌面密钥管理功能可能无法按预期工作
+- 其他依赖系统密钥环保存凭据的应用，可能出现异常行为
+
+如果您需要这些功能，请在登录桌面后打开 `System Settings` -> `KDE Wallet`，按照界面提示手动启用钱包并设置密码。若您启用了自动登录，请根据自己的安全需求决定是否保留钱包密码。
+:::
+
 - User Settings
 
 <div style={{ textAlign: "center" }}>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_auto_login.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_auto_login.mdx
@@ -33,6 +33,16 @@ sudo rsetup
 
 In the `Rsetup` tool, navigate to `User Settings` -> `Configure auto login`, enable `sddm.service`, and follow the on-screen instructions to complete the setup.
 
+:::note About Keyring / KWallet
+To avoid repeated keyring unlock pop-ups in auto-login scenarios, RadxaOS desktop images do not enable the user's KDE Wallet / keyring for you in advance. This is convenient for kiosk-style or auto-start deployments, but it can also lead to the following side effects:
+
+- Chromium, Chrome, or other Electron apps may not be able to save passwords normally
+- SSH public/private key workflows may not integrate with the desktop credential manager as expected
+- Other applications that rely on the system keyring to store credentials may behave unexpectedly
+
+If you need these features, open `System Settings` -> `KDE Wallet` after logging into the desktop, then follow the on-screen prompts to enable the wallet and set a password manually. If your device uses auto login, decide whether to keep a wallet password based on your own security requirements.
+:::
+
 - User Settings
 
 <div style={{ textAlign: "center" }}>


### PR DESCRIPTION
## Summary
- explain why KDE Wallet / keyring is not enabled in advance for RadxaOS auto-login setups
- document the common side effects for Chromium / Electron password storage, SSH key integration, and other credential-dependent desktop apps
- point users to `System Settings` -> `KDE Wallet` when they need to enable the wallet manually

## Testing
- `./scripts/agent-doc-lint.sh docs/common/radxa-os/system-config/_auto_login.mdx i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_auto_login.mdx`
- `./scripts/agent-doc-translation-guard.sh`

Fixes #934
