### PR TITLE
docs: clarify Moonlight ffmpeg-rockchip shared-build requirement

### DIFF
--- a/docs/common/dev/_moonlight.mdx
+++ b/docs/common/dev/_moonlight.mdx
@@ -12,6 +12,12 @@
 参考至[编译并安装 ffmpeg-rockchip](rtsp?target=ffmpeg#编译并安装-ffmpeg-rockchip)
 即可安装 rockchip-ffmpeg。
 
+:::tip
+如果你是自行编译 `ffmpeg-rockchip` 给 Moonlight 使用，请确保 `ffmpeg-rockchip` 的 `./configure`
+参数包含 `--enable-shared`。否则 Moonlight 在链接阶段可能会误用静态 `libavcodec.a`，并报出类似
+`undefined reference to symbol 'inflateEnd'` 这样的缺少 zlib 依赖错误。
+:::
+
 ## 安装 Moonlight 编译依赖
 
 ```bash

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_moonlight.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_moonlight.mdx
@@ -12,6 +12,12 @@ but the results may be unsatisfactory.
 Refer to [RTSP Streaming](rtsp?target=ffmpeg), there is no need to follow the entire documentation. Just follow the instructions up to
 [Compile and Install ffmpeg-rockchip](rtsp?target=ffmpeg#compile-and-install-ffmpeg-rockchip) to install rockchip-ffmpeg.
 
+:::tip
+If you build `ffmpeg-rockchip` yourself for Moonlight, make sure the `ffmpeg-rockchip` `./configure`
+arguments include `--enable-shared`. Otherwise Moonlight may pick the static `libavcodec.a` during
+linking and fail with missing system library errors such as `undefined reference to symbol 'inflateEnd'`.
+:::
+
 ## Install Moonlight build dependencies
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify that Moonlight users should build `ffmpeg-rockchip` with `--enable-shared`
- explain why static `libavcodec.a` can trigger linker failures such as `inflateEnd`
- keep the fix small and scoped to the Moonlight doc in both Chinese and English

## Validation
- ./scripts/agent-doc-lint.sh docs/common/dev/_moonlight.mdx i18n/en/docusaurus-plugin-content-docs/current/common/dev/_moonlight.mdx
- ./scripts/agent-doc-drift-guard.sh
- ./scripts/agent-doc-translation-guard.sh

Fixes #1317