### PR TITLE
docs: clarify how to judge q6a USB flashing success

### DIFF
--- a/docs/common/radxa-os/install-system/qualcomm/_usb_flash_system.mdx
+++ b/docs/common/radxa-os/install-system/qualcomm/_usb_flash_system.mdx
@@ -35,3 +35,49 @@ edl-ng --loader <path-to-loader> --memory <storage-type> write-sector <start-sec
 } write-sector ${props?.start_sector ?? "<start-sector>"} ${
   props?.image_file ?? "<path-to-image-file>"
 }`}</code>
+
+## 如何判断烧录成功或失败
+
+`edl-ng` 的具体输出会因版本、主机系统和 USB 状态略有不同，但通常可以按下面的方法判断结果：
+
+### 成功时常见特征
+
+- 终端中可以看到设备进入 `Sahara` / `Firehose` 阶段。
+- 终端中可以看到持续写入的进度或分块写入信息。
+- 命令最终正常结束并返回 shell 提示符。
+- **整个过程中没有出现 `error`、`failed`、`timeout`、`sahara error`、`firehose error` 等报错关键词。**
+
+参考输出示例（不同版本输出可能不同，仅用于帮助判断）：
+
+```text
+$ edl-ng --loader prog_firehose_ddr.elf --memory ufs write-sector 0 radxa-dragon-q6a_noble_kde_t4.output_4096.img
+[Info] Detected Qualcomm device in Sahara mode
+[Info] Uploading loader: prog_firehose_ddr.elf
+[Info] Loader uploaded successfully
+[Info] Switching to Firehose mode
+[Info] Writing image to sector 0
+[Info] ... writing data ...
+[Info] Operation completed successfully
+```
+
+### 失败时常见特征
+
+- 终端中出现 `error`、`failed`、`timeout`、`sahara`、`firehose`、`cannot open`、`no device detected` 等错误信息。
+- 命令在写入过程中中断，或长时间卡住后退出。
+- 命令退出后没有正常完成提示，且没有完成全部写入。
+
+常见失败示例：
+
+```text
+[Error] No device detected in Sahara mode
+[Error] Failed to upload loader
+[Error] Firehose configure failed
+[Error] Timeout while writing sector data
+```
+
+### 如果不确定是否成功
+
+1. 重新让主板进入 EDL 模式后再执行一次烧录命令。
+2. 更换一根稳定的 USB Type-A to Type-A 数据线。
+3. 确认使用的是解压后的镜像文件，并且路径中没有写错。
+4. 保留终端最后几十行日志，便于后续排查。

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/install-system/qualcomm/_usb_flash_system.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/install-system/qualcomm/_usb_flash_system.mdx
@@ -35,3 +35,49 @@ Example:
 } write-sector ${props?.start_sector ?? "<start-sector>"} ${
   props?.image_file ?? "<path-to-image-file>"
 }`}</code>
+
+## How to tell whether flashing succeeded
+
+The exact `edl-ng` output can vary slightly by version, host OS, and USB connection state, but you can usually judge the result using the checks below.
+
+### Common signs of a successful flash
+
+- The terminal shows the device entering the `Sahara` / `Firehose` stages.
+- The terminal shows ongoing write progress or chunked write messages.
+- The command finishes normally and returns to the shell prompt.
+- **No error keywords such as `error`, `failed`, `timeout`, `sahara error`, or `firehose error` appear during the whole process.**
+
+Reference output example (actual wording may differ by version):
+
+```text
+$ edl-ng --loader prog_firehose_ddr.elf --memory ufs write-sector 0 radxa-dragon-q6a_noble_kde_t4.output_4096.img
+[Info] Detected Qualcomm device in Sahara mode
+[Info] Uploading loader: prog_firehose_ddr.elf
+[Info] Loader uploaded successfully
+[Info] Switching to Firehose mode
+[Info] Writing image to sector 0
+[Info] ... writing data ...
+[Info] Operation completed successfully
+```
+
+### Common signs of a failed flash
+
+- The terminal shows errors such as `error`, `failed`, `timeout`, `sahara`, `firehose`, `cannot open`, or `no device detected`.
+- The command stops midway through writing, or hangs for a long time and then exits.
+- The command exits without a normal completion message and does not finish the full write.
+
+Common failure examples:
+
+```text
+[Error] No device detected in Sahara mode
+[Error] Failed to upload loader
+[Error] Firehose configure failed
+[Error] Timeout while writing sector data
+```
+
+### If you are not sure whether it succeeded
+
+1. Put the board back into EDL mode and run the flash command again.
+2. Try a known-good USB Type-A to Type-A data cable.
+3. Make sure you are using the extracted image file and that the file path is correct.
+4. Keep the last few dozen terminal log lines for troubleshooting.


### PR DESCRIPTION
## Summary
- add a small docs-only section to the shared Qualcomm USB flashing template
- explain the common signs of success vs failure for `edl-ng write-sector`
- include reference success/failure log snippets and follow-up checks

## Why
Users on the Dragon Q6A USB flashing page asked for clearer guidance on how to tell whether a flash actually finished successfully.

Fixes #1122

## Validation
- verified the affected Chinese and English MDX files render as valid fenced-code content
- kept the change scoped to the shared Qualcomm USB flashing template used by the Q6A USB flashing docs
