### PR TITLE
docs(e20c): clarify Flippy OpenWrt maintenance scope

### DIFF
--- a/docs/e/e20c/download.md
+++ b/docs/e/e20c/download.md
@@ -22,6 +22,12 @@ Flippy OpenWrt:
 
 [Flippy OpenWrt Github](https://github.com/unifreq/openwrt_packit)
 
+:::note
+Flippy OpenWrt 为第三方社区镜像，软件源与后续维护状态由上游项目决定，不受 Radxa 控制。
+
+如果你需要更稳定、持续维护的软件源与后续版本更新，建议优先使用下方的 OpenWrt 官方镜像。
+:::
+
 OpenWrt 官方镜像:
 
 - [Radxa E20C OpenWrt ext4 sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_e20c-ext4-sysupgrade.img.gz)

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
@@ -22,6 +22,12 @@ Flippy OpenWrt:
 
 [Flippy OpenWrt Github](https://github.com/unifreq/openwrt_packit)
 
+:::note
+Flippy OpenWrt is a third-party community image. Package feeds and ongoing maintenance are controlled by the upstream project, not by Radxa.
+
+If you need more stable package feeds and maintained follow-up releases, we recommend using the official OpenWrt images below.
+:::
+
 Official OpenWrt images:
 
 - [Radxa E20C OpenWrt ext4 sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_e20c-ext4-sysupgrade.img.gz)


### PR DESCRIPTION
## Summary
- clarify that Flippy OpenWrt is a third-party community image
- recommend the official OpenWrt images when users need maintained package feeds and follow-up releases
- mirror the note in the English page

## Why
Issue #1178 reports that the old Flippy software source is no longer usable. We cannot safely claim a new third-party image/version here, but we can make the download page clearer so users know which image is maintained by Radxa upstream choices versus a third-party community image.

Fixes #1178