### PR TITLE
docs: expand ROCK 5 ITX fan usage guide

### DIFF
--- a/docs/rock5/rock5itx/getting-started/interface-usage/fan.md
+++ b/docs/rock5/rock5itx/getting-started/interface-usage/fan.md
@@ -6,6 +6,31 @@ sidebar_position: 15
 
 ## 简介
 
+ROCK 5 ITX 提供标准 4-Pin PWM 风扇接口，可搭配兼容的散热器使用。推荐散热器为瑞莎 8418B。
+
+## 安装与使用
+
+### 安装瑞莎 8418B 散热器
+
+1. 将导热硅脂均匀涂抹在 RK3588 SoC 表面。
+2. 将散热器对准主板上的 4 个安装孔，确认风扇线材朝向便于接入 FAN 接口的一侧。
+3. 将扣具与主板背面的 4 个安装孔对齐后固定。
+4. 按照**对角线顺序**逐步拧紧螺丝，避免主板受力不均。
+5. 将风扇线插入主板上的 FAN 接口，接口带防反插设计，接线时请确认方向。
+
+<img src="/img/accessories/heatsink-case/heatsink_8418b_01.webp" alt="Heatsink 8418B" style={{width: "80%" }} />
+
+<img src="/img/accessories/heatsink-case/heatsink_8418b_02.webp" alt="Heatsink 8418B 2" style={{width: "80%" }} />
+
+<img src="/img/accessories/heatsink-case/heatsink_8418b_03.webp" alt="Heatsink 8418B 3" style={{width: "80%" }} />
+
+### 使用说明
+
+- ROCK 5 ITX 风扇接口支持 4-Pin PWM 风扇。
+- 主板提供标准 FAN 接口，适合使用带风扇的散热器。
+- 当前硬件接口**不支持风扇转速回读（tachometer）**，因此不提供转速报码相关功能。
+- 如需查看整机装配步骤，可参考[组装指南](../assembly-guide#install-a-cooling-fan)。
+
 ## 支持列表
 
 - 瑞莎 8418B 散热器

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/interface-usage/fan.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/interface-usage/fan.md
@@ -6,6 +6,31 @@ sidebar_position: 15
 
 ## Introduction
 
+ROCK 5 ITX provides a standard 4-pin PWM fan header for compatible coolers. The recommended cooler is the Radxa 8418B.
+
+## Installation and usage
+
+### Install the Radxa 8418B cooler
+
+1. Apply thermal grease evenly to the RK3588 SoC.
+2. Align the cooler with the four mounting holes on the motherboard, and make sure the fan cable can reach the FAN header comfortably.
+3. Align and secure the fasteners with the four mounting holes on the back of the motherboard.
+4. Tighten the screws gradually in **diagonal order** to avoid uneven stress on the board.
+5. Connect the fan cable to the FAN header on the motherboard. The connector is keyed, so check the orientation before inserting it.
+
+<img src="/img/accessories/heatsink-case/heatsink_8418b_01.webp" alt="Heatsink 8418B" style={{width: "80%" }} />
+
+<img src="/img/accessories/heatsink-case/heatsink_8418b_02.webp" alt="Heatsink 8418B 2" style={{width: "80%" }} />
+
+<img src="/img/accessories/heatsink-case/heatsink_8418b_03.webp" alt="Heatsink 8418B 3" style={{width: "80%" }} />
+
+### Usage notes
+
+- The ROCK 5 ITX FAN header supports 4-pin PWM fans.
+- The board provides a standard FAN header for fan-equipped heatsinks.
+- The current hardware interface **does not support fan tachometer readback**, so fan speed reporting is not available.
+- For the full chassis assembly flow, see the [Assembly Guide](../assembly-guide#install-a-cooling-fan).
+
 ## Support List
 
 - Radxa 8418B Radiator


### PR DESCRIPTION
## Summary
- add practical ROCK 5 ITX fan installation and usage guidance to the fan page
- reuse the existing 8418B installation visuals so users can follow the mounting order and connector orientation
- clarify the supported 4-pin PWM header and the current lack of tachometer readback

## Testing
- ./scripts/agent-doc-lint.sh docs/rock5/rock5itx/getting-started/interface-usage/fan.md i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/interface-usage/fan.md
- ./scripts/agent-doc-translation-guard.sh

Fixes #944