### PR TITLE
docs: add ROCK Pi S0 legacy path landing page

### DIFF
--- a/docs/rockpi/rocks0.md
+++ b/docs/rockpi/rocks0.md
@@ -1,0 +1,25 @@
+---
+sidebar_position: 999
+sidebar_class_name: hidden
+doc_kind: page
+title: ROCK Pi S0
+description: ROCK Pi S0 文档入口的兼容页面，帮助旧链接跳转到当前文档路径。
+locale: zh
+product: rockpi
+board: rockpis0
+task_type: reference
+last_verified: 2026-03-15
+source_of_truth: local
+---
+
+# ROCK Pi S0
+
+你访问的是旧的 ROCK Pi S0 文档链接。
+
+当前正式文档路径已经统一为 `rockpis0`。请使用下面的页面继续查看：
+
+- [ROCK Pi S0 概览](/rockpi/rockpis0)
+- [快速上手](/rockpi/rockpis0/getting-started)
+- [资源下载汇总](/rockpi/rockpis0/getting-started/download)
+
+如果你是从其他网站或旧书签进入这里，建议将链接更新为 `/rockpi/rockpis0`，以避免后续再次访问到失效路径。

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rocks0.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rocks0.md
@@ -1,0 +1,25 @@
+---
+sidebar_position: 999
+sidebar_class_name: hidden
+doc_kind: page
+title: ROCK Pi S0
+description: Compatibility landing page for older ROCK Pi S0 documentation links.
+locale: en
+product: rockpi
+board: rockpis0
+task_type: reference
+last_verified: 2026-03-15
+source_of_truth: local
+---
+
+# ROCK Pi S0
+
+You are visiting an older ROCK Pi S0 documentation link.
+
+The canonical documentation path now uses `rockpis0`. Please continue from one of the pages below:
+
+- [ROCK Pi S0 overview](/rockpi/rockpis0)
+- [Getting started](/rockpi/rockpis0/getting-started)
+- [Resource download](/rockpi/rockpis0/getting-started/download)
+
+If you arrived here from another website or an old bookmark, please update the link to `/rockpi/rockpis0` to avoid hitting a dead path again later.


### PR DESCRIPTION
## Summary
- add a compatibility landing page for the legacy `/rockpi/rocks0` path in both Chinese and English
- point visitors to the canonical `/rockpi/rockpis0` overview, getting-started, and download pages
- prevent a support-confirmed dead link from looking like the product documentation disappeared

## Why
A real Support email in the last 24 hours reported that `https://docs.radxa.com/en/rockpi/rocks0` returned a 404 page, which made the customer think ROCK Pi S0 might be out of production or unsupported. The current canonical docs path is `/rockpi/rockpis0`, so this small docs-only compatibility page closes that gap without changing product content.

## Validation
- `scripts/agent-doc-lint.sh docs/rockpi/rocks0.md i18n/en/docusaurus-plugin-content-docs/current/rockpi/rocks0.md`
- `scripts/agent-doc-drift-guard.sh`
