### PR TITLE
docs(x2l): clarify power input support by BIOS version

### DIFF
--- a/docs/x/x2l/README.md
+++ b/docs/x/x2l/README.md
@@ -29,7 +29,7 @@ Radxa X2L 是瑞莎全新推出的基于 Intel J4125 的 X86 单板机。
 |  USB   | 2 个 USB 3.0 HOST 端口，2个 USB 2.0 HOST 端口                                                             |
 | 以太网 | 支持千兆以太网                                                                                            |
 |   IO   | 40 pin GPIO 扩展座                                                                                        |
-|  电源  | USB Type-C 12V / 2A                                                                                       |
+|  电源  | USB Type-C PD；BIOS `1.32` 及以上版本额外支持 12V DC 输入                                                  |
 |  按钮  | 1 个用户按钮， 1 个电源按钮， 1 个BOOTSEL 按钮（用于重置 RP2040），1 个Clear CMOS 按钮（用于重置 BIOS）   |
 |  尺寸  | 155mm x 80mm                                                                                              |
 

--- a/docs/x/x2l/getting-started/preparation.md
+++ b/docs/x/x2l/getting-started/preparation.md
@@ -8,10 +8,19 @@ sidebar_position: 1
 
 ### 电源
 
-支持 PD 协议的电源适配器
+默认支持 USB Type-C PD 电源适配器。
+
+如果 BIOS 版本低于 `1.32`，请使用支持 PD 协议的 USB Type-C 电源适配器；
+如果 BIOS 版本为 `1.32` 或更高版本，则同时支持以下两种供电方式：
+
+| BIOS 版本 | USB Type-C PD | 12V DC 输入 |
+| --- | --- | --- |
+| `< 1.32` | 支持 | 不支持 |
+| `>= 1.32` | 支持 | 支持 |
 
 :::tip
 瑞莎推荐使用 [Radxa Power PD30W](../accessories/power/pd_30w)。
+如果你计划使用 12V DC 输入，建议先参考 [BIOS 更新文档](../bios/update-bios) 确认当前版本。
 :::
 
 ### 显示器

--- a/i18n/en/docusaurus-plugin-content-docs/current/x/x2l/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/x/x2l/README.md
@@ -29,7 +29,7 @@ The Radxa X2L is a new X86 SBC launched by Radxa, featuring the Intel J4125 proc
 |    USB     | 2x USB3.0 Type A HOST ports, 2x USB2.0 Type A HOST ports                                                         |
 |  Ethernet  | 1x Gigabit Ethernet                                                                                              |
 |     IO     | 40-Pin GPIO Header                                                                                               |
-|   Power    | USB Type-C 12V/2A                                                                                                |
+|   Power    | USB Type-C PD; BIOS `1.32` and later also support 12V DC input                                                  |
 |   Button   | 1x Power Button, 1x BOOTSEL Button for RP2040, 1x User Button, 1x Clear CMOS Button                              |
 | Form Fator | 155mm x 80mm                                                                                                     |
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/x/x2l/getting-started/preparation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/x/x2l/getting-started/preparation.md
@@ -8,10 +8,19 @@ sidebar_position: 1
 
 ### Power Supply
 
-Power adapter supporting PD protocol
+The board supports USB Type-C PD power by default.
+
+If the BIOS version is lower than `1.32`, use a USB Type-C power adapter that supports PD.
+If the BIOS version is `1.32` or later, both of the following power-input methods are supported:
+
+| BIOS version | USB Type-C PD | 12V DC input |
+| --- | --- | --- |
+| `< 1.32` | Supported | Not supported |
+| `>= 1.32` | Supported | Supported |
 
 :::tip
 Radxa recommends using [Radxa Power PD30W](../accessories/power/pd_30w).
+If you plan to use 12V DC input, check the [BIOS update guide](../bios/update-bios) first to confirm the current version.
 :::
 
 ### Monitor


### PR DESCRIPTION
## Summary

Clarify which X2L power-input methods are supported before and after BIOS 1.32 so users do not assume 12V DC input works on older BIOS releases.

## Changes

- update the X2L overview page to describe PD as the default power method
- add a BIOS-version matrix to the preparation page for PD vs 12V DC input support
- add a BIOS update guide link for users who want to use 12V DC input
- sync the same clarification to the English docs

## Testing

- ./scripts/agent-doc-lint.sh docs/x/x2l/README.md docs/x/x2l/getting-started/preparation.md i18n/en/docusaurus-plugin-content-docs/current/x/x2l/README.md i18n/en/docusaurus-plugin-content-docs/current/x/x2l/getting-started/preparation.md
- ./scripts/agent-doc-translation-guard.sh
- ./scripts/agent-doc-drift-guard.sh --warn-only

Fixes #413