### PR TITLE
docs(rock5b): fix English quick-start power-supply link

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/getting-started/quick-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/getting-started/quick-start.md
@@ -30,7 +30,7 @@ description: "Getting started quickly with the ROCK 5B/5B+ makes it easy to star
 
 To boot up the ROCK 5B/5B+, you'll also need the following:
 
-- A charger(PD charge recommended), positive inside and ground outside.The ROCK 5B/5B+ also supports PoE power supply. For more details on power supply, please refer to [power-supply](../power-supply).
+- A charger(PD charge recommended), positive inside and ground outside.The ROCK 5B/5B+ also supports PoE power supply. For more details on power supply, please refer to [power-supply](./power-supply).
 - An HDMI cable and an HDMI-enabled monitor with a recommended resolution of 1080P or higher, a 4K / 8K monitor will provide the best experience.
 - A set of USB mouse and keyboard, common USB input devices support plug and play.
 - A network cable, you need to connect to the Internet to update your system.


### PR DESCRIPTION
## Summary
- fix the broken English quick-start link for the ROCK 5B/5B+ power-supply page
- align the English page with the already-correct Chinese link target
- keep the change docs-only and limited to the affected page

## Validation
- verified the old relative path `../power-supply` resolves to a missing file in the English docs tree
- verified the new relative path `./power-supply` resolves to the existing `getting-started/power-supply.md` page

Fixes #598
