### PR TITLE
fix(rock4c+): correct official images link

### DIFF
--- a/docs/rock4/rock4c+/getting-started/before-start.md
+++ b/docs/rock4/rock4c+/getting-started/before-start.md
@@ -84,6 +84,6 @@ ROCK 4C+ 支持 LCD 显示功能。
 
 ## 系统安装
 
-首先，请从 [ROCK 4 官方镜像下载页](../../official-images)下载 ROCK 4C+ 的官方镜像。  
+首先，请从 [ROCK 4 官方镜像下载页](../../../official-images)下载 ROCK 4C+ 的官方镜像。  
 然后，参照[操作系统安装指南](install-os)安装操作系统。  
 最后，将系统存储介质：microSD 卡或 eMMC 模块插入主板上的插口，并通过 Type-C 供电启动 ROCK 4C+。

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/getting-started/before-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/getting-started/before-start.md
@@ -82,6 +82,6 @@ Audio can be played through speaker or headphones using a standard 3.5mm jack.
 
 ## OS Installation
 
-First, please download the official images of ROCK 4C Plus on the [ROCK 4 Official Images Download](../../official-images).  
+First, please download the official images of ROCK 4C Plus on the [ROCK 4 Official Images Download](../../../official-images).  
 Then, you can install the OS by referring the [OS Installation Guide](install-os).  
 Finally, insert the system storage media, microSD Card or eMMC Module into the socket on the board and power on ROCK 4C Plus by adapter with Type-C port.


### PR DESCRIPTION
## Summary
- fix the ROCK 4C+ getting-started link to the ROCK 4 series official images page
- update both Chinese and English pages so the relative path resolves to `/rock4/official-images`

## Validation
- ran `./scripts/agent-doc-lint.sh` on both changed files
- verified the target docs files exist:
  - `docs/rock4/official-images.md`
  - `i18n/en/docusaurus-plugin-content-docs/current/rock4/official-images.md`

Fixes #983
