### PR TITLE
docs(rock4c+): restore English landing page card lists

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/README.md
@@ -6,4 +6,4 @@ sidebar_position: 10
 
 A highly scalable SBC powered by RK3399-T.
 
-<!-- <DocCardList /> -->
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/getting-started/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/getting-started/README.md
@@ -6,4 +6,4 @@ sidebar_position: 10
 
 Start with your ROCK 4C+ from here.
 
-<!-- <DocCardList /> -->
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/hardware/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/hardware/README.md
@@ -6,4 +6,4 @@ sidebar_position: 50
 
 Hardware Information about ROCK 4C+
 
-<!-- <DocCardList /> -->
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/low-level-dev/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4c+/low-level-dev/README.md
@@ -6,4 +6,4 @@ sidebar_position: 40
 
 Mainly introduces uboot, kernel, debian os compilation and packaging and so on.
 
-<!-- <DocCardList /> -->
+<DocCardList />


### PR DESCRIPTION
## Summary

Restore the English `DocCardList` blocks on the ROCK 4C+ landing pages so the overview and section pages show their child navigation cards again.

## Changes

- re-enable `DocCardList` on the English ROCK 4C+ top-level page
- re-enable `DocCardList` on the English getting-started landing page
- re-enable `DocCardList` on the English hardware landing page
- re-enable `DocCardList` on the English low-level development landing page

## Testing

- ran `./scripts/agent-doc-lint.sh` on the 4 updated markdown files
- verified the English pages now match the corresponding Chinese landing-page structure

Fixes #836
Fixes #1250