### PR TITLE
docs(cubie): clarify A7Z GPIO overlay examples

### DIFF
--- a/docs/cubie/a7z/hardware-use/pin-gpio.md
+++ b/docs/cubie/a7z/hardware-use/pin-gpio.md
@@ -68,6 +68,19 @@ GPIOCHIP0 -> 7 + 32 \* (A ~ K) -> 7 + 32 \* 1 -> 39
 
 通过板载的 40-Pin GPIO 接口，演示常见的 GPIO 使用方法。
 
+## Overlay 说明
+
+A7Z 的同一种外设功能通常可以复用到多个不同引脚上，因此 `rsetup` 的 `Overlay` -> `Manage overlays` 页面主要提供的是常见用法示例，而不是把所有可选 pinmux 组合全部列出来。
+
+如果你需要把 PWM、UART、I2C、SPI 等功能切换到表中列出的其他引脚，建议按下面的顺序处理：
+
+1. 先根据上面的 GPIO 复用表确认目标功能和目标引脚
+2. 先尝试 `rsetup` 里现成的 overlay 示例
+3. 如果现成选项不覆盖你的目标引脚，可以参考 [radxa-overlays](https://github.com/radxa-pkg/radxa-overlays) 的写法修改 overlay
+4. 修改完成后，可通过 `rsetup` 的 `Overlay` -> `Install 3rd party overlay` 安装自定义 DTS / DTBO
+
+这样可以避免把每一种 pinmux 组合都做成单独的内置选项，同时也方便你按项目需要扩展到其他引脚。
+
 ## 安装 python-periphery
 
 使用 `python-periphery` 库来控制 GPIO 引脚。

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/hardware-use/pin-gpio.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/hardware-use/pin-gpio.md
@@ -68,6 +68,19 @@ GPIOCHIP0 -> 7 + 32 \* (A ~ K) -> 7 + 32 \* 1 -> 39
 
 Through the 40-Pin GPIO interface, demonstrate common GPIO usage.
 
+## Overlay Notes
+
+On Cubie A7Z, the same peripheral function can usually be routed to multiple pins, so the `rsetup` `Overlay` -> `Manage overlays` page only exposes a few common example overlays instead of every possible pinmux combination.
+
+If you need to move PWM, UART, I2C, SPI, or other functions to different pins listed in the table above, use this workflow:
+
+1. Use the GPIO multiplexing table above to confirm the target function and target pin
+2. Try the built-in overlay examples in `rsetup` first
+3. If the built-in options do not cover your target pin, adapt an overlay by following the examples in [radxa-overlays](https://github.com/radxa-pkg/radxa-overlays)
+4. After editing, install your custom DTS / DTBO from `rsetup` -> `Overlay` -> `Install 3rd party overlay`
+
+This keeps `rsetup` practical for common cases while still letting you extend the pinmux to other pins when your project needs it.
+
 ## Install python-periphery
 
 Use the `python-periphery` library to control GPIO pins.


### PR DESCRIPTION
## Summary
- add a small overlay note to the Cubie A7Z 40-pin GPIO page
- explain that `rsetup` only exposes common overlay examples instead of every possible pinmux combination
- point users to the GPIO multiplexing table, `Install 3rd party overlay`, and the `radxa-overlays` examples when they need other pins
- keep the English page in sync with the Chinese source

## Why
Issue #1214 shows that readers can misread the current GPIO page as if the few built-in `rsetup` overlay entries are the only supported routing options. A small docs-only clarification is enough here: the board exposes more pinmux choices, while `rsetup` ships a practical subset of examples.

## Validation
- `./scripts/agent-doc-lint.sh docs/cubie/a7z/hardware-use/pin-gpio.md i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/hardware-use/pin-gpio.md`
- `./scripts/agent-doc-translation-guard.sh`
- `git diff --check`

Fixes #1214
