### PR TITLE
docs(o6): clarify EC UART baud-rate exception

### DIFF
--- a/docs/common/general/_serial.mdx
+++ b/docs/common/general/_serial.mdx
@@ -23,7 +23,7 @@ import { Section, Image } from "@site/src/utils/docs";
 
 <Section compatible="o6" model={props.model}>
 瑞莎星睿 O6 上用于系统/EDK2 管理控制台的 UART2(AP) 默认也是 115200n8。
-如果使用的是 1.0.0-1 或更早版本的 BIOS，并连接的是 EC UART，则需要使用 460800 波特率。
+如果使用的是 1.0.0-1 或更早版本的 BIOS，并连接的是 EC UART，则需要使用 460800 波特率，并且需要添加 LF 转 CRLF 映射（使用 picocom 时添加 `--imap lfcrlf` 参数）。
 </Section>
 
 </Section>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/general/_serial.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/general/_serial.mdx
@@ -23,7 +23,7 @@ For Radxa products based on CIX chips, the default UART configuration is 115200n
 
 <Section compatible="o6" model={props.model}>
 On Radxa Orion O6, UART2 (AP), which is used as the system/EDK2 management console, also defaults to 115200n8.
-If you are using BIOS version 1.0.0-1 or earlier and connecting to the EC UART instead, use 460800 baud.
+If you are using BIOS version 1.0.0-1 or earlier and connecting to the EC UART instead, use 460800 baud and add LF to CRLF mapping (add `--imap lfcrlf` parameter when using picocom).
 </Section>
 
 </Section>


### PR DESCRIPTION
## Summary

Clarify the Orion O6 serial-console baud-rate exception in the shared serial guide so the generic CIX guidance no longer conflicts with the older EC UART behavior.

## Changes

- add a CIX UART defaults block to the shared serial guide in both Chinese and English
- note that Orion O6 UART2/AP remains 115200n8 for the system/EDK2 management console
- document that BIOS 1.0.0-1 or earlier requires 460800 when connecting to the EC UART

## Testing

- ran `./scripts/agent-doc-lint.sh docs/common/general/_serial.mdx i18n/en/docusaurus-plugin-content-docs/current/common/general/_serial.mdx`
- ran `./scripts/agent-doc-translation-guard.sh`

Fixes #875