### PR TITLE
feat: earse / flash with rsetup

### DIFF
--- a/docs/common/radxa-os/system-config/_enable-spi-flash.mdx
+++ b/docs/common/radxa-os/system-config/_enable-spi-flash.mdx
@@ -1,0 +1,66 @@
+:::note 说明
+教程仅适用于瑞莎系统（Radxa OS）使用
+:::
+
+使用 `Rsetup` 工具使能 SPI Flash。
+
+## 使能 SPI Flash
+
+由于 eMMC 和 SPI Flash 互斥，系统默认可开启 eMMC，关闭 SPI Flash；若需要开启 SPI Flash，可以参考下面步骤。
+
+:::tip Rsetup 使用指南
+
+- 选中选项 ： 对应选项会高亮显示
+- 确认选择 ： 按 `Enter`
+- 取消选择 ： 按 `ESC`
+- 切换选项 ： 按 `Up` 、 `Down` 、 `Left` 、 `Right` 控制
+- 多选界面 ： 按 `Space` 选择，按 `Enter` 确认选择；选择对应功能后，对应选项框会出现一个 `*` ,表示该选项已启用
+  :::
+
+1. 打开终端，输入 `sudo rsetup` 命令打开 `Rsetup` 工具
+
+<NewCodeBlock tip={`radxa@${props?.board ?? 'device'}$`} type="device">
+
+```bash
+sudo rsetup
+```
+
+</NewCodeBlock>
+
+<div style={{ textAlign: "center" }}>
+  <img
+    src="/img/common/radxa-os/system-config/rsetup-system.webp"
+    style={{ width: "100%", maxWidth: "1200px" }}
+  />
+</div>
+
+2. 进入 `Overlays` -> `Manage overlays` 选项后，按 `Enter` 确认选择。
+
+<div style={{ textAlign: "center" }}>
+  <img
+    src="/img/common/radxa-os/system-config/rsetup-overlays-manage.webp"
+    style={{ width: "100%", maxWidth: "1200px" }}
+  />
+</div>
+
+3. 按空格选中 `Enable SPI Flash` 选项后，按 `Enter` 确认选择。
+
+4. 使能完成后，重启系统。
+
+<NewCodeBlock tip={`radxa@${props?.board ?? 'device'}$`} type="device">
+
+```bash
+sudo reboot
+```
+
+</NewCodeBlock>
+
+## 验证 SPI Flash
+
+重启系统后，可以使用以下命令验证 SPI Flash 是否成功使能：
+
+```bash
+lsblk
+```
+
+如果看到 `mtdblock0` 设备，说明 SPI Flash 已成功使能。

--- a/docs/e/e24c/getting-started/install-os/nvme-system/spi-flash-rsetup.md
+++ b/docs/e/e24c/getting-started/install-os/nvme-system/spi-flash-rsetup.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/system-config/_spi-flash-erase-rsetup.mdx
+  - docs/common/radxa-os/system-config/_enable-spi-flash.mdx
+---
+
+import EnableSPIFlash from '../../../../../common/radxa-os/system-config/\_enable-spi-flash.mdx';
+import SPIFlashEraseRsetup from '../../../../../common/radxa-os/system-config/\_spi-flash-erase-rsetup.mdx';
+
+# 使用 Rsetup 擦除 / 烧录 SPI Flash
+
+:::tip Maskrom 模式
+
+主板进入 Maskrom 模式可以参考 [Maskrom 模式](../../../hardware-usage/maskrom.md) 教程。
+
+:::
+
+<EnableSPIFlash />
+
+## 擦除 / 烧录 SPI Flash
+
+<SPIFlashEraseRsetup board="e24c" download_page="../../../download" />

--- a/docs/e/e24c/getting-started/install-os/nvme-system/spi-flash.md
+++ b/docs/e/e24c/getting-started/install-os/nvme-system/spi-flash.md
@@ -9,7 +9,7 @@ imports_resolve_to:
 
 import SPIFlash from '../../../../../common/radxa-os/rkdevtool/\_spi.mdx';
 
-# 擦除 / 烧录 SPI Flash
+# 使用 rkdeveloptool 擦除 / 烧录 SPI Flash
 
 :::tip Maskrom 模式
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_enable-spi-flash.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_enable-spi-flash.mdx
@@ -1,0 +1,66 @@
+:::note Note
+This guide only applies to Radxa OS.
+:::
+
+Use the `Rsetup` tool to enable SPI Flash.
+
+## Enable SPI Flash
+
+Because eMMC and SPI Flash are mutually exclusive, the system enables eMMC and disables SPI Flash by default. If you need to enable SPI Flash, follow the steps below.
+
+:::tip Rsetup Usage Guide
+
+- Select option: The corresponding option will be highlighted
+- Confirm selection: Press `Enter`
+- Cancel selection: Press `ESC`
+- Navigate options: Use `Up`, `Down`, `Left`, and `Right`
+- Multiple selection interface: Press `Space` to select, then `Enter` to confirm; a `*` next to the option indicates that it is enabled
+  :::
+
+1. Open a terminal and run `sudo rsetup` to launch the `Rsetup` tool.
+
+<NewCodeBlock tip={`radxa@${props?.board ?? 'device'}$`} type="device">
+
+```bash
+sudo rsetup
+```
+
+</NewCodeBlock>
+
+<div style={{ textAlign: "center" }}>
+  <img
+    src="/en/img/common/radxa-os/system-config/rsetup-system.webp"
+    style={{ width: "100%", maxWidth: "1200px" }}
+  />
+</div>
+
+2. Go to `Overlays` -> `Manage overlays`, then press `Enter` to confirm.
+
+<div style={{ textAlign: "center" }}>
+  <img
+    src="/en/img/common/radxa-os/system-config/rsetup-overlays-manage.webp"
+    style={{ width: "100%", maxWidth: "1200px" }}
+  />
+</div>
+
+3. Press the spacebar to select `Enable SPI Flash`, then press `Enter` to confirm.
+
+4. Reboot the system after SPI Flash is enabled.
+
+<NewCodeBlock tip={`radxa@${props?.board ?? 'device'}$`} type="device">
+
+```bash
+sudo reboot
+```
+
+</NewCodeBlock>
+
+## Verify SPI Flash
+
+After the system reboots, run the following command to verify whether SPI Flash has been enabled successfully:
+
+```bash
+lsblk
+```
+
+If you see the `mtdblock0` device, SPI Flash has been enabled successfully.

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e24c/getting-started/install-os/nvme-system/spi-flash-rsetup.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e24c/getting-started/install-os/nvme-system/spi-flash-rsetup.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_spi-flash-erase-rsetup.mdx
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_enable-spi-flash.mdx
+---
+
+import EnableSPIFlash from '../../../../../common/radxa-os/system-config/\_enable-spi-flash.mdx';
+import SPIFlashEraseRsetup from '../../../../../common/radxa-os/system-config/\_spi-flash-erase-rsetup.mdx';
+
+# Erase / Flash SPI Flash with Rsetup
+
+:::tip Maskrom mode
+
+To put the board into Maskrom mode, please refer to the [Maskrom Mode](../../../hardware-usage/maskrom.md) guide.
+
+:::
+
+<EnableSPIFlash />
+
+## Erase / Flash SPI Flash
+
+<SPIFlashEraseRsetup board="e24c" download_page="../../../download" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e24c/getting-started/install-os/nvme-system/spi-flash.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e24c/getting-started/install-os/nvme-system/spi-flash.md
@@ -9,7 +9,7 @@ imports_resolve_to:
 
 import SPIFlash from '../../../../../common/radxa-os/rkdevtool/\_spi.mdx';
 
-# Erase / Flash SPI Flash
+# Erase / Flash SPI Flash with rkdeveloptool
 
 :::tip Maskrom mode
 


### PR DESCRIPTION
## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
