### PR TITLE
docs: clarify outdated ROCK 5B+ schematic block diagram note

### DIFF
--- a/docs/rock5/rock5b/download.md
+++ b/docs/rock5/rock5b/download.md
@@ -201,6 +201,10 @@ L2203 L2205 L2300 L2301 L2303 改成 3225 封装的 RHP322512T-R24M
 
 ### V1.2
 
+:::note
+`v1.2 原理图 pdf` 中的 Block Diagram 仍包含旧版接口标注，不完全代表当前 ROCK 5B+ 的实际 PCIe 布局。ROCK 5B+ 实际为 **2 个 PCIe M Key + 1 个 PCIe B Key**，**没有 PCIe E Key**。当前接口说明请以 [硬件接口](./hardware-design/hardware-interface) 页面为准。
+:::
+
 - [v1.2 原理图 pdf](https://dl.radxa.com/rock5/5b+/docs/hw/radxa_rock5bp_v1.2_schematic.pdf)
 - [v1.2 位号图 pdf](https://dl.radxa.com/rock5/5b+/docs/hw/radxa_rock5bp_v1.2_components_placement_map.pdf)
 - [v1.2 2D DXF](https://dl.radxa.com/rock5/5b+/docs/hw/radxa_rock5bp_v12_2d.zip)

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/download.md
@@ -200,6 +200,10 @@ Pins 1-31 widened to 0.3mm, two locator pins widened to 0.7mm
 
 <TabItem value="ROCK 5B+">
 
+:::note
+The block diagram inside the `v1.2 Schematic pdf` still shows an older interface annotation and does not fully reflect the current ROCK 5B+ PCIe layout. The actual ROCK 5B+ provides **2 PCIe M Key slots and 1 PCIe B Key slot**, and **does not provide a PCIe E Key slot**. For the current interface summary, refer to the [Hardware Interface](./hardware-design/hardware-interface) page.
+:::
+
 - [v1.2 Schematic pdf](https://dl.radxa.com/rock5/5b+/docs/hw/radxa_rock5bp_v1.2_schematic.pdf)
 - [v1.2 Components Placement Map pdf](https://dl.radxa.com/rock5/5b+/docs/hw/radxa_rock5bp_v1.2_components_placement_map.pdf)
 - [v1.2 2D DXF](https://dl.radxa.com/rock5/5b+/docs/hw/radxa_rock5bp_v12_2d.zip)


### PR DESCRIPTION
## Summary
- add a note on the ROCK 5B+ hardware-design download section
- clarify that the linked v1.2 schematic PDF block diagram uses an older interface annotation
- point readers to the current hardware interface page, which reflects the actual ROCK 5B+ PCIe layout

## Why
Issue #1005 reports that the ROCK 5B+ schematic PDF block diagram does not match the current board interface summary. We cannot patch the PDF itself from the docs repo, but we can prevent confusion on the download page by calling out the mismatch and linking to the up-to-date interface reference.

Fixes #1005

## Validation
- ./scripts/agent-doc-lint.sh docs/rock5/rock5b/download.md i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/download.md
- ./scripts/agent-doc-translation-guard.sh