### PR TITLE
docs: clarify Penta SATA HAT kit variants

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/README.md
+++ b/docs/accessories/storage/penta-sata-hat/README.md
@@ -59,6 +59,20 @@ sidebar_position: 1
 
   ![Radxa Penta SATA HAT](/img/accessories/storage/penta-sata-hat-04.webp)
 
+## 组件说明与排查建议
+
+Penta SATA HAT 系列通常由以下部分组成：
+
+- **Base board（主板）**：负责 SATA 存储连接
+- **Top board（顶板，可选）**：提供 OLED 显示屏和风扇，详情见 [Penta SATA HAT TOP 板](./sata-hat-top-board.md)
+- **完整套件（full kit）**：Base board + Top board + 对应配件
+
+如果您在安装或启动时遇到问题，建议先确认当前使用的是哪一种组合，再继续排查：
+
+1. 仅连接 base board 时，先确认系统镜像、内核版本，以及 SATA 设备是否能被识别
+2. 只有在安装了 top board 时，才需要 `rockpi-penta` 软件包来驱动 OLED 和风扇
+3. 如果接入 IPEX 线缆后系统异常，建议同时记录具体板型、使用的是 base board 还是 full kit，以及串口/内核日志
+
 ## 40 针引脚定义
 
 | 描述          | 功能    | 引脚# | 引脚# | 功能 | 描述       |

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/README.md
@@ -59,6 +59,20 @@ If you use large capacity 3.5-inch mechanical hard drives on the Penta SATA HAT,
 
   ![Radxa M.2 Extension Board](/img/accessories/storage/penta-sata-hat-04.webp)
 
+## Components and troubleshooting scope
+
+The Penta SATA HAT family is commonly used in the following combinations:
+
+- **Base board**: the storage board used for SATA connectivity
+- **Top board (optional)**: adds the OLED display and fan; see [Penta SATA HAT top board](./sata-hat-top-board.md)
+- **Full kit**: base board + top board + the matching accessories
+
+If you run into installation or boot problems, identify which combination you are using before troubleshooting further:
+
+1. With only the base board connected, first confirm the system image, kernel version, and whether the SATA devices are detected
+2. Install the `rockpi-penta` package only when the top board is present, because it is used for the OLED and fan features
+3. If the system becomes unstable after connecting the IPEX cable, record the board model, whether you are using the base board or the full kit, and any serial or kernel logs
+
 ## 40Pin Pinout
 
 | Description   | Function | Pin# | Pin# | Function | Description |


### PR DESCRIPTION
## Summary
- add a short scope note to the Penta SATA HAT overview page explaining the base board, optional top board, and full-kit combinations
- note that the 'rockpi-penta' package is only needed when the top board is installed
- add a troubleshooting reminder to record the board model, kit combination, and logs when an IPEX-related boot problem is reported

## Why
A confirmed support case today involved a ROCK Pi 4B user reporting that the board hangs after the IPEX cable is connected. During support triage, we had to stop and clarify whether the customer was using only the base board, the optional top board, or the full kit, because the current overview page does not explain that distinction up front.

This is a small docs-only clarification aimed at making first-pass support and self-troubleshooting more accurate before users apply top-board-specific software steps.

## Validation
- agent-doc-lint passed.
- agent-doc-translation-guard passed.