### PR TITLE
docs: fix ZERO 3 U-Boot bsp profile

### DIFF
--- a/docs/common/dev/_u-boot.mdx
+++ b/docs/common/dev/_u-boot.mdx
@@ -58,7 +58,7 @@ cd bsp
 |    rock-5a     | rk2410  |     radxa-cm5-io      | rk2410  | radxa-cm3-rpi-cm4-io | latest  | rock-pi-4b-plus | latest  |
 |    rock-5b     | rk2410  | radxa-cm5-rpi-cm4-io  | rk2410  | radxa-cm3-sodimm-io  | latest  |  rock-4c-plus   | latest  |
 |  rock-5b-plus  | rk2410  | radxa-cm3j-rpi-cm4-io | rk2410  |      radxa-e23       | latest  |   rock-pi-4a    | latest  |
-|    rock-5c     | rk2410  |       radxa-e25       | rknext  |     radxa-zero3      | latest  |   rock-pi-4b    | latest  |
+|    rock-5c     | rk2410  |       radxa-e25       | rknext  |     radxa-zero3      | rk2410  |   rock-pi-4b    | latest  |
 |    rock-5d     | rk2410  |     radxa-cm3i-io     | rknext  |       rock-3a        | latest  |   rock-pi-4c    | latest  |
 |    rock-5t     | rk2410  |                       |         |       rock-3b        | latest  | rock-4-core-io  | latest  |
 |  rock-5a-spi   | rk2410  |                       |         |       rock-3c        | latest  |                 |         |

--- a/docs/zero/zero3/low-level-dev/u-boot.md
+++ b/docs/zero/zero3/low-level-dev/u-boot.md
@@ -9,4 +9,4 @@ import UBOOT from "../../../common/dev/\_u-boot.mdx"
 
 # U-boot 开发
 
-<UBOOT model="Radxa ZERO 3" profile="latest" product="radxa-zero3"/>
+<UBOOT model="Radxa ZERO 3" profile="rk2410" product="radxa-zero3"/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_u-boot.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_u-boot.mdx
@@ -62,7 +62,7 @@ Taking Radxa ROCK 5B as an example, the U-Boot profile is "rk2410". The followin
 |    rock-5a     | rk2410  |     radxa-cm5-io      | rk2410  | radxa-cm3-rpi-cm4-io | latest  | rock-pi-4b-plus | latest  |
 |    rock-5b     | rk2410  | radxa-cm5-rpi-cm4-io  | rk2410  | radxa-cm3-sodimm-io  | latest  |  rock-4c-plus   | latest  |
 |  rock-5b-plus  | rk2410  | radxa-cm3j-rpi-cm4-io | rk2410  |      radxa-e23       | latest  |   rock-pi-4a    | latest  |
-|    rock-5c     | rk2410  |       radxa-e25       | rknext  |     radxa-zero3      | latest  |   rock-pi-4b    | latest  |
+|    rock-5c     | rk2410  |       radxa-e25       | rknext  |     radxa-zero3      | rk2410  |   rock-pi-4b    | latest  |
 |    rock-5d     | rk2410  |     radxa-cm3i-io     | rknext  |       rock-3a        | latest  |   rock-pi-4c    | latest  |
 |    rock-5t     | rk2410  |                       |         |       rock-3b        | latest  | rock-4-core-io  | latest  |
 |  rock-5a-spi   | rk2410  |                       |         |       rock-3c        | latest  |                 |         |

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/low-level-dev/u-boot.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/low-level-dev/u-boot.md
@@ -9,4 +9,4 @@ import UBOOT from "../../../common/dev/\_u-boot.mdx"
 
 # U-boot Develop
 
-<UBOOT model="Radxa ZERO 3" profile="latest" product="radxa-zero3"/>
+<UBOOT model="Radxa ZERO 3" profile="rk2410" product="radxa-zero3"/>


### PR DESCRIPTION
## Summary
- correct the ZERO 3 U-Boot profile from `latest` to `rk2410`
- keep the shared U-Boot product/profile table in sync with the current `radxa-repo/bsp` config
- update both Chinese and English docs for the ZERO 3 U-Boot page

## Testing
- `bash scripts/agent-doc-lint.sh docs/zero/zero3/low-level-dev/u-boot.md i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/low-level-dev/u-boot.md docs/common/dev/_u-boot.mdx i18n/en/docusaurus-plugin-content-docs/current/common/dev/_u-boot.mdx`

Fixes #756