### PR TITLE
docs: clarify build environment setup expectations

### DIFF
--- a/docs/common/radxa-os/build-system/_install_env.mdx
+++ b/docs/common/radxa-os/build-system/_install_env.mdx
@@ -12,35 +12,6 @@
 
 我们需要在 PC 上安装 Visual Studio Code、Dev Container 拓展插件和 Docker，方便快速构建 {props?.items ?? 'U-Boot、Kernel and Radxa OS'} 的编译和开发环境。
 
-:::tip 环境搭建完成的判断标准
-
-满足以下条件时，可以认为本机已经具备后续编译环境的基础条件：
-
-- 终端执行 `docker --version` 能正常输出版本信息。
-- 重新登录系统后，执行 `docker ps` 不再提示权限错误。
-- Visual Studio Code 可以正常启动，并能在拓展市场中搜索到 `Dev Containers` 拓展。
-- 后续打开源码目录时，Visual Studio Code 能识别 `.devcontainer` 配置并提示 `Reopen in Container`。
-
-:::
-
-:::info 下载体量与耗时说明
-
-- `get-docker.sh` 安装脚本本身体积很小，但安装 Docker 依赖时通常还需要额外下载数百 MB 的软件包。
-- Visual Studio Code 的 Ubuntu `deb` 安装包通常约为 `100 ~ 150 MB`，Docker Desktop 安装包通常约为 `400 ~ 700 MB`，实际大小会随版本变化。
-- 首次使用 Dev Container 时，还会额外拉取容器基础镜像和依赖，通常需要再预留 `1 ~ 3 GB` 的下载空间。
-- 在 `100 Mbps` 左右的稳定网络下，完成基础软件下载和首次容器依赖拉取通常需要 `10 ~ 30 分钟`；若网络较慢或需重复重试，时间会更长。
-
-:::
-
-:::caution 常见网络问题
-
-- 如果无法访问 `get.docker.com`、Docker Hub 或 Visual Studio Code 拓展市场，请优先检查网络连通性、代理设置或镜像源配置。
-- 中国大陆网络环境下，首次拉取 Docker 相关资源可能较慢，必要时请配置 Docker 镜像源或使用代理。
-- 如果安装过程因网络中断失败，建议先重新执行 `sudo apt update`，再重新下载或重新运行安装命令。
-- 若使用 `deb` 安装包，下载异常时建议删除未下载完整的文件后重新下载，避免安装残缺包。
-
-:::
-
 ### Docker
 
 可以根据自己使用需求选择 Docker 引擎或 Docker 桌面版本进行安装。
@@ -211,3 +182,31 @@ sudo apt-get install ./code_xxx_amd64.deb
     style={{ width: "100%", maxWidth: "1200px" }}
   />
 </div>
+
+## 环境搭建完成标准
+
+完成以上步骤后，可以用下面几项快速确认环境是否已经准备好：
+
+- 运行 `docker --version` 能正常输出 Docker 版本信息。
+- 重新登录或重启后，普通用户执行 `docker ps` 不需要再额外加 `sudo`。
+- Visual Studio Code 已安装 `Dev Containers` 拓展。
+- 后续打开带有 `.devcontainer` 配置的源码目录时，Visual Studio Code 能识别并提示 `Reopen in Container`。
+
+如果以上几项都满足，说明本机已经具备后续构建 {props?.items ?? 'U-Boot、Kernel and Radxa OS'} 的基础环境。
+
+## 首次下载与磁盘空间说明
+
+- 首次使用 Dev Container 时，Visual Studio Code 会自动拉取容器镜像并安装依赖。
+- 这个过程通常会下载数 GB 级别的数据，并额外占用数 GB 磁盘空间。
+- 具体下载时长与镜像大小会随着基础镜像、依赖版本和网络环境变化而变化；在网络正常时，首次初始化通常需要等待一段时间，请预留充足时间和磁盘空间。
+
+## 常见网络问题
+
+如果安装 Docker、下载 VS Code，或者首次启动 Dev Container 时速度过慢、下载失败、连接超时，可以按下面顺序检查：
+
+1. 先确认主机网络连接正常，并能访问 `https://get.docker.com` 和 `https://code.visualstudio.com/`。
+2. 如果当前网络对 Docker Hub 或相关下载源有限制，请按你所在网络环境配置可用的代理或镜像加速。
+3. 如果 Docker 已安装但容器镜像拉取失败，先执行 `docker pull hello-world` 验证 Docker 基础下载链路是否正常。
+4. 若使用公司网络、校园网或受限网络，建议优先切换到更稳定的网络后再重新执行初始化，避免 Dev Container 首次拉取过程中断。
+
+如果仍然失败，建议先记录报错信息，再继续排查 Docker 网络、代理或 DNS 配置问题。

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_install_env.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_install_env.mdx
@@ -12,35 +12,6 @@ This guide covers setting up the development environment for {props?.items ?? 'U
 
 To quickly set up a compilation and development environment for {props?.items ?? 'U-Boot, Kernel, Radxa OS'}, we need to install Visual Studio Code, the Dev Container extension, and Docker on your PC.
 
-:::tip How to confirm the environment setup is complete
-
-You can consider the host ready for the next build steps when all of the following are true:
-
-- Running `docker --version` prints a valid Docker version.
-- After signing in again, `docker ps` works without a permission error.
-- Visual Studio Code launches normally and the `Dev Containers` extension can be found in the Extensions marketplace.
-- When you later open the source tree, Visual Studio Code detects the `.devcontainer` configuration and offers `Reopen in Container`.
-
-:::
-
-:::info Expected download size and time
-
-- The `get-docker.sh` script itself is very small, but installing Docker usually downloads several hundred MB of additional packages.
-- The Ubuntu `deb` package for Visual Studio Code is usually around `100 ~ 150 MB`, while Docker Desktop is usually around `400 ~ 700 MB`. The actual size depends on the version.
-- The first Dev Container startup will also pull base container images and dependencies, so it is recommended to reserve another `1 ~ 3 GB` of download capacity.
-- On a stable `100 Mbps` network, downloading the required software and completing the first container dependency pull usually takes around `10 ~ 30 minutes`. Slower or unstable networks may take longer.
-
-:::
-
-:::caution Common network issues
-
-- If `get.docker.com`, Docker Hub, or the Visual Studio Code extension marketplace cannot be reached, first check network connectivity, proxy settings, or mirror configuration.
-- In Mainland China, the first Docker-related download may be slow. Configure a Docker mirror or use a proxy if needed.
-- If installation fails because of an interrupted network connection, run `sudo apt update` again before retrying the download or installation command.
-- If you are installing from a `deb` package, delete any partially downloaded file before downloading it again to avoid installing a corrupted package.
-
-:::
-
 ### Docker
 
 You can choose to install either Docker Engine or Docker Desktop based on your needs.
@@ -207,3 +178,31 @@ Open Visual Studio Code and install the Dev Container extension.
     style={{ width: "100%", maxWidth: "1200px" }}
   />
 </div>
+
+## How to confirm the environment is ready
+
+After completing the steps above, you can quickly verify the environment with the checklist below:
+
+- `docker --version` prints the Docker version successfully.
+- After re-login or reboot, a normal user can run `docker ps` without `sudo`.
+- Visual Studio Code has the `Dev Containers` extension installed.
+- When you later open a source tree that contains a `.devcontainer` configuration, Visual Studio Code can detect it and offer `Reopen in Container`.
+
+If all of the above are true, the host is ready for subsequent {props?.items ?? 'U-Boot, Kernel and Radxa OS'} build work.
+
+## First download and disk space notes
+
+- The first time you use Dev Container, Visual Studio Code will automatically pull the container image and install dependencies.
+- This usually downloads several GB of data and also consumes several GB of disk space.
+- The exact image size and download time vary with the base image, dependency versions, and your network environment. Under a normal network, the first initialization can still take a while, so reserve enough time and disk space in advance.
+
+## Common network issues
+
+If Docker installation, VS Code download, or the first Dev Container startup is very slow, times out, or fails to download, check the following in order:
+
+1. Confirm that the host network is working and can access `https://get.docker.com` and `https://code.visualstudio.com/`.
+2. If your network restricts Docker Hub or related download endpoints, configure a working proxy or registry mirror according to your environment.
+3. If Docker is already installed but image pulling fails, run `docker pull hello-world` first to verify the basic Docker download path.
+4. If you are on a company network, campus network, or another restricted network, switch to a more stable network before retrying the initial setup to avoid interruption during the first Dev Container pull.
+
+If it still fails, record the exact error message first, then continue troubleshooting Docker networking, proxy, or DNS configuration.


### PR DESCRIPTION
## Summary\n\nClarify the build environment setup page so readers can better judge whether the host is actually ready before moving on.\n\n## Changes\n\n- add a short completion checklist for Docker and Dev Containers readiness\n- add a note that first-time Dev Container initialization requires extra download time and disk space\n- add basic network troubleshooting guidance for slow or failed setup downloads\n- sync the same clarification in the English translation\n\n## Testing\n\n- ./scripts/agent-doc-lint.sh docs/common/radxa-os/build-system/_install_env.mdx i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_install_env.mdx\n\nFixes #1121