### PR TITLE
docs: add ROCK Pi S hardware document link to download page

### DIFF
--- a/docs/rockpi/rockpis/download.md
+++ b/docs/rockpi/rockpis/download.md
@@ -34,3 +34,7 @@ Armbian 的默认凭据如下：
 :::caution
 非瑞莎官方维护的镜像，瑞莎不能保证完整功能，如遇到问题，请到对应的社区寻求帮助。
 :::
+
+## 硬件设计
+
+- [ROCK Pi S 硬件设计资料](https://dl.radxa.com/rockpis/docs/hw/)

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/download.md
@@ -35,3 +35,7 @@ Default Armbian credentials:
 :::caution
 For images that are not officially maintained by Radxa, Radxa cannot guarantee full functionality. If you encounter problems, please seek help from the corresponding community.
 :::
+
+## Hardware Design
+
+- [ROCK Pi S hardware design files](https://dl.radxa.com/rockpis/docs/hw/)


### PR DESCRIPTION
## Summary
- add a hardware document entry to the ROCK Pi S download page
- add the same entry to the English translation page
- keep the change limited to discoverability of existing hardware docs

Fixes #782

## Testing
- scripts/agent-doc-lint.sh docs/rockpi/rockpis/download.md i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis/download.md