### PR TITLE
docs: clarify ROCK 5B fan connector spec

### DIFF
--- a/docs/rock5/rock5b/getting-started/interface-usage/fan.md
+++ b/docs/rock5/rock5b/getting-started/interface-usage/fan.md
@@ -11,6 +11,14 @@ import FAN from "../../../../common/accessories/\_fan.mdx";
 
 # 风扇接口
 
+## 接口规格
+
+ROCK 5B / ROCK 5B+ 主板的风扇接口适配 **2-Pin、1.25 mm 间距、5V DC** 的风扇连接线。
+
+:::tip 选型参考
+如果你使用的是官方散热器，可参考 [瑞莎 6240B 散热器](../../../../accessories/heatsink-case/heatsink-6240b) 的规格说明，其风扇接口为 **2-Pin 1.25 mm 间距连接器**。
+:::
+
 ## 接口测试方法
 
 <FAN product="ROCK 5B" fan_connection_img="/img/rock5b/heatsink4012-use-3.webp" thermal_governor_path="../../radxa-os/rsetup#thermal_governor_path" model="rock-5b" pwm_fan_result_img="/img/rock5b/rock5b-pwm-fan-result.webp" pwm_fan_dev_id="4" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/getting-started/interface-usage/fan.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/getting-started/interface-usage/fan.md
@@ -11,6 +11,14 @@ import FAN from "../../../../common/accessories/\_fan.mdx";
 
 # FAN Interface
 
+## Connector Specification
+
+The fan header on ROCK 5B / ROCK 5B+ is designed for a **2-pin, 1.25 mm pitch, 5V DC** fan connector.
+
+:::tip Selection reference
+If you are using the official heatsink, see the [Radxa Heatsink 6240B](../../../../accessories/heatsink-case/heatsink-6240b) specification page. Its fan cable uses a **2-pin 1.25 mm pitch connector**.
+:::
+
 ## Interface Test Methods
 
 <FAN product="ROCK 5B" fan_connection_img="/img/rock5b/heatsink4012-use-3.webp" thermal_governor_path="../../radxa-os/rsetup#thermal_governor_path" model="rock-5b" pwm_fan_result_img="/img/rock5b/rock5b-pwm-fan-result.webp" pwm_fan_dev_id="4" />


### PR DESCRIPTION
## Summary
- add the ROCK 5B / ROCK 5B+ fan header connector spec to the fan interface page
- document that the board uses a 2-pin, 1.25 mm pitch, 5V DC fan connector
- sync the same clarification to the English doc

## Why
Issue #984 asks for the missing fan connector details (type/size) in the ROCK 5B docs. The existing docs already describe the matching 6240B heatsink cable, but the board fan page did not surface the connector spec clearly.

## Validation
- ./scripts/agent-doc-lint.sh docs/rock5/rock5b/getting-started/interface-usage/fan.md i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/getting-started/interface-usage/fan.md
- git diff --check

Fixes #984