### PR TITLE
fix(docs): remove .git suffix from modelscope download command

### DIFF
--- a/docs/common/dev/_rkllm_qwen2_vl.mdx
+++ b/docs/common/dev/_rkllm_qwen2_vl.mdx
@@ -15,7 +15,7 @@
 
 ```bash
 pip install -U modelscope
-modelscope download --model radxa/Qwen2-VL-2B-RKLLM.git
+modelscope download --model radxa/Qwen2-VL-2B-RKLLM
 ```
 
 </NewCodeBlock>


### PR DESCRIPTION
The `modelscope download` CLI uses model IDs in the format `org/model-name`, not git clone URLs. The `.git` suffix is a GitHub convention that causes the download command to fail.

**Change:** Remove `.git` from `radxa/Qwen2-VL-2B-RKLLM.git` → `radxa/Qwen2-VL-2B-RKLLM` in the shared `common/dev/_rkllm_qwen2_vl.mdx` file (used by 8 product pages).

**Note:** The issue reporter also suggested adding `--local_dir`, but their suggestion contained a typo (`--locla_dir`). The `--local_dir` flag is optional and the default download location works correctly, so this PR only fixes the confirmed bug.

Fixes #1477