### PR TITLE
fix: correct macOS rkdeveloptool build instructions

### DIFF
--- a/docs/common/radxa-os/rkdevtool/_use.mdx
+++ b/docs/common/radxa-os/rkdevtool/_use.mdx
@@ -86,9 +86,22 @@ rkdeveloptool -V
 
 打开系统终端或命令行，运行以下命令进行安装。
 
-:::note
-`git` 和 `wget` 已随 Xcode Command Line Tools 安装，无需通过 Homebrew 单独安装。macOS 不支持 `$(nproc)`，请使用 `make` 直接编译。`main.cpp` 中使用了可变长度数组（VLA），macOS 的 Clang 默认不允许在 C++ 中使用 VLA，需要先将变量声明为 `const`。
+:::tip 推荐
+推荐通过第三方 Homebrew Tap 直接安装，无需手动编译：
 :::
+
+<NewCodeBlock tip="macOS$" type="host">
+
+```bash
+brew tap IgorKha/rkdeveloptool
+brew install rkdeveloptool
+```
+
+</NewCodeBlock>
+
+:::details 从源码编译（备选）
+
+如果 Tap 安装失败，也可以从源码编译。macOS 不支持 `$(nproc)`，请使用 `make` 直接编译。`main.cpp` 中使用了可变长度数组（VLA），macOS 的 Clang 默认不允许在 C++ 中使用 VLA，需要先将变量声明为 `const`。
 
 <NewCodeBlock tip="macOS$" type="host">
 
@@ -104,6 +117,8 @@ cp rkdeveloptool /opt/homebrew/bin/
 ```
 
 </NewCodeBlock>
+
+:::
 
 - 验证版本号
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/rkdevtool/_use.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/rkdevtool/_use.mdx
@@ -85,21 +85,41 @@ If you don't have HomeBrew installed, you can install it using the following com
 
 - Install rkdeveloptool
 
-Open your system terminal or command line and run the following commands to install:
+Open your system terminal or command line and run the following commands to install.
+
+:::tip Recommended
+It is recommended to install directly via a third-party Homebrew Tap, no manual compilation needed:
+:::
 
 <NewCodeBlock tip="MacOS$" type="host">
 
 ```bash
-brew install automake autoconf libusb pkg-config git wget
+brew tap IgorKha/rkdeveloptool
+brew install rkdeveloptool
+```
+
+</NewCodeBlock>
+
+:::details Compile from source (alternative)
+
+If the Tap installation fails, you can also compile from source. macOS does not support `$(nproc)`, use `make` directly. `main.cpp` uses variable-length arrays (VLA), macOS Clang does not allow VLA in C++ by default, so you need to declare the variable as `const` first.
+
+<NewCodeBlock tip="MacOS$" type="host">
+
+```bash
+brew install automake autoconf libusb pkg-config
 git clone https://github.com/rockchip-linux/rkdeveloptool
 cd rkdeveloptool
 autoreconf -i
 ./configure
-make -j $(nproc)
+sed -i '' 's/int nSectorSize = 512;/const int nSectorSize = 512;/' main.cpp
+make
 cp rkdeveloptool /opt/homebrew/bin/
 ```
 
 </NewCodeBlock>
+
+:::
 
 - Verify Installation
 


### PR DESCRIPTION
This PR fixes macOS build issues for rkdeveloptool reported in #1485.

## Changes

- Remove usage: git [-v | --version] [-h | --help] [-C <path>] [-c <name>=<value>]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--no-lazy-fetch]
           [--no-optional-locks] [--no-advice] [--bare] [--git-dir=<path>]
           [--work-tree=<path>] [--namespace=<name>] [--config-env=<name>=<envvar>]
           <command> [<args>]

These are common Git commands used in various situations:

start a working area (see also: git help tutorial)
   clone      Clone a repository into a new directory
   init       Create an empty Git repository or reinitialize an existing one

work on the current change (see also: git help everyday)
   add        Add file contents to the index
   mv         Move or rename a file, a directory, or a symlink
   restore    Restore working tree files
   rm         Remove files from the working tree and from the index

examine the history and state (see also: git help revisions)
   bisect     Use binary search to find the commit that introduced a bug
   diff       Show changes between commits, commit and working tree, etc
   grep       Print lines matching a pattern
   log        Show commit logs
   show       Show various types of objects
   status     Show the working tree status

grow, mark and tweak your common history
   backfill   Download missing objects in a partial clone
   branch     List, create, or delete branches
   commit     Record changes to the repository
   merge      Join two or more development histories together
   rebase     Reapply commits on top of another base tip
   reset      Reset current HEAD to the specified state
   switch     Switch branches
   tag        Create, list, delete or verify a tag object signed with GPG

collaborate (see also: git help workflows)
   fetch      Download objects and refs from another repository
   pull       Fetch from and integrate with another repository or a local branch
   push       Update remote refs along with associated objects

'git help -a' and 'git help -g' list available subcommands and some
concept guides. See 'git help <command>' or 'git help <concept>'
to read about a specific subcommand or concept.
See 'git help git' for an overview of the system. and  from brew install (already provided by Xcode CLT)
- Replace  with  ( is not supported on macOS)
- Add  patch to change VLA (Variable Length Array) to  for Clang compatibility

## Issue

Fixes issues reported in issue #1485 where users encountered:
- Unnecessary git installation via brew
- Command not found: nproc
- Clang compiler error with VLA in main.cpp

The patch changes the variable declaration from:
# 1 "<stdin>"
# 1 "<built-in>" 1
# 1 "<built-in>" 3
# 465 "<built-in>" 3
# 1 "<command line>" 1
# 1 "<built-in>" 2
# 1 "<stdin>" 2
to:
# 1 "<stdin>"
# 1 "<built-in>" 1
# 1 "<built-in>" 3
# 465 "<built-in>" 3
# 1 "<command line>" 1
# 1 "<built-in>" 2
# 1 "<stdin>" 2

This allows the code to compile successfully with macOS Clang, which does not allow VLA by default in C++.

Fixes #1485