### PR TITLE
fix(rock5): correct broken link to SPI/NVME boot guide in FAQ (#683)

### DIFF
--- a/docs/rock5/faq.md
+++ b/docs/rock5/faq.md
@@ -20,7 +20,7 @@ sidebar_position: 99
 
 ### 没有 eMMC 和 TF 卡，ROCK 5B 可以从 PCIe M.2 NVME SSD 启动吗？
 
-- 是的。 ROCK 5B 可以从 PCIe M.2 NVME SSD 启动。ROCK 5B 配备一个 16MB SPI NOR Flash 和 PCIe M.2 M-Key 连接器。SPI NOR Flash 存储 bootloader。 NVME SSD 存储整个系统镜像（至少内核和 rootfs）。[SPI NOR Flash and PCIe NVME SSD boot](./lowlevel-development/bootloader_spi_flash)
+- 是的。 ROCK 5B 可以从 PCIe M.2 NVME SSD 启动。ROCK 5B 配备一个 16MB SPI NOR Flash 和 PCIe M.2 M-Key 连接器。SPI NOR Flash 存储 bootloader。 NVME SSD 存储整个系统镜像（至少内核和 rootfs）。刷写镜像请参考本指南：[SPI Nor Flash](./rock5b/getting-started/install-os/erase_spi-flash) 和 [PCIe NVME SSD](./rock5b/getting-started/install-os/nvme)。
 
 ### 散热器是否包含在价格中？
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/faq.md
@@ -22,10 +22,9 @@ sidebar_position: 8
 ### Can the ROCK 5B boot from a PCIe M.2 NVME SSD without an eMMC and TF card?
 
 - Yes. The ROCK 5B can boot from a PCIe M.2 NVME SSD.
-  The ROCK 5B is equipped with a 16MB SPI NOR Flash and a PCIe M.2 M-Key connector. the SPI NOR Flash stores the bootloader.
-  the NVME SSD stores the entire system image (at least the kernel and rootfs).
-  the ROCK 5B is equipped with a 16MB SPI NOR Flash and a PCIe M.2 M-Key connector.  
-  For more information, please check [SPI NOR Flash and PCIe NVME SSD boot](./lowlevel-development/bootloader_spi_flash)
+  The ROCK 5B is equipped with a 16MB SPI NOR Flash and a PCIe M.2 M-Key connector. The SPI NOR Flash stores the bootloader.
+  The NVME SSD stores the entire system image (at least the kernel and rootfs).
+  For more information, please check the following guides: [SPI Nor Flash](./rock5b/getting-started/install-os/erase_spi-flash) and [PCIe NVME SSD](./rock5b/getting-started/install-os/nvme).
 
 ### Is the heatsink included in the price?
 


### PR DESCRIPTION
## Summary

Fixed a broken link in the ROCK 5 series FAQ.

**File changed:** `docs/rock5/faq.md`

**Problem:** The FAQ entry about booting ROCK 5B from PCIe NVME SSD contained a broken link:

```
./lowlevel-development/bootloader_spi_flash
```

This path does not exist in the current docs structure.

**Fix:** Replaced the broken link with two correct links to the actual SPI flash erase and NVME installation pages:

- [SPI Nor Flash](./rock5b/getting-started/install-os/erase_spi-flash)
- [PCIe NVME SSD](./rock5b/getting-started/install-os/nvme)

These match the correct links already present in `rock5/rock5b/faq.md` Q3.

**Source:** radxa-docs/docs#683