### PR TITLE
docs(rock4d): add OpenWrt download links

### DIFF
--- a/docs/rock4/rock4d/download.md
+++ b/docs/rock4/rock4d/download.md
@@ -24,6 +24,12 @@ USB 刷机使用，Loader 文件用于 USB 下载初始化。
 
 ## 系统镜像下载
 
+:::note 使用提示
+
+本页中的 `.img.xz` 文件为压缩镜像。如果所使用的烧录工具不支持直接写入 `.xz` 压缩包，请先解压得到 `.img` 文件，再进行烧录。
+
+:::
+
 ### Linux 系统镜像
 
 :::info 最新系统镜像发布页面
@@ -61,6 +67,11 @@ USB 刷机使用，Loader 文件用于 USB 下载初始化。
 - 适用于 UFS 模块启动的 gpt 系统镜像：[Android-UFS-gpt.zip](https://github.com/radxa/manifests/releases/download/radxa-rock4d-20250528/Rock4d-Android14-rkr6-ufs-20250527-gpt.zip)
 
 - 适用于 NVME 启动的系统镜像：[Android-NVME.zip](https://github.com/radxa/manifests/releases/download/radxa-rock4d-20250528/Rock4d-Android14-rkr6-nvme-20250527-gpt.zip)
+
+### OpenWRT
+
+- [Radxa ROCK 4D OpenWRT ext4 sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-4d-ext4-sysupgrade.img.gz)
+- [Radxa ROCK 4D OpenWRT squashfs sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-4d-squashfs-sysupgrade.img.gz)
 
 ## 硬件设计
 

--- a/docs/rock4/rock4d/other-os/openwrt/install-os.md
+++ b/docs/rock4/rock4d/other-os/openwrt/install-os.md
@@ -10,7 +10,7 @@ import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-
 <OpenWrtMainline
   product="Radxa ROCK 4D"
   download_page="../../download"
-  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_4d-ext4-sysupgrade.img.gz"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock-4d-ext4-sysupgrade.img.gz"
   power="合适的电源适配器"
   model="rock4d"
   maskrom_page="../../hardware-use/maskrom"

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/download.md
@@ -24,6 +24,12 @@ For erasing and flashing the SPI boot firmware, please refer to the [Erase/Flash
 
 ## System Image Downloads
 
+:::note Usage note
+
+`.img.xz` files on this page are compressed system images. If your flashing tool cannot write `.xz` archives directly, extract the archive first to get the `.img` file, then flash that `.img` file.
+
+:::
+
 ### Linux System Images
 
 :::info Latest Image Release Page
@@ -62,6 +68,11 @@ If the SPI Flash has not been erased, you can directly write the system image to
 - GPT system image for booting from UFS module: [Android-UFS-gpt.zip](https://github.com/radxa/manifests/releases/download/radxa-rock4d-20250528/Rock4d-Android14-rkr6-ufs-20250527-gpt.zip)
 
 - System image for booting from NVMe: [Android-NVME.zip](https://github.com/radxa/manifests/releases/download/radxa-rock4d-20250528/Rock4d-Android14-rkr6-nvme-20250527-gpt.zip)
+
+### OpenWRT
+
+- [Radxa ROCK 4D OpenWRT ext4 sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-4d-ext4-sysupgrade.img.gz)
+- [Radxa ROCK 4D OpenWRT squashfs sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-4d-squashfs-sysupgrade.img.gz)
 
 ## Hardware Design
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/other-os/openwrt/install-os.md
@@ -10,7 +10,7 @@ import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-
 <OpenWrtMainline
   product="Radxa ROCK 4D"
   download_page="../../download"
-  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_4d-ext4-sysupgrade.img.gz"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock-4d-ext4-sysupgrade.img.gz"
   power="a suitable power adapter"
   model="rock4d"
   maskrom_page="../../hardware-use/maskrom"


### PR DESCRIPTION
Adds missing OpenWrt download links for ROCK 4D (ext4/squashfs sysupgrade) and aligns install page recommended image name with OpenWrt upstream filenames.\n\n- Syncs zh/en download pages\n- Fixes ROCK 4D OpenWrt wrapper image_name (rock-4d vs rock_4d)