### PR TITLE
docs(cubie/a7a): add Baidu Netdisk download link

### DIFF
--- a/docs/cubie/a7a/download.md
+++ b/docs/cubie/a7a/download.md
@@ -68,6 +68,14 @@ sidebar_position: 150
 
 - [Radxa Cubie A7A Android 13 20260206](https://github.com/radxa/allwinner-android-manifests/releases/download/A733-Android13-20260205/a733_android13_radxa_a7a_20260206_uart0.zip)：适用于 AC101B 音频编解码器版本的 Cubie A7A
 
+## 百度网盘下载
+
+:::tip
+百度网盘分享链接会定期更新镜像文件，推荐通过百度网盘下载获取最新镜像。
+:::
+
+- [百度网盘下载（radxa-a733）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-a733&parentPath=%2Fsharelink3108273493-988411983016443)
+
 ## 刷机工具
 
 SD卡启动盘制作工具：


### PR DESCRIPTION
## Summary

Add Baidu Netdisk download folder link to Cubie A7A download page.

### Changes

- **docs/cubie/a7a/download.md**: Add Baidu Netdisk link for radxa-a733 folder

### Baidu Netdisk Link

- Folder: radxa-a733
- URL: https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-a733

---
Please review and merge.