### PR TITLE
docs: add NPU info to E52C specification table

### DIFF
--- a/docs/e/e52c/getting-started/introduction.md
+++ b/docs/e/e52c/getting-started/introduction.md
@@ -47,6 +47,10 @@ Radxa E52C 是一款紧凑型网络计算机，具有广泛的网络功能和强
         <td colspan="2" align="center">无 GPU</td>
     </tr>
     <tr>
+        <td align="center">NPU</td>
+        <td colspan="2" align="center">NPU 支持 INT4/INT8/INT16/FP16/BF16 和 TF32 加速，计算能力高达 5TOPs</td>
+    </tr>
+    <tr>
         <td align="center">内存</td>
         <td colspan="2" align="center">1GB / 2GB / 4GB 32位 LPDDR4</td>
     </tr>

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/getting-started/introduction.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/getting-started/introduction.md
@@ -47,6 +47,10 @@ It provides a reliable and powerful platform for developers, IoT enthusiasts, DI
         <td colspan="2" align="center"> N/A </td>
     </tr>
     <tr>
+        <td align="center">NPU</td>
+        <td colspan="2" align="center">NPU supports INT4/INT8/INT16/FP16/BF16 and TF32 acceleration, computing power up to 5TOPs</td>
+    </tr>
+    <tr>
         <td align="center">DDR</td>
         <td colspan="2" align="center">1GB / 2GB / 4GB 32-bit LPDDR4</td>
     </tr>


### PR DESCRIPTION
## Description

RK3582 based E52C supports NPU with 5 TOPs computing power per the official Rockchip RK3582 datasheet. This PR adds the missing NPU row to the E52C specification table in both Chinese and English introduction pages.

## Changes

- Added NPU row to `contents/docs/e/e52c/getting-started/introduction.md` (Chinese)
- Added NPU row to `contents/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/getting-started/introduction.md` (English)

The NPU row follows the same format as Rock 5B (RK3588) but with 5 TOPs instead of 6 TOPs.

## Related

This fix came from a support case where E52C was incorrectly assumed to have no NPU based on missing documentation, while RK3582 actually includes NPU hardware.