### PR TITLE
docs(cm5): add Baidu Netdisk download link

### DIFF
--- a/docs/som/cm/cm5/download.md
+++ b/docs/som/cm/cm5/download.md
@@ -68,8 +68,8 @@ USB 刷机使用，Loader 文件用于 USB 下载初始化。
 :::
 
 - [百度网盘下载（radxa-cm5-io）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-cm5-io&parentPath=%2Fsharelink3108273493-988411983016443)
-- [百度网盘下载（radxa-cm5-io-d_1）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-cm5-io-d_1&parentPath=%2Fsharelink3108273493-988411983016443)
+- [百度网盘下载（radxa-cm5-io-6_1）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-cm5-io-6_1&parentPath=%2Fsharelink3108273493-988411983016443)
 - [百度网盘下载（radxa-cm5-rpi-cm4-io）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-cm5-rpi-cm4-io&parentPath=%2Fsharelink3108273493-988411983016443)
-- [百度网盘下载（radxa-cm5-rpi-cm4-io-d_1）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-cm5-rpi-cm4-io-d_1&parentPath=%2Fsharelink3108273493-988411983016443)
+- [百度网盘下载（radxa-cm5-rpi-cm4-io-6_1）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-cm5-rpi-cm4-io-6_1&parentPath=%2Fsharelink3108273493-988411983016443)
 
 ### 质量认证


### PR DESCRIPTION
## Summary

Add Baidu Netdisk download folder link to CM5 download page.

### Changes

- **docs/som/cm/cm5/download.md**: Add Baidu Netdisk link for radxa-cm5-io folder

### Baidu Netdisk Link

- Folder: radxa-cm5-io 等（含 radxa-cm5-io、radxa-cm5-io-d_1、radxa-cm5-rpi-cm4-io、radxa-cm5-rpi-cm4-io-d_1）
- URL: https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-cm5-io

---
Please review and merge.