### PR TITLE
docs(e52c): add Baidu Netdisk download link

### DIFF
--- a/docs/e/e52c/download.md
+++ b/docs/e/e52c/download.md
@@ -30,6 +30,14 @@ import Images from "./\_image.mdx"
 
 [rk3588_spl_loader_v1.15.113.bin](https://dl.radxa.com/e/e52c/images/rk3588_spl_loader_v1.15.113.bin)
 
+## 百度网盘下载
+
+:::tip
+百度网盘分享链接会定期更新镜像文件，推荐通过百度网盘下载获取最新镜像。
+:::
+
+- [百度网盘下载（radxa-e52c）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-e52c&parentPath=%2Fsharelink3108273493-988411983016443)
+
 ## 硬件设计
 
 Radxa E52C V1.2 版本


### PR DESCRIPTION
## Summary

Add Baidu Netdisk download folder link to E52C download page.

### Changes

- **docs/e/e52c/download.md**: Add Baidu Netdisk link for radxa-e52c folder

### Baidu Netdisk Link

- radxa-e52c: https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-e52c

---
Please review and merge.