### PR TITLE
docs(zero/zero2pro): add Baidu Netdisk download link

### DIFF
--- a/docs/zero/zero2pro/download.md
+++ b/docs/zero/zero2pro/download.md
@@ -25,6 +25,14 @@ Armbian 的默认凭据如下：
 | 用户名 | `root` |
 | 密码   | `1234` |
 
+## 百度网盘下载
+
+:::tip
+百度网盘分享链接会定期更新镜像文件，推荐通过百度网盘下载获取最新镜像。
+:::
+
+- [百度网盘下载（radxa-zero-2pro）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-zero-2pro&parentPath=%2Fsharelink3108273493-988411983016443)
+
 ## 刷机工具
 
 - [Zagdig](https://zadig.akeo.ie/)：Windows Maskrom 驱动。


### PR DESCRIPTION
## Summary

Add Baidu Netdisk download folder link to Radxa ZERO 2 Pro download page.

### Changes

- **docs/zero/zero2pro/download.md**: Add Baidu Netdisk link for radxa-zero-2pro folder

### Baidu Netdisk Link

- radxa-zero-2pro: https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-zero-2pro

---
Please review and merge.