### PR TITLE
docs(zero/zero3): add Baidu Netdisk download link

### DIFF
--- a/docs/zero/zero3/download.md
+++ b/docs/zero/zero3/download.md
@@ -81,7 +81,7 @@ Armbian 的默认凭据如下：
 百度网盘分享链接会定期更新镜像文件，推荐通过百度网盘下载获取最新镜像。
 :::
 
-- [百度网盘下载（radxa-zeros3）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-zeros3&parentPath=%2Fsharelink3108273493-988411983016443)
+- [百度网盘下载（radxa-zero3）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-zero3&parentPath=%2Fsharelink3108273493-988411983016443)
 
 ## 质量认证
 


### PR DESCRIPTION
## Summary

Add Baidu Netdisk download folder link to Radxa ZERO 3 download page.

### Changes

- **docs/zero/zero3/download.md**: Add Baidu Netdisk link for radxa-zero3 folder

### Baidu Netdisk Link

- radxa-zero3: https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-zero3

---
Please review and merge.