### PR TITLE
docs(rk3528): add Baidu Netdisk link for rk3528 to E20C, ROCK2A, ROCK2F

### DIFF
--- a/docs/e/e20c/download.md
+++ b/docs/e/e20c/download.md
@@ -47,6 +47,14 @@ OpenWrt 官方镜像:
 
 [rk3528_spl_loader_v1.07.104.bin](https://dl.radxa.com/rock2/images/loader/rk3528_spl_loader_v1.07.104.bin)
 
+## 百度网盘下载
+
+:::tip
+百度网盘分享链接会定期更新镜像文件，推荐通过百度网盘下载获取最新镜像。
+:::
+
+- [百度网盘下载（rk3528）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Frk3528&parentPath=%2Fsharelink3108273493-988411983016443)
+
 ## 硬件设计
 
 Radxa E20C V1.1 版本

--- a/docs/rock2/rock2a/download.md
+++ b/docs/rock2/rock2a/download.md
@@ -36,6 +36,14 @@ Armbian ：
 
 [Armbian](https://www.armbian.com/rock-2a/) （包含 Ubuntu 和 Debian 系统）
 
+## 百度网盘下载
+
+:::tip
+百度网盘分享链接会定期更新镜像文件，推荐通过百度网盘下载获取最新镜像。
+:::
+
+- [百度网盘下载（rk3528）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Frk3528&parentPath=%2Fsharelink3108273493-988411983016443)
+
 ## 硬件设计
 
 Radxa ROCK 2A V1.2 版本

--- a/docs/rock2/rock2f/download.md
+++ b/docs/rock2/rock2f/download.md
@@ -34,6 +34,14 @@ Armbian ：
 
 [Armbian](https://www.armbian.com/rock-2f/) （包含 Ubuntu 和 Debian 系统）
 
+## 百度网盘下载
+
+:::tip
+百度网盘分享链接会定期更新镜像文件，推荐通过百度网盘下载获取最新镜像。
+:::
+
+- [百度网盘下载（rk3528）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Frk3528&parentPath=%2Fsharelink3108273493-988411983016443)
+
 ## 硬件设计
 
 Radxa ROCK 2F V1.0 版本


### PR DESCRIPTION
## Summary

Add Baidu Netdisk folder link (rk3528) to three download pages. The rk3528 image is compatible with E20C, ROCK 2A, and ROCK 2F.

### Changes

- **docs/e/e20c/download.md**: Add Baidu Netdisk link for rk3528 folder
- **docs/rock2/rock2a/download.md**: Add Baidu Netdisk link for rk3528 folder
- **docs/rock2/rock2f/download.md**: Add Baidu Netdisk link for rk3528 folder

### Baidu Netdisk Link

- rk3528: https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Frk3528

---
Please review and merge.