### PR TITLE
docs(cubie/a7a): consolidate accessory-use into accessories directory

### DIFF
--- a/docs/cubie/a7a/accessories/3d-case.md
+++ b/docs/cubie/a7a/accessories/3d-case.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # 第三方 3D 打印外壳

--- a/docs/cubie/a7a/accessories/README.md
+++ b/docs/cubie/a7a/accessories/README.md
@@ -23,3 +23,7 @@ sidebar_position: 99
 | PoE 扩展 | 25W PoE+ HAT           | 通过以太网供电的扩展板，支持 IEEE 802.3at 标准           | [查看详情](https://radxa.com/products/accessories/25w-poe-plus-hat)       |
 | 网络扩展 | Dual 2.5G Router HAT   | 双 2.5G 以太网路由器扩展板                               | [查看详情](https://radxa.com/products/accessories/dual-2-5g-router-hat)   |
 | 散热方案 | Heatsink 6540B         | 散热器，尺寸 65x40mm                                     | [查看详情](https://radxa.com/products/accessories/heatsink-6540b)         |
+
+## 3D 打印外壳
+
+- [第三方 3D 打印外壳](./3d-case)：社区设计的 Cubie A7A 专用外壳

--- a/docs/cubie/a7a/accessory-use/README.md
+++ b/docs/cubie/a7a/accessory-use/README.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 99
----
-
-# 配件使用
-
-介绍如何使用 Cubie A7A 的各种配件。
-
-<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/3d-case.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/3d-case.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Third-Party 3D-Printed Cases

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/README.md
@@ -23,3 +23,7 @@ This page lists the official accessories compatible with Cubie A7A.
 | PoE      | 25W PoE+ HAT           | Power-over-Ethernet expansion board supporting IEEE 802.3at              | [Learn more](https://radxa.com/products/accessories/25w-poe-plus-hat)       |
 | Network  | Dual 2.5G Router HAT   | Dual 2.5G Ethernet router expansion board                                | [Learn more](https://radxa.com/products/accessories/dual-2-5g-router-hat)   |
 | Thermal  | Heatsink 6540B         | Heatsink, 65x40 mm                                                       | [Learn more](https://radxa.com/products/accessories/heatsink-6540b)         |
+
+## 3D-Printed Cases
+
+- [Third-Party 3D-Printed Cases](./3d-case): Community-designed cases for Cubie A7A

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessory-use/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessory-use/README.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 99
----
-
-# Accessories Usage
-
-Introduces how to use various accessories for Cubie A7A.
-
-<DocCardList />


### PR DESCRIPTION
## Summary

Consolidate the accessory-use directory into accessories for Cubie A7A.

### Changes

- Move **3D case** documentation from  to 
- Update  (Chinese and English) to include 3D case section
- Remove the redundant  directory
- Update sidebar position for 3d-case.md (2 → 3)

### New Structure



---
Please review and merge.