### PR TITLE
docs(rock4/rock4d, rock5/rock5b): consolidate accessory-use into accessories

### DIFF
--- a/docs/rock4/rock4d/accessories/3d-case.md
+++ b/docs/rock4/rock4d/accessories/3d-case.md
@@ -1,23 +1,23 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # 第三方 3D 打印外壳
 
-本页收录社区作者为 ROCK 5B+ 设计并开源的第三方 3D 打印外壳，方便用户快速打印并保护主板。
+本页收录社区作者为 Radxa ROCK 4D 设计并开源的第三方 3D 打印外壳，方便用户快速打印并保护主板。
 
 > 说明：以下外壳均为第三方设计，与 Radxa 官方无从属关系，请在打印和使用前自行评估风险。
 
-## 型号一：ROCK 5B+ 外壳
+## 型号一：ROCK 4D 无螺丝外壳
 
 - MakerWorld 模型页面：
-  - https://makerworld.com.cn/zh/models/2272559
+  - https://makerworld.com/en/models/2558377-radxa-rock-4d-screwless
 
 特点概述：
 
-- 适配 ROCK 5B+ 板卡外形和接口开孔
-- 适合作为桌面或实验环境中的日常防护外壳
-- 可作为 3D 打印自制外壳的参考方案
+- 适配 Radxa ROCK 4D 板卡孔位
+- 无螺丝固定设计，安装拆卸方便
+- 适合桌面或机柜等固定场景
 
 ---
 

--- a/docs/rock4/rock4d/accessories/README.md
+++ b/docs/rock4/rock4d/accessories/README.md
@@ -25,3 +25,7 @@ sidebar_position: 99
 | SATA 扩展 | Penta SATA HAT         | 五盘位 SATA 扩展板，支持搭建 NAS 存储系统                | [查看详情](https://radxa.com/products/accessories/penta-sata-hat)         |
 | 网络扩展  | Dual 2.5G Router HAT   | 双 2.5G 以太网路由器扩展板                               | [查看详情](https://radxa.com/products/accessories/dual-2-5g-router-hat)   |
 | 散热方案  | Heatsink 2513          | 散热器，尺寸 25x13mm                                     | [查看详情](https://radxa.com/products/accessories/heatsink-2513)          |
+
+## 3D 打印外壳
+
+- [第三方 3D 打印外壳](./3d-case)：社区设计的 ROCK 4D 专用外壳

--- a/docs/rock4/rock4d/accessory-use/README.md
+++ b/docs/rock4/rock4d/accessory-use/README.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 99
----
-
-# 配件使用
-
-介绍如何使用 ROCK 4D 的各种配件。
-
-<DocCardList />

--- a/docs/rock5/rock5b/accessories/3d-case.md
+++ b/docs/rock5/rock5b/accessories/3d-case.md
@@ -1,23 +1,23 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # 第三方 3D 打印外壳
 
-本页收录社区作者为 Radxa ROCK 4D 设计并开源的第三方 3D 打印外壳，方便用户快速打印并保护主板。
+本页收录社区作者为 ROCK 5B+ 设计并开源的第三方 3D 打印外壳，方便用户快速打印并保护主板。
 
 > 说明：以下外壳均为第三方设计，与 Radxa 官方无从属关系，请在打印和使用前自行评估风险。
 
-## 型号一：ROCK 4D 无螺丝外壳
+## 型号一：ROCK 5B+ 外壳
 
 - MakerWorld 模型页面：
-  - https://makerworld.com/en/models/2558377-radxa-rock-4d-screwless
+  - https://makerworld.com.cn/zh/models/2272559
 
 特点概述：
 
-- 适配 Radxa ROCK 4D 板卡孔位
-- 无螺丝固定设计，安装拆卸方便
-- 适合桌面或机柜等固定场景
+- 适配 ROCK 5B+ 板卡外形和接口开孔
+- 适合作为桌面或实验环境中的日常防护外壳
+- 可作为 3D 打印自制外壳的参考方案
 
 ---
 

--- a/docs/rock5/rock5b/accessories/README.md
+++ b/docs/rock5/rock5b/accessories/README.md
@@ -24,3 +24,7 @@ sidebar_position: 99
 | 散热方案 | Heatsink 4012          | 通用型散热器，尺寸 40x12mm                               | [查看详情](https://radxa.com/products/accessories/heatsink-4012)      |
 | 散热方案 | Heatsink 4025A         | 主动散热器，带风扇，尺寸 40x25mm                         | [查看详情](https://radxa.com/products/accessories/heatsink-4025A)     |
 | 散热方案 | Metal Case for ROCK 5B | 金属外壳，提供优秀的散热和保护性能                       | [查看详情](https://radxa.com/products/accessories/rock5b-metal-case)  |
+
+## 3D 打印外壳
+
+- [第三方 3D 打印外壳](./3d-case)：社区设计的 ROCK 5B 专用外壳

--- a/docs/rock5/rock5b/accessory-use/README.md
+++ b/docs/rock5/rock5b/accessory-use/README.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 70
----
-
-# 配件使用
-
-介绍如何使用 ROCK 5B/5B+ 的各种配件。
-
-<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/accessories/3d-case.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/accessories/3d-case.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Third-Party 3D-Printed Cases

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/accessories/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/accessories/README.md
@@ -25,3 +25,7 @@ This page lists the official accessories compatible with ROCK 4D.
 | SATA Expansion | Penta SATA HAT         | Five-bay SATA expansion board for NAS builds                             | [Learn more](https://radxa.com/products/accessories/penta-sata-hat)         |
 | Network        | Dual 2.5G Router HAT   | Dual 2.5G Ethernet router expansion board                                | [Learn more](https://radxa.com/products/accessories/dual-2-5g-router-hat)   |
 | Thermal        | Heatsink 2513          | Heatsink, 25x13 mm                                                       | [Learn more](https://radxa.com/products/accessories/heatsink-2513)          |
+
+## 3D-Printed Cases
+
+- [Third-Party 3D-Printed Cases](./3d-case): Community-designed cases for ROCK 4D

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/accessory-use/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/accessory-use/README.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 99
----
-
-# Accessories Usage
-
-Introduces how to use various accessories for ROCK 4D.
-
-<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/accessories/3d-case.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/accessories/3d-case.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Third-Party 3D-Printed Cases

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/accessories/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/accessories/README.md
@@ -24,3 +24,7 @@ This page lists the official accessories compatible with ROCK 5B.
 | Thermal  | Heatsink 4012          | Universal heatsink, 40x12 mm                                             | [Learn more](https://radxa.com/products/accessories/heatsink-4012)      |
 | Thermal  | Heatsink 4025A         | Active cooling heatsink with fan, 40x25 mm                               | [Learn more](https://radxa.com/products/accessories/heatsink-4025A)     |
 | Thermal  | Metal Case for ROCK 5B | Metal case providing cooling and protection                              | [Learn more](https://radxa.com/products/accessories/rock5b-metal-case)  |
+
+## 3D-Printed Cases
+
+- [Third-Party 3D-Printed Cases](./3d-case): Community-designed cases for ROCK 5B

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/accessory-use/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/accessory-use/README.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 70
----
-
-# Accessory Use
-
-This document introduces how to use the various accessories of ROCK 5B/5B+.
-
-<DocCardList />


### PR DESCRIPTION
## Summary

Consolidate the accessory-use directory into accessories for ROCK 4D and ROCK 5B.

### Changes

- **ROCK 4D** (docs/rock4/rock4d/):
  - Move 3D case from  to 
  - Add 3D case section to  (Chinese and English)
  - Remove redundant  directory
  - Update sidebar position for 3d-case.md (2 → 3)

- **ROCK 5B** (docs/rock5/rock5b/):
  - Move 3D case from  to 
  - Add 3D case section to  (Chinese and English)
  - Remove redundant  directory
  - Update sidebar position for 3d-case.md (2 → 3)

### New Structure

**Before:**


**After:**


---
Please review and merge.