### PR TITLE
docs(rock5/rock5c): clarify only Android 12 is available

### DIFF
--- a/docs/rock5/rock5c/download.md
+++ b/docs/rock5/rock5c/download.md
@@ -16,6 +16,10 @@ import Images from "./\_image.mdx"
 除了上面的镜像经过官方充分测试外，其他镜像未经过严格测试，可能会存在未知问题，仅用于评估使用。
 :::
 
+:::note
+目前 ROCK 5C 官方提供的 Android 镜像仅为 Android 12 版本，其他 Android 版本暂不提供。
+:::
+
 ### 第三方操作系统镜像
 
 - [Radxa ROCK 5C Armbian](https://www.armbian.com/radxa-rock-5c/)

--- a/docs/rock5/rock5c/other-os/android/install-os.md
+++ b/docs/rock5/rock5c/other-os/android/install-os.md
@@ -11,6 +11,10 @@ import Rkdeveloptool from "../../../../common/dev/\_rkdeveloptoolV3.mdx";
 
 本文档将介绍如何把 Android 镜像安装到 ROCK 5C。
 
+:::note
+目前 ROCK 5C 官方提供的 Android 镜像仅为 Android 12 版本。
+:::
+
 ROCK 5C 可以从 microSD 卡启动，也可以从 EMMC 启动，基于不同的启动方式，安装系统到不同的介质上.
 
 <Tabs queryString="target">

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/download.md
@@ -17,6 +17,10 @@ import Images from "./\_image.mdx"
 Except for the above images which have been fully tested officially, the other images have not been rigorously tested and may have unknown issues and are for evaluation purposes only.
 :::
 
+:::note
+Currently, only Android 12 is officially available for ROCK 5C.
+:::
+
 ### Third-Party Operating System images
 
 - [Radxa ROCK 5C Armbian](https://www.armbian.com/radxa-rock-5c/)

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/other-os/android/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/other-os/android/install-os.md
@@ -11,6 +11,10 @@ import Rkdeveloptool from "../../../../common/dev/\_rkdeveloptoolV3.mdx";
 
 This document describes how to install an Android image to the ROCK 5C.
 
+:::note
+Currently, only Android 12 is officially available for ROCK 5C.
+:::
+
 ROCK 5C can be booted from microSD card or EMMC, depending on the boot method, the system will be installed on different media.
 
 <Tabs queryString="target">


### PR DESCRIPTION
## Summary

Add explicit notes on the ROCK 5C download page and Android install page stating that only Android 12 is currently officially available for ROCK 5C.

## Changes

- **docs/rock5/rock5c/download.md**: Added note after the official image listing
- **docs/rock5/rock5c/other-os/android/install-os.md**: Added note at the top of the page
- **i18n/en/.../rock5/rock5c/download.md**: Same clarification in English
- **i18n/en/.../rock5/rock5c/other-os/android/install-os.md**: Same clarification in English

## Source

Support case: A customer contacted Radxa support about HDMI issues when using an Android 14 image on ROCK 5C. The customer was unclear which Android versions are officially available. The official download page only lists Android 12 images (via the `<Images>` component). This change makes that explicit in the documentation to prevent future customer confusion.

## What this reduces

- Customer confusion about which Android version is officially available for ROCK 5C
- Support inquiries about Android 14 availability
- Risk of customers using unofficial/third-party Android 14 builds and encountering issues