### PR TITLE
docs(rock4/rock4d): fix Baidu Netdisk folder name rk3576 -> radxa-rk3576

### DIFF
--- a/docs/rock4/rock4d/download.md
+++ b/docs/rock4/rock4d/download.md
@@ -82,7 +82,7 @@ USB 刷机使用，Loader 文件用于 USB 下载初始化。
 - **R 版本**：经过测试的稳定版本，推荐使用
 - **T 版本**：测试版本（仅用于评估）
 :::
-- [百度网盘下载（rk3576）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Frk3576&parentPath=%2Fsharelink3108273493-988411983016443)
+- [百度网盘下载（radxa-rk3576）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-rk3576&parentPath=%2Fsharelink3108273493-988411983016443)
 
 ## 硬件设计
 


### PR DESCRIPTION
## Summary

Correct the Baidu Netdisk folder name for ROCK 4D.

### Changes

- **docs/rock4/rock4d/download.md**: Fix folder name from `rk3576` to `radxa-rk3576` (1 file changed)

### Link

- radxa-rk3576: https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-rk3576

---
Please review and merge.