### PR TITLE
docs: replace rock3b hardware-interface physical photo with motherboard preview image

### DIFF
--- a/docs/rock3/rock3b/hardware-design/hardware-interface.md
+++ b/docs/rock3/rock3b/hardware-design/hardware-interface.md
@@ -10,7 +10,7 @@ sidebar_position: 1
 
 ## 实物照片
 
-<img src="/img/rock3/3b/rock3b_v1-5_real.webp" alt="rk3568 chip block diagram" style={{ width: "80%" }} />
+<img src="/img/rock3/3b/rock3b-interfaces.webp" alt="rk3568 chip block diagram" style={{ width: "80%" }} />
 
 ## 接口详情
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/hardware-design/hardware-interface.md
@@ -10,7 +10,7 @@ sidebar_position: 1
 
 ## Physical photographs
 
-<img src="/img/rock3/3b/rock3b_v1-5_real.webp" alt="rk3568 chip block diagram" style={{ width: "80%" }} />
+<img src="/img/rock3/3b/rock3b-interfaces.webp" alt="rk3568 chip block diagram" style={{ width: "80%" }} />
 
 ## Interface details
 


### PR DESCRIPTION
Replace the Physical photographs image on the ROCK 3B hardware-interface page with the Motherboard Preview image from the introduction page.

## Changes
- docs/rock3/rock3b/hardware-design/hardware-interface.md: Changed image from `rock3b_v1-5_real.webp` to `rock3b-interfaces.webp` (Chinese)
- i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/hardware-design/hardware-interface.md: Changed image from `rock3b_v1-5_real.webp` to `rock3b-interfaces.webp` (English)

## Verification
- Both Chinese and English versions updated
- Image src changed: /img/rock3/3b/rock3b_v1-5_real.webp -> /img/rock3/3b/rock3b-interfaces.webp
