### PR TITLE
docs: update Balena Etcher version from 1.18.11 to 2.1.4

### DIFF
--- a/docs/common/general/_etcherV2.mdx
+++ b/docs/common/general/_etcherV2.mdx
@@ -8,15 +8,15 @@ import React, { Fragment } from "react";
 <Tabs queryString="Platform">
 <TabItem value="Windows">
 
-请下载 [balenaEtcher-Setup-1.18.11.exe](https://github.com/balena-io/etcher/releases/download/v1.18.11/balenaEtcher-Setup-1.18.11.exe)。下载完成后，无需进行额外操作，双击即可打开使用。
+请下载 [balenaEtcher-2.1.4.Setup.exe](https://github.com/balena-io/etcher/releases/download/v2.1.4/balenaEtcher-2.1.4.Setup.exe)。下载完成后，无需进行额外操作，双击即可打开使用。
 
 </TabItem>
 <TabItem value="Linux">
 
-请下载 [balena-etcher_1.18.11_amd64.deb](https://github.com/balena-io/etcher/releases/download/v1.18.11/balena-etcher_1.18.11_amd64.deb)。下载完成后，请在终端执行以下命令进行安装：
+请下载 [balena-etcher_2.1.4_amd64.deb](https://github.com/balena-io/etcher/releases/download/v2.1.4/balena-etcher_2.1.4_amd64.deb)。下载完成后，请在终端执行以下命令进行安装：
 
 ```bash
-sudo dpkg -i balena-etcher_1.18.11_amd64.deb
+sudo dpkg -i balena-etcher_2.1.4_amd64.deb
 ```
 
 </TabItem>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcherV2.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcherV2.mdx
@@ -7,15 +7,15 @@ Balena Etcher is a cross-platform and user friendly image file burning tool that
 <Tabs queryString="Platform">
 <TabItem value="Windows">
 
-Please download [balenaEtcher-Setup-1.18.11.exe](https://github.com/balena-io/etcher/releases/download/v1.18.11/balenaEtcher-Setup-1.18.11.exe) After the download is complete, there is no need to perform any additional actions. After downloading, you can double click it to open it without any additional operation.
+Please download [balenaEtcher-2.1.4.Setup.exe](https://github.com/balena-io/etcher/releases/download/v2.1.4/balenaEtcher-2.1.4.Setup.exe). After the download is complete, there is no need to perform any additional actions. After downloading, you can double click it to open it without any additional operation.
 
 </TabItem>
 <TabItem value="Linux">
 
-Please download [balena-etcher_1.18.11_amd64.deb](https://github.com/balena-io/etcher/releases/download/v1.19.16/balena-etcher_1.19.16_amd64.deb). Once the download is complete, please install it by executing the following command in the terminal:
+Please download [balena-etcher_2.1.4_amd64.deb](https://github.com/balena-io/etcher/releases/download/v2.1.4/balena-etcher_2.1.4_amd64.deb). Once the download is complete, please install it by executing the following command in the terminal:
 
 ```bash
-sudo dpkg -i balena-etcher_1.18.11_amd64.deb
+sudo dpkg -i balena-etcher_2.1.4_amd64.deb
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary

Update Balena Etcher download links from outdated v1.18.11 to current v2.1.4 in the shared Etcher installation guide (both Chinese and English versions).

**Issue:** #415

**Changes:**
- Windows: `balenaEtcher-Setup-1.18.11.exe` → `balenaEtcher-2.1.4.Setup.exe`
- Linux: `balena-etcher_1.18.11_amd64.deb` → `balena-etcher_2.1.4_amd64.deb`
- Updated both download URLs and install commands

**Files changed:**
- `docs/common/general/_etcherV2.mdx` (Chinese)
- `i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcherV2.mdx` (English)

Fixes #415