### PR TITLE
docs(dragon/q6a): document RTL8111H WoA known limitation + USB adapter workaround

### DIFF
--- a/docs/dragon/q6a/other-system/windows.md
+++ b/docs/dragon/q6a/other-system/windows.md
@@ -114,7 +114,9 @@ Windows 安装完成后，系统仍然缺少诸如网络、GPU、音频等专用
 
 此时，大部分硬件（包括网络、GPU、多媒体、音频等）应可在 Windows 中正常工作。
 
-## 后续建议
+:::info 已知限制：板载千兆以太网（RTL8111H）
+Dragon Q6A 板载的 RTL8111H 千兆以太网控制器在 Windows on ARM 下存在已知兼容性限制：设备在系统内显示正常（无感叹号），但无法正常收发数据包。如遇此问题，建议使用 **USB 千兆以太网适配器**（推荐 ASIX AX88179 或 Realtek RTL8153 芯片方案），这些方案在 Windows ARM64 下有完善驱动支持。如需进一步支持，请通过 support@radxa.com 联系 Radxa 技术支持团队。
+:::
 
 - 通过 Windows Update 检查并安装最新系统更新；
 - 从 Microsoft Store 安装 OpenCL、OpenGL、Vulkan 相关兼容包，以获得更完整的 GPU 能力；

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/other-system/windows.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/other-system/windows.md
@@ -118,7 +118,9 @@ After Windows installation, the system still lacks specific drivers (network, GP
 
 At this point, most hardware including networking, GPU, multimedia and audio should work properly under Windows.
 
-## 4. Next Steps
+:::info Known Issue: Onboard Gigabit Ethernet (RTL8111H)
+The onboard RTL8111H Gigabit Ethernet controller on Dragon Q6A has a **known compatibility limitation** under Windows on ARM: the device appears normal in Device Manager (no yellow exclamation mark), but is unable to send or receive any network packets. If you encounter this issue, the recommended workaround is to use a **USB Gigabit Ethernet adapter** (ASIX AX88179 or Realtek RTL8153 chipset-based adapters are well-supported under Windows ARM64). For further assistance, please contact Radxa support at support@radxa.com.
+:::
 
 - Use Windows Update to check for and install the latest system updates;
 - Install OpenCL/OpenGL/Vulkan compatibility packs from Microsoft Store for full GPU capabilities;


### PR DESCRIPTION
## Summary

Add a known limitation note to the Dragon Q6A Windows on ARM documentation page, alerting users that the onboard RTL8111H Gigabit Ethernet controller has a known compatibility issue under Windows on ARM (device appears normal in Device Manager but cannot send/receive packets). Recommends USB Ethernet adapters (ASIX AX88179 / RTL8153) as a workaround.

## Source

- GitHub Discussion #1535 (user: tankist-git-2) — customer reported RTL8111H Ethernet completely non-functional under WoA despite following all driver installation steps; Linux on same board works fine.

## Changes

- `docs/dragon/q6a/other-system/windows.md` — Chinese version: added `:::info` block after driver installation section
- `i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/other-system/windows.md` — English version: same addition

## Verification

- Both CN and EN files updated in sync (bilingual check passed)
- Guard: 1 commit, 1 scope, no mixed-content issues
- Preview: the new note appears after "At this point, most hardware including networking..." in both language versions

## Related

- Discussion: https://github.com/radxa-docs/docs/discussions/1535
- GitHub reply: https://github.com/radxa-docs/docs/discussions/1535#discussioncomment-16379738
- Fixes: Acknowledged as known limitation; no product fix yet