### PR TITLE
docs: use git switch instead of git checkout in zero3 buildroot guide

### DIFF
--- a/docs/zero/zero3/other-os/buildroot.md
+++ b/docs/zero/zero3/other-os/buildroot.md
@@ -39,13 +39,15 @@ tar xvf rk356x_linux5.10_rkr8_sdk.repo.tar
 
 ## 添加板子 Zero 3E 板子支持
 
+> **注意**：请勿使用 root 用户进行编译，以免产生权限问题。建议使用普通用户编译。
+
 使用 Radxa 维护的 rockchip 仓库。
 
 ```text
 cd device/rockchip
 git remote add radxa https://github.com/radxa/device-rockchip.git
 git fetch radxa
-git checkout -b rk3566_rk3568-linux-5.10 remotes/radxa/rk3566_rk3568-linux-5.10
+git switch -c rk3566_rk3568-linux-5.10 radxa/rk3566_rk3568-linux-5.10
 ```
 
 使用 Radxa 维护的 kernel 仓库。
@@ -54,7 +56,7 @@ git checkout -b rk3566_rk3568-linux-5.10 remotes/radxa/rk3566_rk3568-linux-5.10
 cd kernel
 git remote add radxa https://github.com/radxa/kernel.git
 git fetch radxa
-git checkout -b linux-5.10-gen-rkr8-buildroot remotes/radxa/linux-5.10-gen-rkr8-buildroot
+git switch -c linux-5.10-gen-rkr8-buildroot radxa/linux-5.10-gen-rkr8-buildroot
 ```
 
 ## 构建 SDK

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/buildroot.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/buildroot.md
@@ -39,13 +39,15 @@ tar xvf rk356x_linux5.10_rkr8_sdk.repo.tar
 
 ## Add board Zero 3E support
 
-Use Radxa reposiory, rockchip.
+> **Note**: Do not compile as root user, as this may cause permission issues. It is recommended to build as a regular user.
+
+Use Radxa repository, rockchip.
 
 ```text
 cd device/rockchip
 git remote add radxa https://github.com/radxa/device-rockchip.git
 git fetch radxa
-git checkout -b rk3566_rk3568-linux-5.10 remotes/radxa/rk3566_rk3568-linux-5.10
+git switch -c rk3566_rk3568-linux-5.10 radxa/rk3566_rk3568-linux-5.10
 ```
 
 Use Radxa repository, kernel.
@@ -54,7 +56,7 @@ Use Radxa repository, kernel.
 cd kernel
 git remote add radxa https://github.com/radxa/kernel.git
 git fetch radxa
-git checkout -b linux-5.10-gen-rkr8-buildroot remotes/radxa/linux-5.10-gen-rkr8-buildroot
+git switch -c linux-5.10-gen-rkr8-buildroot radxa/linux-5.10-gen-rkr8-buildroot
 ```
 
 ## Build SDK


### PR DESCRIPTION
## 来源

GitHub issue #1550 - 用户反馈 Zero 3E Buildroot 文档中应使用 `git switch` 而非 `git checkout` 切换分支。

## 改动内容

- 将 `git checkout -b <branch> remotes/radxa/<branch>` 替换为 `git switch -c <branch> radxa/<branch>`
- 添加编译警告：不要使用 root 用户进行编译
- 修正英文版中的拼写错误：reposiory → repository

## 改动范围

- `docs/zero/zero3/other-os/buildroot.md`（中文）
- `i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/buildroot.md`（英文）

## 验证方式

对比修改前后的 git diff，确认两处 `git checkout -b` 均已替换为 `git switch -c`，且中文和英文版本均已同步更新。

Fixes #1550