### PR TITLE
docs: add ROS2 development documentation for AIRbox Q900

### DIFF
--- a/docs/fogwise/airbox-q900/app-dev/README.md
+++ b/docs/fogwise/airbox-q900/app-dev/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 40
+---
+
+# 应用开发
+
+主要介绍上层应用开发，如 ROS 开发、NPU 开发、CasaOS 等。
+
+<DocCardList />

--- a/docs/fogwise/airbox-q900/app-dev/ros-dev/README.md
+++ b/docs/fogwise/airbox-q900/app-dev/ros-dev/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 3
+---
+
+# ROS 开发
+
+<DocCardList />

--- a/docs/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/README.md
+++ b/docs/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 2
+---
+
+# ROS2 开发
+
+<DocCardList />

--- a/docs/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/ros2-example.md
+++ b/docs/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/ros2-example.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 2
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/application-dev/ros-dev/ros2-dev/_example.mdx
+---
+
+import ROS2Example from '../../../../../common/radxa-os/application-dev/ros-dev/ros2-dev/_example.mdx';
+
+# ROS2 快速体验（Turtlesim）
+
+<ROS2Example board="airbox-q900" />

--- a/docs/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/ros2-install.md
+++ b/docs/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/ros2-install.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/application-dev/ros-dev/ros2-dev/_install.mdx
+---
+
+import ROS2Install from '../../../../../common/radxa-os/application-dev/ros-dev/ros2-dev/_install.mdx';
+
+# ROS2 环境搭建
+
+<ROS2Install board="airbox-q900" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 40
+---
+
+# Application Development
+
+Introduction to upper-layer application development, such as ROS development, NPU development, CasaOS, etc.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/ros-dev/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/ros-dev/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 3
+---
+
+# ROS Development
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 2
+---
+
+# ROS2 Development
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/ros2-example.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/ros2-example.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 2
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/application-dev/ros-dev/ros2-dev/_example.mdx
+---
+
+import ROS2Example from '../../../../../common/radxa-os/application-dev/ros-dev/ros2-dev/_example.mdx';
+
+# ROS2 Quick Start (Turtlesim)
+
+<ROS2Example board="airbox-q900" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/ros2-install.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/ros-dev/ros2-dev/ros2-install.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/application-dev/ros-dev/ros2-dev/_install.mdx
+---
+
+import ROS2Install from '../../../../../common/radxa-os/application-dev/ros-dev/ros2-dev/_install.mdx';
+
+# ROS2 Installation
+
+<ROS2Install board="airbox-q900" />


### PR DESCRIPTION
## Description

Add ROS2 development documentation for AIRbox Q900, following the same structure as Dragon Q6A.

### Changes

- Add `app-dev/ros-dev` section for AIRbox Q900 (Chinese and English)
- Add ROS2 environment setup page (imported from common module)
- Add ROS2 quick start page with Turtlesim example

### Files Changed

- `docs/fogwise/airbox-q900/app-dev/` - Chinese version
- `i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/` - English version

### Verification

- [x] Both Chinese and English versions created
- [x] Content imported from shared common module
- [x] Follows same pattern as Q6A ROS2 docs