### PR TITLE
docs: fix DeepSeek HF download command

### DIFF
--- a/docs/common/dev/_rkllm-deepseek-r1.mdx
+++ b/docs/common/dev/_rkllm-deepseek-r1.mdx
@@ -60,7 +60,7 @@ pip install -U huggingface_hub
 
 ```bash
 cd RK-SDK/rknn-llm/examples/rkllm_api_demo/
-hf download https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --local-dir ./DeepSeek-R1-Distill-Qwen-1.5B
+hf download deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --local-dir ./DeepSeek-R1-Distill-Qwen-1.5B
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkllm-deepseek-r1.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkllm-deepseek-r1.mdx
@@ -60,7 +60,7 @@ pip install -U huggingface_hub
 
 ```bash
 cd RK-SDK/rknn-llm/examples/rkllm_api_demo/
-hf download https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --local-dir ./DeepSeek-R1-Distill-Qwen-1.5B
+hf download deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --local-dir ./DeepSeek-R1-Distill-Qwen-1.5B
 ```
 
 </NewCodeBlock>


### PR DESCRIPTION
## Summary
- fix the `hf download` example in the RKLLM DeepSeek-R1 guide
- update both Chinese and English docs to use the correct Hugging Face repo id format

## Why
The current command uses a full URL with `hf download`, which fails. The CLI expects a repo id such as `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`.

Fixes #1562

## Verification
- confirmed the issue report matches the docs snippet
- updated the zh/en counterpart files
- ran `python3 scripts/github_pr_guard.py check --repo-path ~/radxa-docs/contents --base origin/main` successfully