### PR TITLE
docs: add rkllm qwen2-vl toolchain link

### DIFF
--- a/docs/common/dev/_rkllm_qwen2_vl.mdx
+++ b/docs/common/dev/_rkllm_qwen2_vl.mdx
@@ -151,6 +151,12 @@ bash build-linux.sh
 
 </NewCodeBlock>
 
+如果还没有交叉编译工具链，可从 Arm GNU Toolchain 下载 `10.2-2020.11` 版本：
+<https://developer.arm.com/downloads/-/gnu-a/10-2-2020-11>
+
+下载并解压后，将 `GCC_COMPILER` 指向工具链 `bin` 目录下的 `aarch64-linux-gnu` 前缀即可，例如：
+`/path/to/gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu`
+
 生成的可执行文件在 `install/demo_Linux_aarch64`
 
 ### 板端部署

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkllm_qwen2_vl.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkllm_qwen2_vl.mdx
@@ -151,6 +151,12 @@ bash build-linux.sh
 
 </NewCodeBlock>
 
+If you do not already have a cross-compilation toolchain, you can download Arm GNU Toolchain `10.2-2020.11` here:
+<https://developer.arm.com/downloads/-/gnu-a/10-2-2020-11>
+
+After extracting it, point `GCC_COMPILER` to the `aarch64-linux-gnu` toolchain prefix under the `bin` directory, for example:
+`/path/to/gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu`
+
 The generated binaries are located at `install/demo_Linux_aarch64`.
 
 ### Deploy to the device


### PR DESCRIPTION
## Summary

Add a direct Arm GNU Toolchain download link and a concrete `GCC_COMPILER` example for the RKLLM Qwen2-VL build step.

## Changes

- add the Arm GNU Toolchain `10.2-2020.11` download URL in the Chinese shared doc
- add the matching clarification in the English counterpart
- keep the change limited to the RKLLM Qwen2-VL build section only

## Testing

- `git diff --check`
- `python3 scripts/github_pr_guard.py check --repo-path ~/radxa-docs/docs --fetch`

Fixes #1563
