### PR TITLE
docs: use recommended Arm GNU toolchain for RKLLM install

### DIFF
--- a/docs/common/dev/_rkllm-install.mdx
+++ b/docs/common/dev/_rkllm-install.mdx
@@ -99,7 +99,7 @@ $python3
 
 编译板端运行代码时需要用到交叉编译工具链。
 
-点击下载：[交叉编译工具链](https://developer.arm.com/-/media/files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-x86_64-aarch64-none-linux-gnu.tar.xz?rev=33c6e30e5ac64e6dba8f0431f2c35f1b&revision=33c6e30e-5ac6-4e6d-ba8f-0431f2c35f1b&hash=632C6C0BD43C3E4B59CA8A09A7055D30)。
+点击下载官方推荐版本：[gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu](https://developer.arm.com/downloads/-/gnu-a/10-2-2020-11)。
 
 下载完成之后解压即可。
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkllm-install.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkllm-install.mdx
@@ -99,7 +99,7 @@ $python3
 
 To build the on-device runtime examples, you need a cross-compilation toolchain.
 
-Download: [Cross compilation toolchain](https://developer.arm.com/-/media/files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-x86_64-aarch64-none-linux-gnu.tar.xz?rev=33c6e30e5ac64e6dba8f0431f2c35f1b&revision=33c6e30e-5ac6-4e6d-ba8f-0431f2c35f1b&hash=632C6C0BD43C3E4B59CA8A09A7055D30).
+Download the officially recommended version: [gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu](https://developer.arm.com/downloads/-/gnu-a/10-2-2020-11).
 
 Extract it after downloading.
 


### PR DESCRIPTION
## Summary
- update the RKLLM install page to use the officially recommended Arm GNU toolchain version
- replace the old direct download URL with the recommended Arm GNU toolchain page
- keep Chinese and English docs in sync

Fixes #1567

## Why
The issue reported that the RKLLM install doc should use the officially recommended cross-compilation toolchain version. This PR makes that recommendation explicit and aligns the download link in the shared install snippet.

## Validation
- updated the shared RKLLM install partial in zh/en
- ran `git diff --check`
- ran `python3 scripts/github_pr_guard.py check --repo-path /Users/tomclawz/radxa-docs/contents --fetch`