### PR TITLE
docs: add ZERO 3W v1.12 schematic link

### DIFF
--- a/docs/zero/zero3/download.md
+++ b/docs/zero/zero3/download.md
@@ -14,6 +14,7 @@ Radxa ZERO 3W V1.11 量产版本
 - [v1.11 2D dxf](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_2d_dxf.zip)
 - [v1.11 3D stp](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_3d_stp.zip)
 - [v1.11 原理图 pdf](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_v1110_schematic.pdf)
+- [v1.12 原理图 pdf（AIC8800 版本）](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_v1.12_schematic.pdf)
 - [v1.11 位号图 pdf](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_v1110_smb.zip)
 - [产品简介 pdf](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_product_brief.pdf)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/download.md
@@ -15,6 +15,7 @@ ZERO 3W V1.11 Production Version
 - [v1.11 2D dxf](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_2d_dxf.zip)
 - [v1.11 3D stp](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_3d_stp.zip)
 - [v1.11 Schematic pdf](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_v1110_schematic.pdf)
+- [v1.12 Schematic pdf (AIC8800 version)](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_v1.12_schematic.pdf)
 - [v1.11 Component Placement Diagram zip](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_v1110_smb.zip)
 - [Product brief pdf](https://dl.radxa.com/zero3/docs/hw/3w/radxa_zero_3w_product_brief.pdf)
 


### PR DESCRIPTION
## Summary
- add the missing ZERO 3W v1.12 schematic download link for the AIC8800 version
- mirror the same link in the English download page

## Testing
- verified the new PDF URL returns HTTP 200
- ran `python3 scripts/github_pr_guard.py check --repo-path ~/radxa-docs/contents --fetch`

Fixes #591