### PR TITLE
docs: add ROCK 5 ITX OpenWrt download links

### DIFF
--- a/docs/rock5/rock5itx/download.md
+++ b/docs/rock5/rock5itx/download.md
@@ -51,6 +51,12 @@ Armbian 的默认凭据如下：
 | 用户名 | `root` |
 | 密码   | `1234` |
 
+## OpenWrt
+
+- [OpenWrt 技术数据页面：Radxa ROCK 5 ITX](https://openwrt.org/toh/hwdata/radxa/radxa_rock_5_itx)
+- [Radxa ROCK 5 ITX OpenWrt ext4 sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-5-itx-ext4-sysupgrade.img.gz)
+- [Radxa ROCK 5 ITX OpenWrt squashfs sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-5-itx-squashfs-sysupgrade.img.gz)
+
 ## 百度网盘下载
 
 :::tip

--- a/docs/rock5/rock5itx/other-os/openwrt/install-os.md
+++ b/docs/rock5/rock5itx/other-os/openwrt/install-os.md
@@ -10,7 +10,7 @@ import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-
 <OpenWrtMainline
   product="Radxa ROCK 5 ITX"
   download_page="../../download"
-  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5_itx-ext4-sysupgrade.img.gz"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock-5-itx-ext4-sysupgrade.img.gz"
   power="合适的电源适配器"
   model="rock5itx"
   maskrom_page="../../low-level-dev/maskrom/"

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/download.md
@@ -51,6 +51,12 @@ Default Armbian credentials:
 | Username | `root` |
 | Password | `1234` |
 
+## OpenWrt
+
+- [OpenWrt hardware data page: Radxa ROCK 5 ITX](https://openwrt.org/toh/hwdata/radxa/radxa_rock_5_itx)
+- [Radxa ROCK 5 ITX OpenWrt ext4 sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-5-itx-ext4-sysupgrade.img.gz)
+- [Radxa ROCK 5 ITX OpenWrt squashfs sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-5-itx-squashfs-sysupgrade.img.gz)
+
 ## Quality Certification
 
 ## Reference Documentation

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/other-os/openwrt/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/other-os/openwrt/install-os.md
@@ -10,7 +10,7 @@ import OpenWrtMainline from '../../../../common/other-system/openwrt/\_mainline-
 <OpenWrtMainline
   product="Radxa ROCK 5 ITX"
   download_page="../../download"
-  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock_5_itx-ext4-sysupgrade.img.gz"
+  image_name="openwrt-25.12.0-rockchip-armv8-radxa_rock-5-itx-ext4-sysupgrade.img.gz"
   power="a suitable power adapter"
   model="rock5itx"
   maskrom_page="../../low-level-dev/maskrom/"


### PR DESCRIPTION
## Summary\n- add ROCK 5 ITX OpenWrt ext4/squashfs download links to the download page\n- fix the ROCK 5 ITX OpenWrt install page image filename to match the actual OpenWrt artifact name\n- update both Chinese and English docs\n\n## Source\nThis came from a confirmed support case in the last 24 hours: a colleague pointed out that the ROCK 5 ITX resource download page did not provide the OpenWrt direct download link, while the install page referenced an image name that did not match the real OpenWrt release artifact.\n\n## Why this helps\n- reduces support back-and-forth when users ask for the direct OpenWrt download URL\n- avoids users copying a wrong filename from the install page and hitting 404\n\n## Verification\n- checked the OpenWrt target index for the real ROCK 5 ITX artifact names\n- verified both ext4 and squashfs URLs return HTTP 200\n