### PR TITLE
docs(zero3): fix hardware interface tip formatting

### DIFF
--- a/docs/zero/zero3/hardware-design/hardware-interface.md
+++ b/docs/zero/zero3/hardware-design/hardware-interface.md
@@ -31,7 +31,7 @@ sidebar_position: 4
 
 ZERO 3W/3E 提供了一个40 pin 针脚的 GPIO 座子，与市场上大多数的 SBC 配件兼容。
 
-**提示：实际兼容情况以使用情况为准。**
+**提示：实际兼容性以实际使用情况为准。**
 
 <TabItem value="Zero 3">
      <div className='gpio_style' style={{ overflow :"auto"}}  >

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/hardware-design/hardware-interface.md
@@ -31,7 +31,7 @@ sidebar_position: 4
 
 Radxa ZERO 3 provides a 40-pin GPIO header, which is compatible with most SBC accessories on the market.
 
-**Tips: Actual compatibility is based on usage **
+**Tip: Actual compatibility depends on the use case.**
 
 :::tip
 Pin 3, Pin 5, Pin 27, and Pin 28 add extra pull-up resistors for I2C device power supply, so they work abnormally when used as GPIOs.


### PR DESCRIPTION
## Summary
- fix the malformed tip line on the ZERO 3 hardware interface page so it renders correctly in English
- keep the Chinese and English ZERO 3 hardware interface docs in sync with a matching wording cleanup

## Why
Issue #341 reported that the line `**Tips: Actual compatibility is based on usage **` on the ZERO 3 hardware interface page was missing proper Markdown closure and rendered incorrectly.

## Validation
- ran `git diff --check`
- ran `python3 /Users/tomclawz/.openclaw/workspaces/support/scripts/github_pr_guard.py check --repo-path ~/radxa-docs/contents --fetch`

Fixes #341