### PR TITLE
docs(dragon/q6a): add Baidu Netdisk download link

### DIFF
--- a/docs/dragon/q6a/download.md
+++ b/docs/dragon/q6a/download.md
@@ -59,6 +59,18 @@ sudo dmidecode -s bios-version
 
 :::
 
+## 百度网盘下载
+
+:::tip
+百度网盘分享链接会定期更新镜像文件，推荐通过百度网盘下载获取最新镜像。
+
+**版本说明：**
+- **R 版本**：经过测试的稳定版本，推荐使用
+- **T 版本**：测试版本（仅用于评估）
+:::
+
+- [百度网盘下载（radxa-dragon-q6a）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-dragon-q6a&parentPath=%2Fsharelink3108273493-988411983016443)
+
 ## 启动固件
 
 Dragon Q6A 出厂默认烧录 SPI 启动固件，正常情况下无需烧录启动固件，若系统启动异常，可以尝试重新烧录 SPI 启动固件。


### PR DESCRIPTION
为 radxa-dragon-q6a 添加百度网盘下载链接。

- 链接: https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA
- 文件路径: image-release/radxa-dragon-q6a