### PR TITLE
docs: add Penta SATA HAT 2x5 connector pitch specifications

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -14,6 +14,11 @@ Radxa Penta SATA HAT 有一个 2x5 的座子，座子的信号如下：
 | 7   | GND      | 8   | PWM_33     |
 | 9   | GND      | 10  | NC         |
 
+**技术规格：**
+- **连接器类型：** 2x5 针座子
+- **针距 (Pitch)：** 2.54mm
+- **兼容连接器：** 标准 2.54mm 间距 2x5 针排针 (2x5 pin header, 2.54mm pitch)
+
 这个座子可以用来连接顶板，顶板上有一个 0.91 寸的 OLED 显示屏和一个 4010 风扇，显示屏可以显示 IP 地址和存储信息等，风扇用于散热。
 
 ![SATA HAT top board](/img/accessories/storage/penta/sata-hat-top-board.webp)

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -14,6 +14,11 @@ The Radxa Penta SATA HAT has a 2x5 seat with the following signal:
 | 7   | GND      | 8   | PWM_33     |
 | 9   | GND      | 10  | NC         |
 
+**Technical Specifications:**
+- **Connector Type:** 2x5 pin header
+- **Pitch:** 2.54mm
+- **Compatible Connectors:** Standard 2.54mm pitch 2x5 pin header (2x5 pin header, 2.54mm pitch)
+
 This seat can be used to link to the top plate, which has a 0.91 inch OLED display and a 4010 fan, which can display IP address and storage information, etc., and the fan is used for cooling.
 
 ![SATA HAT top board](/img/accessories/storage/penta/sata-hat-top-board.webp)


### PR DESCRIPTION
## Summary

Add connector pitch specifications for the 2x5 pin header on Radxa Penta SATA HAT top board.

## Why

Based on customer support case (Sam Wolday, Thread ID: `19d4aea0dbb94fa0`), a customer asked about the 2x5 connector pitch for the Penta SATA HAT top board. The current documentation only describes the pin signals but lacks critical mechanical specification – the pitch (spacing between pins) – which is essential for customers who need to source compatible connectors or cables.

Without this information, customers cannot properly connect to the top board's 2x5 header, leading to support inquiries and potential hardware compatibility issues.

## Changes

- **Chinese (`docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md`)**: Added technical specifications section with connector type, pitch (2.54mm), and compatible connector information.
- **English (`i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md`)**: Added the same technical specifications section in English.

## Specifications Added

- **Connector Type:** 2x5 pin header
- **Pitch:** 2.54mm (standard spacing)
- **Compatible Connectors:** Standard 2.54mm pitch 2x5 pin header

## Verification

1. The change is minimal and focused only on adding missing mechanical specifications
2. Both Chinese and English versions have been updated
3. No other documentation changes were made
4. The information addresses a real customer support question

## Source

Customer support email thread: Thread ID `19d4aea0dbb94fa0` (Sam Wolday, Penta SATA Hat 2x5 Pitch question)