### PR TITLE
docs(orion): add script compatibility note for Python version check

### DIFF
--- a/docs/common/orion-common/app-dev/artificial-intelligence/_env-setup.mdx
+++ b/docs/common/orion-common/app-dev/artificial-intelligence/_env-setup.mdx
@@ -66,6 +66,12 @@ bash env_setup.sh
 
 </NewCodeBlock>
 
+:::note[脚本兼容性]
+`env_setup.sh` 脚本会检查 Python 3.10 版本。如果您使用更高版本的 Python（如 Python 3.13），脚本可能会报错。如果遇到此问题，您可以：
+1. 确保使用正确的 Python 3.10 环境：`conda activate noe`
+2. 或者手动安装依赖：`pip install -r requirements.txt CixBuilder-6.1.3407.2-cp310-none-linux_x86_64.whl`
+:::
+
 ### 验证编译环境
 
 在终端运行 `cixbuild -v` 验证编译环境。

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/orion-common/app-dev/artificial-intelligence/_env-setup.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/orion-common/app-dev/artificial-intelligence/_env-setup.mdx
@@ -66,6 +66,12 @@ bash env_setup.sh
 
 </NewCodeBlock>
 
+:::note[Script compatibility]
+The `env_setup.sh` script checks for Python 3.10. If you are using a newer Python version (e.g., Python 3.13), the script may report an error. If you encounter this issue, you can:
+1. Ensure you are using the correct Python 3.10 environment: `conda activate noe`
+2. Or manually install dependencies: `pip install -r requirements.txt CixBuilder-6.1.3407.2-cp310-none-linux_x86_64.whl`
+:::
+
 ### Verify the build environment
 
 Run `cixbuild -v` in the terminal to check the build environment version.


### PR DESCRIPTION
## Summary
Adds a script compatibility note to the Orion O6/O6N AI environment setup page to address Python version check issues reported in #1534.

## Why
Issue #1534 reports that the `env_setup.sh` script fails when users have Python 3.13.12 installed because the script checks for Python 3.10.x. The SDK is only compatible with Python 3.10, but the error message could be confusing for users with newer Python versions.

This PR adds a note explaining:
- The `env_setup.sh` script checks for Python 3.10
- The script may fail with newer Python versions (e.g., 3.13)
- Two workarounds:
  1. Ensure using the correct Python 3.10 environment: `conda activate noe`
  2. Manual installation as fallback: `pip install -r requirements.txt CixBuilder-6.1.3407.2-cp310-none-linux_x86_64.whl`

## Verification
- The note appears in both Chinese and English versions of the page
- Added after the `bash env_setup.sh` command in the "Use the script to set up the development environment" section
- Uses the `:::note[]` admonition format consistent with other notes on the page
- Provides clear, actionable instructions for users encountering the Python version check error

Fixes #1534