### PR TITLE
docs(rock5/rock5itx): add component descriptions under physical image

### DIFF
--- a/docs/rock5/rock5itx/hardware-design/hardware-interface.md
+++ b/docs/rock5/rock5itx/hardware-design/hardware-interface.md
@@ -16,6 +16,13 @@ sidebar_position: 4
 
 <img src="/img/rock5itx/rock5itx-real.webp" width="600" />
 
+**图片说明：**
+- **左上角**：PCIe M.2 M Key 插槽（支持 NVMe SSD）
+- **右上角**：PCIe M.2 E Key 插槽（支持 WiFi/蓝牙模块）
+- **中间**：RK3588 SoC 芯片
+- **下方**：各种接口，包括 HDMI、USB、以太网、SATA 等
+- **边缘**：40-pin GPIO 接口、摄像头接口、LCD 接口等
+
 以下是各个硬件接口的详细接口线序以及说明。
 
 ## TP 接口

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/hardware-design/hardware-interface.md
@@ -16,6 +16,13 @@ sidebar_position: 4
 
 <img src="/img/rock5itx/rock5itx-real.webp" width="600" />
 
+**Image description:**
+- **Top left**: PCIe M.2 M Key slot (supports NVMe SSD)
+- **Top right**: PCIe M.2 E Key slot (supports WiFi/Bluetooth modules)
+- **Center**: RK3588 SoC chip
+- **Bottom**: Various interfaces including HDMI, USB, Ethernet, SATA, etc.
+- **Edges**: 40-pin GPIO interface, camera interface, LCD interface, etc.
+
 The following are the detailed interface wiring sequences and descriptions for each hardware interface.
 
 ## TP Interface


### PR DESCRIPTION
## Summary

Add component descriptions under the physical image on the Rock 5 ITX hardware interface page, as requested in GitHub discussion #1541.

## Why

In GitHub discussion #1541, a user requested descriptions for the components visible in the physical image on the Rock 5 ITX hardware interface page. Currently, the image shows the board layout but lacks any explanatory text to help users identify key components.

This improvement will:
1. Help users quickly identify main components on the Rock 5 ITX board
2. Provide better context for the subsequent interface pinout tables
3. Address a specific user request from the community

## Verification

The changes have been made to both Chinese and English versions of the documentation:
- `docs/rock5/rock5itx/hardware-design/hardware-interface.md`
- `i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/hardware-design/hardware-interface.md`

The added descriptions identify:
- PCIe M.2 M Key slot (NVMe SSD)
- PCIe M.2 E Key slot (WiFi/Bluetooth modules)
- RK3588 SoC chip
- Various interfaces (HDMI, USB, Ethernet, SATA)
- Edge interfaces (40-pin GPIO, camera interface, LCD interface)

These descriptions are based on visible components in the image and align with the existing interface documentation on the page.