### PR TITLE
docs: clarify ROCKPi 4 series naming and full compatibility with Penta SATA HAT

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/README.md
+++ b/docs/accessories/storage/penta-sata-hat/README.md
@@ -20,6 +20,18 @@ sidebar_position: 1
 - ROCK 5A
 - ROCK 5C
 
+:::note
+**ROCKPi 4 系列与 ROCK 4 系列兼容性说明**：ROCKPi 4 系列是早期产品名称，现已统一规范为 ROCK 4 系列。
+
+- ROCKPi 4A = ROCK 4A
+- ROCKPi 4B = ROCK 4B
+- ROCKPi 4A+ = ROCK 4A+
+- ROCKPi 4B+ = ROCK 4B+
+- ROCKPi 4SE = ROCK 4SE
+
+ROCK 4A/4A+/4B/4B+/4SE 与 ROCKPi 4A/4A+/4B/4B+/4SE 兼容性一致，均完全兼容 Penta SATA HAT。如果您的设备标注为 ROCKPi 4A/B/4SE，请参考对应 ROCK 4A/B/4SE 的安装指南。
+:::
+
 目前支持的树莓派型号：
 
 - Raspberry Pi 5

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/README.md
@@ -20,6 +20,18 @@ Currently supported Radxa ROCK Series products:
 - ROCK 5A
 - ROCK 5C
 
+:::note
+**ROCKPi 4 Series vs. ROCK 4 Series Compatibility Note**: ROCKPi 4 series is the early product name, now unified as the ROCK 4 series.
+
+- ROCKPi 4A = ROCK 4A
+- ROCKPi 4B = ROCK 4B
+- ROCKPi 4A+ = ROCK 4A+
+- ROCKPi 4B+ = ROCK 4B+
+- ROCKPi 4SE = ROCK 4SE
+
+ROCK 4A/4A+/4B/4B+/4SE are fully compatible with ROCKPi 4A/4A+/4B/4B+/4SE and all are fully compatible with Penta SATA HAT. If your device is labeled as ROCKPi 4A/B/4SE, please refer to the installation guide for the corresponding ROCK 4A/B/4SE.
+:::
+
 Currently supported Raspberry Pi models:
 
 - Raspberry Pi 5


### PR DESCRIPTION
## Summary

Adds a compatibility note to clarify that the ROCKPi 4 series is an early product name, now unified as the ROCK 4 series. All models (ROCKPi 4A/B/A+/B+/4SE = ROCK 4A/B/A+/B+/4SE) share the same hardware design and are fully compatible with Penta SATA HAT.

## Changes

- **docs/accessories/storage/penta-sata-hat/README.md**: Add Chinese compatibility note for full ROCKPi 4 series (4A/4A+/4B/4B+/4SE) naming unification
- **i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/README.md**: Add English compatibility note matching the Chinese version

## Verification

1. Check the Penta SATA HAT README page (Chinese and English)
2. Look for the compatibility note under 'Currently supported Radxa ROCK Series products'
3. Verify the note covers the full ROCKPi 4 series (4A/4A+/4B/4B+/4SE)

## Related

- PR #1586 closed as duplicate (superseded by this PR)
