### PR TITLE
docs: add note for Penta SATA HAT compatibility issue on latest Raspberry Pi OS (Debian trixie)

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -31,6 +31,17 @@ sudo apt install -y ./rockpi-penta-0.2.2.deb
 
 ### 软件配置
 
+:::note
+**最新 Raspberry Pi OS (Debian trixie) 用户注意**
+
+如果您在最新的 Raspberry Pi OS (Debian trixie) 上遇到以下问题：
+- OLED 显示屏只显示静态消息 "RADXA SATA HAT Loading..."
+- 风扇固定在 100% 功率
+- 服务启动报错 `FileNotFoundError: No such file or directory`
+
+可能需要应用额外的修复。请参考 [GitHub issue #1540](https://github.com/radxa-docs/docs/issues/1540) 中用户报告的解决方案：https://github.com/HabiRabbu/rockpi-penta-pi5-fix
+:::
+
 安装软件包后，如果需要修改配置，可以编辑配置文件 `/etc/rockpi-penta.conf`，下面是配置文件的默认值。
 
 ```ini

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -31,6 +31,17 @@ sudo apt install -y ./rockpi-penta-0.2.2.deb
 
 ### Software configuration
 
+:::note
+**Note for latest Raspberry Pi OS (Debian trixie) users**
+
+If you encounter the following issues on the latest Raspberry Pi OS (Debian trixie):
+- OLED display only shows static message "RADXA SATA HAT Loading..."
+- Fan stuck at 100% power
+- Service startup error `FileNotFoundError: No such file or directory`
+
+Additional fixes may be required. Please refer to the solution reported by users in [GitHub issue #1540](https://github.com/radxa-docs/docs/issues/1540): https://github.com/HabiRabbu/rockpi-penta-pi5-fix
+:::
+
 After installing the package, if you need to modify the configuration, you can edit the configuration file `/etc/rockpi-penta.conf`, the following is the default value of the configuration file.
 
 ```ini


### PR DESCRIPTION
## Summary

Adds a note to the Penta SATA HAT top board documentation about known compatibility issues with the latest Raspberry Pi OS (Debian trixie). This addresses user-reported problems documented in issue #1540.

## Why

Users have reported that on the latest Raspberry Pi OS (Debian trixie), the Penta SATA HAT top board exhibits the following issues:

- OLED display stuck showing static message "RADXA SATA HAT Loading..."
- Fan stuck at 100% power
- Service startup errors with `FileNotFoundError: No such file or directory`

The root cause appears to be changes in the `gpiod` library or system configuration in Debian trixie. While this is primarily a software compatibility issue, it's important to document the problem and provide users with references to known workarounds.

## Verification

1. Both Chinese (docs/) and English (i18n/en/) versions have been updated with the same note
2. The note includes a reference to the user-reported fix repository: https://github.com/HabiRabbu/rockpi-penta-pi5-fix
3. Issue #1540 provides detailed logs and user-reported solution

Fixes #1540
