### PR TITLE
docs: add troubleshooting section for NPU enablement issues

### DIFF
--- a/docs/common/dev/_rknn-install.mdx
+++ b/docs/common/dev/_rknn-install.mdx
@@ -182,6 +182,48 @@ RK356X 产品用户使用 NPU 前需要在终端使用 **rsetup** 开启 NPU: `s
 如 overlays 选项中无 `Enable NPU` 选项，请通过: `sudo rsetup` -> `System` -> `System Update` 升级系统, 重启后执行上述步骤开启 NPU。
 :::
 
+### 故障排除
+
+如果 `Enable NPU` 选项在系统更新后仍然不出现，请尝试以下步骤：
+
+1. **确认系统更新成功**：
+   - 检查 `System Update` 是否完成且没有报错
+   - 确认系统已完全重启（不是休眠或待机）
+
+2. **检查 NPU 驱动状态**：
+   ```bash
+   # 检查 NPU 驱动是否已加载
+   lsmod | grep rknpu
+   # 或使用 dmesg 查看启动日志
+   sudo dmesg | grep -i npu
+   ```
+
+3. **验证镜像版本**：
+   - 确保使用最新版本的 Radxa 官方镜像
+   - 部分早期镜像可能不包含完整的 NPU 支持
+
+4. **手动安装 NPU 驱动**：
+   ```bash
+   # 对于 RK356X 系列
+   sudo apt update
+   sudo apt install rknpu2-rk356x
+   sudo reboot
+   ```
+
+5. **检查硬件兼容性**：
+   - 确认您的设备型号支持 NPU 功能
+   - 某些入门级或特定配置的设备可能没有 NPU 硬件
+
+如果以上步骤仍无法解决问题，请在 Radxa 论坛或 GitHub 仓库提交问题，并附上：
+- 设备型号和镜像版本
+- `sudo dmesg | grep -i npu` 的输出
+- `lsmod | grep rknpu` 的输出
+- `sudo rsetup` 界面的截图（如果可能）
+
+:::info
+Radxa 官方镜像已默认安装 RKNPU2 及其所需依赖，如无法运行可尝试注释命令。
+:::
+
 :::info
 Radxa 官方镜像已默认安装 RKNPU2 及其所需依赖，如无法运行可尝试注释命令。
 :::

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rknn-install.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rknn-install.mdx
@@ -183,6 +183,48 @@ For RK356X products, you must enable the NPU with **rsetup** before using it:
 If there is no `Enable NPU` option in `Overlays`, please run: `sudo rsetup` -> `System` -> `System Update` to upgrade the system, then reboot and repeat the steps above to enable the NPU.
 :::
 
+### Troubleshooting
+
+If the `Enable NPU` option does not appear even after a system update, try the following steps:
+
+1. **Confirm the system update succeeded**:
+   - Verify that `System Update` completed without errors
+   - Ensure the system was fully rebooted (not just suspended or hibernated)
+
+2. **Check NPU driver status**:
+   ```bash
+   # Check if the NPU driver is loaded
+   lsmod | grep rknpu
+   # Or check the boot logs with dmesg
+   sudo dmesg | grep -i npu
+   ```
+
+3. **Verify image version**:
+   - Make sure you are using the latest Radxa official image
+   - Some earlier images may not include full NPU support
+
+4. **Manually install the NPU driver**:
+   ```bash
+   # For RK356X series
+   sudo apt update
+   sudo apt install rknpu2-rk356x
+   sudo reboot
+   ```
+
+5. **Check hardware compatibility**:
+   - Confirm that your device model supports NPU functionality
+   - Some entry-level or specific configurations may not have NPU hardware
+
+If the problem persists after trying these steps, please submit an issue on the Radxa forum or GitHub repository, and include:
+- Device model and image version
+- Output of `sudo dmesg | grep -i npu`
+- Output of `lsmod | grep rknpu`
+- Screenshot of the `sudo rsetup` interface (if possible)
+
+:::info
+Radxa official images come with RKNPU2 and its required dependencies preinstalled. If you encounter issues running NPU workloads, you can try uncommenting and executing the following commands.
+:::
+
 :::info
 Radxa official images come with RKNPU2 and its required dependencies preinstalled. If you encounter issues running NPU workloads, you can try uncommenting and executing the following commands.
 :::


### PR DESCRIPTION
## Summary
Adds a troubleshooting section to the RKNN installation guide for when the "Enable NPU" option does not appear in rsetup even after system update.

## Why
Based on issue #1383, users have reported that the "Enable NPU" option sometimes remains missing after following the documented steps (system update + reboot). This troubleshooting section provides additional steps to diagnose and resolve the issue, including:
- Confirming system update success
- Checking NPU driver status
- Verifying image version
- Manual NPU driver installation
- Hardware compatibility check
- Guidance for submitting bug reports

## Verification
1. The changes are docs-only and affect only the RKNN installation guide
2. Both Chinese and English versions are updated
3. The troubleshooting steps are based on common support scenarios
4. The PR follows the bilingual check (both docs/ and i18n/en updated)

Fixes #1383
