### PR TITLE
docs: add PureOS reference for ROCK 3A

### DIFF
--- a/docs/rock3/rock3a/other-os/README.md
+++ b/docs/rock3/rock3a/other-os/README.md
@@ -4,6 +4,6 @@ sidebar_position: 45
 
 # 其他系统
 
-介绍非 Radxa OS 的其他系统，例如 Android
+介绍非 Radxa OS 的其他系统，例如 Android、OpenWrt 等
 
 <DocCardList />

--- a/docs/rock3/rock3a/other-os/pureos/README.md
+++ b/docs/rock3/rock3a/other-os/pureos/README.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 3
+---
+
+# PureOS
+
+PureOS 是一个基于 Debian 的自由软件发行版，由 Purism 公司开发，专注于隐私和安全。
+
+## 支持状态
+
+**目前 PureOS 没有针对 ROCK 3A 的官方支持或预构建镜像。**
+
+## 替代方案
+
+如果你希望在 ROCK 3A 上使用类似 PureOS 的自由软件环境，可以考虑以下替代方案：
+
+### 1. Debian
+- **官方支持**：Radxa 为 ROCK 3A 提供官方的 Debian 镜像
+- **兼容性**：由于 PureOS 基于 Debian，大部分 Debian 软件包在 ROCK 3A 上都能正常工作
+- **获取方式**：从 [Radxa 下载页面](https://docs.radxa.com/rock3/rock3a/download) 获取最新的 Debian 镜像
+
+### 2. 从源代码构建
+如果你希望尝试在 ROCK 3A 上运行 PureOS，可以：
+1. 从 PureOS 官网获取源代码
+2. 使用 ROCK 3A 的 Debian 内核配置作为基础
+3. 参考 Debian 的安装指南进行适配
+
+## 已知限制
+
+1. **硬件支持**：PureOS 可能不包含 ROCK 3A 特定的硬件驱动
+2. **内核配置**：需要针对 ROCK 3A 的 Rockchip RK3568 处理器进行内核配置调整
+3. **引导加载程序**：可能需要手动配置 U-Boot 引导加载程序
+
+## 社区资源
+
+如果你在 ROCK 3A 上尝试安装 PureOS，可以关注以下社区资源：
+- [Radxa 论坛](https://forum.radxa.com/)
+- [Purism 社区](https://forums.puri.sm/)
+- [Debian ARM 移植页面](https://www.debian.org/ports/arm64/)
+
+## 反馈与帮助
+
+如果你在 ROCK 3A 上成功安装了 PureOS，或者遇到了特定的技术问题，欢迎：
+1. 在 [GitHub Issues](https://github.com/radxa-docs/docs/issues) 分享你的经验
+2. 在 [Radxa 论坛](https://forum.radxa.com/) 与其他用户讨论
+3. 为本文档提交改进建议

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/README.md
@@ -2,8 +2,8 @@
 sidebar_position: 45
 ---
 
-# Other System
+# Other Systems
 
-Introduces other systems than Radxa OS, such as Android.
+Introduces other systems than Radxa OS, such as Android, OpenWrt, etc.
 
 <DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/pureos/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/other-os/pureos/README.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 3
+---
+
+# PureOS
+
+PureOS is a free software distribution based on Debian, developed by Purism with a focus on privacy and security.
+
+## Support Status
+
+**Currently, there is no official support or pre-built images of PureOS for ROCK 3A.**
+
+## Alternative Solutions
+
+If you want to use a free software environment similar to PureOS on ROCK 3A, consider the following alternatives:
+
+### 1. Debian
+- **Official Support**: Radxa provides official Debian images for ROCK 3A
+- **Compatibility**: Since PureOS is based on Debian, most Debian packages should work on ROCK 3A
+- **How to Get**: Download the latest Debian image from the [Radxa Download Page](https://docs.radxa.com/rock3/rock3a/download)
+
+### 2. Build from Source
+If you want to try running PureOS on ROCK 3A, you can:
+1. Get the source code from the PureOS website
+2. Use ROCK 3A's Debian kernel configuration as a base
+3. Refer to Debian installation guides for adaptation
+
+## Known Limitations
+
+1. **Hardware Support**: PureOS may not include ROCK 3A specific hardware drivers
+2. **Kernel Configuration**: Kernel configuration adjustments are needed for ROCK 3A's Rockchip RK3568 processor
+3. **Bootloader**: Manual configuration of U-Boot bootloader may be required
+
+## Community Resources
+
+If you're attempting to install PureOS on ROCK 3A, check out these community resources:
+- [Radxa Forum](https://forum.radxa.com/)
+- [Purism Community](https://forums.puri.sm/)
+- [Debian ARM Port Page](https://www.debian.org/ports/arm64/)
+
+## Feedback & Help
+
+If you successfully install PureOS on ROCK 3A, or encounter specific technical issues, please:
+1. Share your experience on [GitHub Issues](https://github.com/radxa-docs/docs/issues)
+2. Discuss with other users on the [Radxa Forum](https://forum.radxa.com/)
+3. Submit improvement suggestions for this documentation


### PR DESCRIPTION
## Summary

Add documentation for PureOS support status on ROCK 3A, addressing user inquiry in issue #1300.

## Why

A user asked about PureOS support for ROCK 3A through the GitHub issue system. The current documentation only covers Android and OpenWrt, leaving a gap for users interested in other operating systems like PureOS.

This documentation update:
1. Clarifies that there is no official PureOS support for ROCK 3A
2. Provides alternative solutions (Debian, building from source)
3. Lists known limitations and community resources
4. Helps users make informed decisions about operating system choices

## Verification

1. **Documentation structure**: The new PureOS page follows the same structure as other "other-os" pages
2. **Bilingual updates**: Both Chinese and English versions are included
3. **Navigation**: The page is properly linked in the documentation hierarchy
4. **Content accuracy**: Information is factual and provides clear guidance to users

Fixes #1300