### PR TITLE
docs: add M.2 key types and protocol support table

### DIFF
--- a/docs/accessories/storage/m2-extension-board.md
+++ b/docs/accessories/storage/m2-extension-board.md
@@ -2,11 +2,29 @@
 sidebar_position: 17
 ---
 
-# PCIe E Key
+# M.2 接口与 PCIe E Key
 
-## 简介
+## M.2 接口概述
 
-PCIe E Key 是用于连接嵌入式设备的接口，通常用于连接存储卡、WiFi 模块、蓝牙模块等设备。
+M.2 接口有多种 key 类型，每种支持不同的协议：
+
+| Key 类型 | 支持的协议 | 主要用途 |
+|----------|------------|----------|
+| **M Key** | PCIe x4, SATA (部分) | NVMe SSD, 高性能存储 |
+| **B Key** | PCIe x2, SATA, USB | SATA SSD, USB 设备, 无线模块 |
+| **B+M Key** | PCIe x2, SATA | 兼容性 SSD (同时有 B 和 M 缺口) |
+| **E Key** | PCIe x1, USB, I2C, SDIO | 无线网卡 (WiFi/BT), LTE 模块 |
+| **A Key** | PCIe x2, USB, DP, I2C | 无线网卡, WWAN 模块 |
+
+**关键区别：**
+- **M Key**：主要用于高速 NVMe SSD，支持 PCIe x4 通道
+- **B Key**：主要用于 SATA SSD 或 USB 设备，支持 PCIe x2 通道
+- **B+M Key**：兼容设计，可在 M Key 或 B Key 插槽中使用，但性能受限于 B Key 的 PCIe x2
+- **E Key**：主要用于无线通信模块 (WiFi/蓝牙)
+
+## PCIe E Key 简介
+
+PCIe E Key 是 M.2 接口的一种，专门用于连接嵌入式设备，通常用于连接存储卡、WiFi 模块、蓝牙模块等设备。
 
 ## 支持的配件
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/m2-extension-board.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/m2-extension-board.md
@@ -14,6 +14,24 @@ Radxa M.2 Extension Boards are solutions for expanding the storage capacity of e
 - M.2 M key connector, support M key SSD and B&M key SSD
 - Support 2280 / 2260 / 2242 / 2230 M.2 SSD
 
+## M.2 Key Types and Protocol Support
+
+M.2 interfaces come with different key types, each supporting specific protocols:
+
+| Key Type | Supported Protocols | Primary Use |
+|----------|---------------------|-------------|
+| **M Key** | PCIe x4, SATA (some) | NVMe SSD, high-performance storage |
+| **B Key** | PCIe x2, SATA, USB | SATA SSD, USB devices, wireless modules |
+| **B+M Key** | PCIe x2, SATA | Compatibility SSD (has both B and M notches) |
+| **E Key** | PCIe x1, USB, I2C, SDIO | Wireless cards (WiFi/BT), LTE modules |
+| **A Key** | PCIe x2, USB, DP, I2C | Wireless cards, WWAN modules |
+
+**Key Differences:**
+- **M Key**: Primarily for high-speed NVMe SSDs, supports PCIe x4 lanes
+- **B Key**: Primarily for SATA SSDs or USB devices, supports PCIe x2 lanes
+- **B+M Key**: Compatible design, can be used in both M Key and B Key slots, but performance is limited to B Key's PCIe x2
+- **E Key**: Primarily for wireless communication modules (WiFi/Bluetooth)
+
 ## Package List
 
 - 1 x Radxa M.2 Extension Board


### PR DESCRIPTION
## Summary

Adds comprehensive table explaining different M.2 key types (M Key, B Key, B+M Key, E Key, A Key) and their supported protocols (PCIe, SATA, USB, etc.) as requested in issue #691.

## Why

Issue #691 reports that users need clarification on which protocols are supported by different M.2 key types. Specifically:
- M Key supports SATA and PCIe
- B Key supports USB and PCIe

This information helps users choose compatible accessories for their Radxa products.

## Changes

1. Added M.2 interface overview section in  (Chinese)
2. Added corresponding section in  (English)
3. Includes detailed table explaining key types and their supported protocols

## Verification

- Table provides clear information about M.2 key types
- Both Chinese and English versions are updated
- Information is accurate based on M.2 specification

Fixes: #691