### PR TITLE
docs: add note about checking image-specific default credentials

### DIFF
--- a/docs/common/radxa-os/_basicSoftwareConf.mdx
+++ b/docs/common/radxa-os/_basicSoftwareConf.mdx
@@ -19,6 +19,10 @@ import RemoteAccess from "../radxa-os/_remote-access.mdx";
   </tr>
 </table>
 
+:::note
+这些是大多数 Radxa 系统镜像的默认凭据。如果这些凭据不工作，请检查你所使用镜像的发布说明，某些特定镜像版本可能使用不同的默认凭据。如果仍然无法登录，建议通过串口控制台进行故障排除。
+:::
+
 ## 更新系统
 
 请参考 <a href={props.rsetup_path}>System Update</a>部分更新系统。

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_basicSoftwareConf.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_basicSoftwareConf.mdx
@@ -19,6 +19,10 @@ import RemoteAccess from "../radxa-os/_remote-access.mdx";
   </tr>
 </table>
 
+:::note
+These are the default credentials for most Radxa system images. If these credentials don't work, please check the release notes for the specific image you're using, as some image versions may use different default credentials. If you still can't log in, we recommend troubleshooting via serial console.
+:::
+
 ## Updating the system
 
 See the <a href={props.rsetup_path}> System Update </a> section to update your system.


### PR DESCRIPTION
## Summary

Adds a note to the Username and password section in the basic software configuration documentation to address issue #1141 where users reported default credentials not working for specific image versions.

## Why

Issue #1141 reported that the default credentials (`radxa`/`radxa` and `rock`/`rock`) don't work for the `rock-5b-plus_bookworm_kde_b2.output.img.xz` image. This highlights a documentation gap where users may not be aware that specific image versions could have different default credentials.

## Changes

- Added a note in both Chinese and English versions of `_basicSoftwareConf.mdx`
- The note advises users to check release notes for image-specific credentials if default credentials don't work
- Also recommends using serial console for troubleshooting

## Verification

1. The note appears after the username/password table in the basic software configuration section
2. Both Chinese and English versions are updated
3. The change is minimal and focused on addressing the specific issue reported

Fixes #1141