### PR TITLE
docs(orion): add FAQ for USB3 bulk transfer disconnect/re-enumeration issue

### DIFF
--- a/docs/orion/faq.md
+++ b/docs/orion/faq.md
@@ -49,3 +49,54 @@ sudo reboot
 </NewCodeBlock>
 
 说明：禁用后将释放 NPU 预留内存，如需恢复，删除 blacklist 配置并重启即可。
+
+## 2.Orion O6 USB3 批量传输导致设备断开/重新枚举问题
+
+在使用 Cypress FX3（VID:PID 04b4:00f1）等 USB3 设备进行高吞吐量批量传输时，Orion O6 可能出现设备断开并重新枚举的问题。
+
+### 症状
+- 设备在持续高吞吐量 USB 批量传输期间断开连接并重新枚举
+- 错误信息：`LIBUSB_ERROR_NO_DEVICE`
+- dmesg 显示：`usb 6-1: USB disconnect, device number 3` → `usb 6-1: new SuperSpeed USB device number 4 using xhci-hcd`
+
+### 可能原因
+1. **电源供应不足**：USB3.2 Type-A 端口电流限制为 1A，高功耗设备可能超出此限制
+2. **线缆质量**：USB3 线缆质量不佳或长度过长可能导致信号完整性问题
+3. **xHCI 驱动/固件问题**：xHCI 控制器在高负载下可能出现稳定性问题
+4. **USB3 链路管理**：USB3 链路电源管理（U1/U2 状态）可能导致不稳定
+
+### 排查步骤
+1. **检查电源**：
+   - 使用专用 12V/3A 或更高功率的电源适配器
+   - 避免使用 USB 集线器为高功耗设备供电
+2. **更换线缆和端口**：
+   - 使用高质量、短距离的 USB3 线缆
+   - 尝试不同的 USB3.2 Type-A 端口
+3. **检查系统日志**：
+   ```bash
+   dmesg | grep -i "usb\|xhci"
+   journalctl -k | grep -i "usb\|xhci"
+   ```
+4. **禁用 USB 自动挂起和链路电源管理**：
+   ```bash
+   # 临时禁用 USB 自动挂起
+   for dev in /sys/bus/usb/devices/*/power/control; do
+     echo on > "$dev" 2>/dev/null || true
+   done
+   
+   # 禁用 USB3 链路电源管理（需在启动参数中添加）
+   # 在 /boot/extlinux/extlinux.conf 的 append 行添加：
+   # usbcore.autosuspend=-1 usbcore.quirks=vid:pid:u
+   ```
+
+### 解决方案
+1. **使用外接供电的 USB3 集线器**：为高功耗 USB3 设备提供独立电源
+2. **更新 BIOS 和内核**：检查是否有可用的 BIOS 更新或内核补丁
+3. **调整传输参数**：降低批量传输的数据速率或使用较小的数据包
+4. **联系技术支持**：如果问题持续存在，请联系 Radxa 技术支持并提供详细的系统日志
+
+### 已知兼容性问题
+- Cypress FX3（VID:PID 04b4:00f1）在高吞吐量批量传输时可能出现此问题
+- 某些 USB3 存储设备在持续写入时可能触发断开/重新枚举
+
+**注意**：此问题可能与特定硬件组合相关，建议在购买 USB3 外设前验证其与 Orion O6 的兼容性。

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/faq.md
@@ -49,3 +49,54 @@ sudo reboot
 </NewCodeBlock>
 
 Note: Disabling will free the memory reserved for NPU. To restore, delete the blacklist configuration and reboot.
+
+## 2.Orion O6 USB3 Bulk Transfer Causes Device Disconnect/Re-enumeration
+
+When using USB3 devices like Cypress FX3 (VID:PID 04b4:00f1) for high-throughput bulk transfers, Orion O6 may experience device disconnection and re-enumeration.
+
+### Symptoms
+- Device disconnects and re-enumerates during sustained high-throughput USB bulk transfers
+- Error: `LIBUSB_ERROR_NO_DEVICE`
+- dmesg shows: `usb 6-1: USB disconnect, device number 3` → `usb 6-1: new SuperSpeed USB device number 4 using xhci-hcd`
+
+### Possible Causes
+1. **Insufficient Power Supply**: USB3.2 Type-A ports have a 1A current limit, high-power devices may exceed this limit
+2. **Cable Quality**: Poor quality or excessively long USB3 cables may cause signal integrity issues
+3. **xHCI Driver/Firmware Issues**: xHCI controller may exhibit stability issues under high load
+4. **USB3 Link Management**: USB3 link power management (U1/U2 states) may cause instability
+
+### Troubleshooting Steps
+1. **Check Power Supply**:
+   - Use a dedicated 12V/3A or higher power adapter
+   - Avoid powering high-power devices through USB hubs
+2. **Replace Cables and Ports**:
+   - Use high-quality, short-length USB3 cables
+   - Try different USB3.2 Type-A ports
+3. **Check System Logs**:
+   ```bash
+   dmesg | grep -i "usb\|xhci"
+   journalctl -k | grep -i "usb\|xhci"
+   ```
+4. **Disable USB Autosuspend and Link Power Management**:
+   ```bash
+   # Temporarily disable USB autosuspend
+   for dev in /sys/bus/usb/devices/*/power/control; do
+     echo on > "$dev" 2>/dev/null || true
+   done
+   
+   # Disable USB3 link power management (add to boot parameters)
+   # Add to the append line in /boot/extlinux/extlinux.conf:
+   # usbcore.autosuspend=-1 usbcore.quirks=vid:pid:u
+   ```
+
+### Solutions
+1. **Use Externally Powered USB3 Hub**: Provide independent power for high-power USB3 devices
+2. **Update BIOS and Kernel**: Check for available BIOS updates or kernel patches
+3. **Adjust Transfer Parameters**: Reduce data rate for bulk transfers or use smaller packets
+4. **Contact Technical Support**: If the issue persists, contact Radxa technical support with detailed system logs
+
+### Known Compatibility Issues
+- Cypress FX3 (VID:PID 04b4:00f1) may experience this issue during high-throughput bulk transfers
+- Some USB3 storage devices may trigger disconnect/re-enumeration during sustained write operations
+
+**Note**: This issue may be specific to certain hardware combinations. It's recommended to verify compatibility with Orion O6 before purchasing USB3 peripherals.


### PR DESCRIPTION
## Summary
Add FAQ entry for Orion O6 USB3 bulk transfer disconnect/re-enumeration issue.

## Why
GitHub issue #1251 reported that Orion O6 experiences USB3 device disconnection and re-enumeration during high-throughput bulk transfers, particularly with Cypress FX3 (VID:PID 04b4:00f1) devices. This FAQ entry provides troubleshooting guidance for users encountering similar issues.

The FAQ includes:
- Detailed symptom description
- Possible causes (power supply, cable quality, xHCI driver/firmware issues, USB3 link management)
- Step-by-step troubleshooting procedures
- Workarounds and solutions
- Known compatibility issues

## Verification
- Added FAQ entry in both Chinese (`docs/orion/faq.md`) and English (`i18n/en/docusaurus-plugin-content-docs/current/orion/faq.md`)
- Content is based on the detailed technical report in issue #1251
- Follows standard FAQ format used in other Radxa documentation
- Provides actionable troubleshooting steps for users

Fixes #1251