### PR TITLE
docs: fix qai-appbuilder symlink path issue #1602

### DIFF
--- a/docs/common/ai/_qai-appbuilder.mdx
+++ b/docs/common/ai/_qai-appbuilder.mdx
@@ -123,6 +123,7 @@ pip3 install ./qai_appbuilder-2.34.0-cp312-cp312-linux_aarch64.whl
 <NewCodeBlock tip="Device" type="device">
 
 ```bash
+cd ../../
 ln -s qairt/2.37.1.250807/lib/aarch64-oe-linux-gcc11.2/ ai-engine-direct-helper/samples/python/qai_libs
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_qai-appbuilder.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_qai-appbuilder.mdx
@@ -126,6 +126,7 @@ Create a `qai_libs` symlink in `ai-engine-direct-helper/samples/python` to link 
 <NewCodeBlock tip="Device" type="device">
 
 ```bash
+cd ../../
 ln -s qairt/2.37.1.250807/lib/aarch64-oe-linux-gcc11.2/ ai-engine-direct-helper/samples/python/qai_libs
 ```
 


### PR DESCRIPTION
## Summary
Fix the symlink command in QAI AppBuilder documentation where the current directory is `ai-engine-direct-helper/dist` after installing the wheel, causing the symlink creation to fail.

## Why
GitHub issue #1602 reported that in step 1.5 "Create QAIRT SDK LIB Symlink", after installing the wheel, the current directory is `ai-engine-direct-helper/dist`. The existing command `ln -s qairt/2.37.1.250807/lib/aarch64-oe-linux-gcc11.2/ ai-engine-direct-helper/samples/python/qai_libs` fails with error:
```
ln: failed to create symbolic link 'ai-engine-direct-helper/samples/python/qai_libs': No such file or directory
```

This happens because the command assumes the user is in the root directory, but after installing the wheel, the user is still in the `dist` subdirectory.

The fix adds `cd ../../` before the `ln` command to ensure the correct working directory.

## Verification
- Added `cd ../../` before the symlink command in both Chinese (`docs/common/ai/_qai-appbuilder.mdx`) and English (`i18n/en/docusaurus-plugin-content-docs/current/common/ai/_qai-appbuilder.mdx`) versions
- The fix ensures users are in the correct directory before creating the symlink
- Maintains backward compatibility with existing workflow
- Follows the user's suggestion to address the directory path issue

Fixes #1602