### PR TITLE
fix: links in Rock 5B Android install-os tutorial

### DIFF
--- a/docs/rock5/rock5b/other-os/android/install-os.md
+++ b/docs/rock5/rock5b/other-os/android/install-os.md
@@ -14,7 +14,7 @@ ROCK 5B/5B+ 可以从 microSD 卡启动，也可以从 EMMC 启动，还可以�
 
 ### 清除 SPI Flash
 
-在使用 microSD 卡/ eMMC 启动时，如果SPI Flash 里面有数据，需要先清空 SPI Flash，参考 [清除 SPI Flash](../../low-level-dev/maskrom/erase)。
+在使用 microSD 卡/ eMMC 启动时，如果SPI Flash 里面有数据，需要先清空 SPI Flash，参考 [清除 SPI Flash](../../getting-started/install-os/erase_spi-flash)。
 
 <details>
 
@@ -37,7 +37,7 @@ ROCK 5B/5B+ 可以从 microSD 卡启动，也可以从 EMMC 启动，还可以�
 
 - 1x microSD 卡(容量 >=8GB)
 - 1x microSD 读卡器
-- 5V 电源适配器 (推荐使用 [Radxa Power PD30W](../../../../accessories/power/pd_30w))
+- 5V 电源适配器 (推荐使用 [Radxa Power PD30W](https://radxa.com/products/accessories/power-pd-30w))
 
 #### 安装系统
 
@@ -49,7 +49,7 @@ ROCK 5B/5B+ 可以从 microSD 卡启动，也可以从 EMMC 启动，还可以�
 - Radxa ROCK 5B/5B+ 的供电接口为 [USB 2.0 OTG Type C port](../../hardware-design/hardware-interface)，请使用 Type-C 线缆连接供电口和适配器。
 
 :::tip
-ROCK 5B/5B+ 支持 9V/2A、12V/2A、15V/2A 和 20V/2A 的 USB Type-C PD 2.0。瑞莎推荐使用 [Radxa Power PD30W](../../../../accessories/power/pd_30w)。
+ROCK 5B/5B+ 支持 9V/2A、12V/2A、15V/2A 和 20V/2A 的 USB Type-C PD 2.0。瑞莎推荐使用 [Radxa Power PD30W](https://radxa.com/products/accessories/power-pd-30w)。
 :::
 
 #### 参考文档
@@ -73,7 +73,7 @@ ROCK 5B/5B+ 支持 9V/2A、12V/2A、15V/2A 和 20V/2A 的 USB Type-C PD 2.0。�
 
 #### Linux 系统使用 rkdeveloptool 写入
 
-[rkdeveloptool](../../low-level-dev/maskrom/linux)
+[rkdeveloptool](../../low-level-dev/install-os/rkdevtool-emmc?platform=Linux+%2F+macOS)
 
 </TabItem>
 
@@ -81,7 +81,7 @@ ROCK 5B/5B+ 支持 9V/2A、12V/2A、15V/2A 和 20V/2A 的 USB Type-C PD 2.0。�
 
 #### Mac 系统使用 rkdeveloptool 写入
 
-[rkdeveloptool](../../low-level-dev/maskrom/mac-os)
+[rkdeveloptool](../../low-level-dev/install-os/rkdevtool-emmc?platform=Linux+%2F+macOS)
 
 </TabItem>
 
@@ -89,7 +89,7 @@ ROCK 5B/5B+ 支持 9V/2A、12V/2A、15V/2A 和 20V/2A 的 USB Type-C PD 2.0。�
 
 #### Windows 系统使用 rkdevtool 写入
 
-[rkdevtool](../../low-level-dev/maskrom/windows)
+[rkdevtool](../../low-level-dev/install-os/rkdevtool-emmc?platform=Windows)
 
 </TabItem>
 
@@ -115,26 +115,6 @@ ROCK 5B/5B+ 支持 9V/2A、12V/2A、15V/2A 和 20V/2A 的 USB Type-C PD 2.0。�
 请到 [资源下载中心](../../download) 下载对应的镜像文件
 
 #### 系统安装
-
-<Tabs queryString="target">
-
-<TabItem value="linux" label="Linux(适用于 Rock5B)">
-
-#### Linux 系统使用 rkdeveloptool 写入
-
-[rkdeveloptool](../../low-level-dev/maskrom/linux)
-
-</TabItem>
-
-<TabItem value="mac" label="mac(适用于Rock 5B)">
-
-#### Mac 系统使用 rkdeveloptool 写入
-
-[rkdeveloptool](../../low-level-dev/maskrom/mac-os)
-
-</TabItem>
-
-<TabItem value="windows" label="Windows（适用于Rock 5B/5B+）">
 
 ##### 安装 RKDevTool
 
@@ -163,10 +143,6 @@ RKDevTool 是 Rockchip 为 Windows 平台下进行 USB 烧录所开发的软件�
 ##### 按照以下操作烧入镜像
 
 ![RK Android update](/img/rock5itx/rock5itx_android_update_zh.webp)
-
-</TabItem>
-
-</Tabs>
 
 #### 启动 ROCK 5B/5B+
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/other-os/android/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/other-os/android/install-os.md
@@ -14,7 +14,7 @@ ROCK 5B/5B+ can be booted from microSD card or EMMC, depending on the boot metho
 
 ### Erase SPI Flash
 
-Before using a microSD card/eMMC to boot an SBC with SPI Flash, If there is data in SPI Flash, the SPI Flash needs to be erased. Refer to [Erase SPI Flash](../../low-level-dev/maskrom/erase)
+Before using a microSD card/eMMC to boot an SBC with SPI Flash, If there is data in SPI Flash, the SPI Flash needs to be erased. Refer to [Erase SPI Flash](../../getting-started/install-os/erase_spi-flash)
 
 <details>
 
@@ -42,7 +42,7 @@ For scenarios where an NVMe drive is needed to boot the system, the SPI Flash im
 
 - 1x microSD card (capacity >=8GB)
 - 1x microSD card reader
-- 5V power adapter (Recommended [Radxa Power PD30W](../../../../accessories/power/pd_30w))
+- 5V power adapter (Recommended [Radxa Power PD30W](https://radxa.com/products/accessories/power-pd-30w))
 
 #### Image Download
 
@@ -58,7 +58,7 @@ Please go to [Resource Download](../../download) to download the corresponding i
 - The power supply interface of Radxa ROCK 5B is [USB 2.0 OTG Type C port](../../hardware-design/hardware-interface), please connect the power supply port and the adapter with Type-C cable.
 
 :::tip
-The ROCK 5B/5B+ supports USB Type-C PD 2.0 at 9V/2A, 12V/2A, 15V/2A and 20V/2A. Radxa recommends using the [Radxa Power PD30W](../../../../accessories/power/pd_30w).
+The ROCK 5B/5B+ supports USB Type-C PD 2.0 at 9V/2A, 12V/2A, 15V/2A and 20V/2A. Radxa recommends using the [Radxa Power PD30W](https://radxa.com/products/accessories/power-pd-30w).
 :::
 
 #### Reference Documentation
@@ -86,7 +86,7 @@ Please go to [Resource Download](../../download) to download the corresponding i
 
 #### Linux systems are written using rkdeveloptool
 
-[rkdeveloptool](../../low-level-dev/maskrom/linux)
+[rkdeveloptool](../../low-level-dev/install-os/rkdevtool-emmc?platform=Linux+%2F+macOS)
 
 </TabItem>
 
@@ -94,7 +94,7 @@ Please go to [Resource Download](../../download) to download the corresponding i
 
 #### Mac systems are written using rkdeveloptool
 
-[rkdeveloptool](../../low-level-dev/maskrom/mac-os)
+[rkdeveloptool](../../low-level-dev/install-os/rkdevtool-emmc?platform=Linux+%2F+macOS)
 
 </TabItem>
 
@@ -102,7 +102,7 @@ Please go to [Resource Download](../../download) to download the corresponding i
 
 #### Windows systems write with rkdevtool
 
-[rkdevtool](../../low-level-dev/maskrom/windows)
+[rkdevtool](../../low-level-dev/install-os/rkdevtool-emmc?platform=Windows)
 
 </TabItem>
 
@@ -128,28 +128,6 @@ Please go to [Resource Download](../../download) to download the corresponding i
 Please go to [Resource Download](../../download) to download the corresponding image file.
 
 #### System Installation
-
-#### Install the system
-
-<Tabs queryString="target">
-
-<TabItem value="linux" label="Linux(Rock 5B)">
-
-#### Linux systems are written using rkdeveloptool
-
-[rkdeveloptool](../../low-level-dev/maskrom/linux)
-
-</TabItem>
-
-<TabItem value="mac" label="Mac(Rock 5B)">
-
-#### Mac systems are written using rkdeveloptool
-
-[rkdeveloptool](../../low-level-dev/maskrom/mac-os)
-
-</TabItem>
-
-<TabItem value="windows" label="Windows(Rock 5B/5B+)">
 
 #### Install RKDevTool
 
@@ -178,10 +156,6 @@ unzip RKDevTool_Release_v2.96_zh.zip ，click RKDevTool.exe to open.
 ##### Follow the steps below to flash the operation image
 
 ![RK Android update](/img/rock5itx/rock5itx_android_update_en.webp)
-
-</TabItem>
-
-</Tabs>
 
 #### Boot the system
 


### PR DESCRIPTION
## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
