### PR TITLE
docs: Move multiple DT overlay note to more prominent position in NIO 12L Ubuntu User Guide

### DIFF
--- a/docs/nio/nio12l/ubuntu/ubuntu-user-guide.md
+++ b/docs/nio/nio12l/ubuntu/ubuntu-user-guide.md
@@ -87,6 +87,19 @@ $ genio-flash board-assets
 
 断电重启设备后，将会看到 8HD 触摸屏显示桌面。
 
+## 同时启用多个 DT overlay
+
+用户可以同时打开多个 dt overlay，如：
+
+```text
+list_dtbo= gpu-mali.dtbo video.dtbo ddr-8g.dtbo i2c3.dtbo i2c4.dtbo gpio104-pwm.dtbo spi1-spidev.dtbo spi2-spidev.dtbo
+```
+
+这样可以在一次配置中启用多个硬件功能，无需多次修改 `u-boot-initial-env` 文件。
+
+
+
+
 ## 常用硬件接口 I2C, UART, SPI, etc
 
 NIO 12L 有一个 40-PIN 的扩展座子。UART1 和 PWM 没法同时用。
@@ -421,10 +434,3 @@ NeuroPilot Neuron SDK 主要支持以下模型格式：
 
 - [NeuroPilot 主页](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/ai-experience-suite/overview.html)
 - [Neuron SDK 文档](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/ml-guide/ml-neuron-sdk.html)
-
-说明：
-用户可以同时打开多个 dt overlay，如：
-
-```text
-list_dtbo= gpu-mali.dtbo video.dtbo ddr-8g.dtbo i2c3.dtbo i2c4.dtbo gpio104-pwm.dtbo spi1-spidev.dtbo spi2-spidev.dtbo
-```

--- a/i18n/en/docusaurus-plugin-content-docs/current/nio/nio12l/ubuntu/ubuntu-user-guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/nio/nio12l/ubuntu/ubuntu-user-guide.md
@@ -87,6 +87,16 @@ This will update the new `u-boot-initial-env` to the device from the host.
 
 After powering off and rebooting the device, you should see the desktop displayed on the 8HD touchscreen.
 
+## Enable Multiple DT Overlays Simultaneously
+
+You can enable multiple DT overlays at the same time, for example:
+
+```text
+list_dtbo= gpu-mali.dtbo video.dtbo ddr-8g.dtbo i2c3.dtbo i2c4.dtbo gpio104-pwm.dtbo spi1-spidev.dtbo spi2-spidev.dtbo
+```
+
+This allows you to enable multiple hardware features in a single configuration without having to modify the `u-boot-initial-env` file multiple times.
+
 ## Common hardware interfaces: I2C, UART, SPI, etc.
 
 NIO 12L has a 40‑pin expansion header. UART1 and PWM cannot be used at the same time.
@@ -421,10 +431,3 @@ For more details, please refer to the official MediaTek NeuroPilot documentation
 
 - [NeuroPilot Overview](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/ai-experience-suite/overview.html)
 - [Neuron SDK Documentation](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/ml-guide/ml-neuron-sdk.html)
-
-Note:
-You can enable multiple DT overlays at the same time, for example:
-
-```text
-list_dtbo= gpu-mali.dtbo video.dtbo ddr-8g.dtbo i2c3.dtbo i2c4.dtbo gpio104-pwm.dtbo spi1-spidev.dtbo spi2-spidev.dtbo
-```


### PR DESCRIPTION
## Summary

This PR addresses issue #1623 where the important note about enabling multiple DT overlays was placed at the end of the Ubuntu User Guide page, after the QT and NeuroPilot sections, making it less visible to users.

## Changes

1. **Moved the 'Enable Multiple DT Overlays' section** to appear immediately after the touchscreen configuration section, making it more prominent and logically placed
2. **Added clear section titles** in both Chinese and English versions
3. **Removed the duplicate note** from the end of the NeuroPilot section
4. **Improved the explanation** to clarify that this allows enabling multiple hardware features in a single configuration without having to modify the  file multiple times

## Why this change is important

The ability to enable multiple DT overlays simultaneously is a key feature that users should be aware of early in the documentation. By placing this information immediately after the touchscreen configuration section (which is one of the first hardware configuration steps users typically perform), we ensure users don't miss this important capability.

## Testing

- Verified that both Chinese and English versions are updated
- Confirmed the new section appears in the correct location (after touchscreen configuration, before hardware interfaces)
- Ensured no duplicate information remains at the end of the document

Fixes: #1623