### PR TITLE
docs(nio12l): update broken MediaTek NeuroPilot links

### DIFF
--- a/docs/nio/nio12l/ubuntu/ubuntu-user-guide.md
+++ b/docs/nio/nio12l/ubuntu/ubuntu-user-guide.md
@@ -429,5 +429,5 @@ NeuroPilot Neuron SDK 主要支持以下模型格式：
 
 更多详细信息请参考 MediaTek 官方文档：
 
-- [NeuroPilot 主页](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/ai-experience-suite/overview.html)
-- [Neuron SDK 文档](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/ml-guide/ml-neuron-sdk.html)
+- [NeuroPilot 主页](https://neuropilot-developer.mediatek.com/resources/public/latest/en/docs/readme)
+- [Neuron SDK 文档](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/release/v25.0/sw/yocto/ml-guide/ml-neuron-sdk.html)

--- a/i18n/en/docusaurus-plugin-content-docs/current/nio/nio12l/ubuntu/ubuntu-user-guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/nio/nio12l/ubuntu/ubuntu-user-guide.md
@@ -429,5 +429,5 @@ The NeuroPilot Neuron SDK primarily supports the following model formats:
 
 For more details, please refer to the official MediaTek NeuroPilot documentation:
 
-- [NeuroPilot Overview](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/ai-experience-suite/overview.html)
-- [Neuron SDK Documentation](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/ml-guide/ml-neuron-sdk.html)
+- [NeuroPilot Overview](https://neuropilot-developer.mediatek.com/resources/public/latest/en/docs/readme)
+- [Neuron SDK Documentation](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/release/v25.0/sw/yocto/ml-guide/ml-neuron-sdk.html)


### PR DESCRIPTION
## Why

Reported in GitHub issue #1631: two MediaTek NeuroPilot links on the Nio 12L ubuntu-user-guide page were returning 404.

## What

Updated two MediaTek documentation links in both zh-CN and en-US versions of `nio/nio12l/ubuntu/ubuntu-user-guide.md`:

1. **NeuroPilot Overview link** — changed from `https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/ai-experience-suite/overview.html` to `https://neuropilot-developer.mediatek.com/resources/public/latest/en/docs/readme`

2. **Neuron SDK Documentation link** — changed from `https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/ml-guide/ml-neuron-sdk.html` to `https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/release/v25.0/sw/yocto/ml-guide/ml-neuron-sdk.html`

## Verification

- Both new URLs are accessible and return HTTP 200
- Links are within the same documentation section (MediaTek NeuroPilot SDK reference)
- Both zh-CN and en-US files updated in lockstep

Fixes #1631
