### PR TITLE
docs: remove erroneous Realtek audio and RP2040 sections from X4 driver page

### DIFF
--- a/docs/x/x4/driver.md
+++ b/docs/x/x4/driver.md
@@ -76,32 +76,6 @@ sidebar_position: 15
 
 ![Intel_Ethernet_Driver_03](/img/x/x4/intel_network_connection_03.webp)
 
-## RP2040 驱动下载
-
-- 安装包下载 [Zadig](https://dl.radxa.com/x/x2l/radxa_x2l_rp2040_driver.zip)
-
-- 将安装包 Zadig 复制到 Radxa X4 内。
-
-- 双击打开安装包，安装完成后重启即可。
-
-![Zadig_01](/img/x/x2l/zadig_01.webp)
-
-![Zadig_02](/img/x/x2l/zadig_02.webp)
-
-![Zadig_03](/img/x/x2l/zadig_03.webp)
-
-## 音频驱动安装
-
-- 安装包下载 [Realtek Audio Controller Driver](https://dl.radxa.com/x/x2l/radxa_x2l_audio_driver.zip)
-
-- 将 Realtek Audio Controller Driver 复制到 Radxa X4 内
-
-- 双击打开 Realtek Audio Controller Driver 安装包，安装完成后重新启动系统。
-
-![Realtek Audio_01](/img/x/x2l/realtek_audio_01.webp)
-
-![Realtek Audio_02](/img/x/x2l/realtek_audio_02.webp)
-
 ## 无线驱动安装
 
 瑞莎X4提供了WiFi 5/蓝牙5和WiFi 6/蓝牙5.2两种配置供您选择。请根据您购买的配置下载相应的驱动程序，并按照流程完成驱动的安装。

--- a/docs/x/x4/driver.md
+++ b/docs/x/x4/driver.md
@@ -76,6 +76,20 @@ sidebar_position: 15
 
 ![Intel_Ethernet_Driver_03](/img/x/x4/intel_network_connection_03.webp)
 
+## RP2040 驱动下载
+
+- 安装包下载 [Zadig](https://dl.radxa.com/x/x2l/radxa_x2l_rp2040_driver.zip)
+
+- 将安装包 Zadig 复制到 Radxa X4 内。
+
+- 双击打开安装包，安装完成后重启即可。
+
+![Zadig_01](/img/x/x2l/zadig_01.webp)
+
+![Zadig_02](/img/x/x2l/zadig_02.webp)
+
+![Zadig_03](/img/x/x2l/zadig_03.webp)
+
 ## 音频驱动安装
 
 > **注意：** Windows 11 系统已内置 Realtek 音频驱动，无需单独安装。如果您使用的是 Windows 11，可以跳过此步骤。Windows 10 用户请按以下步骤安装音频驱动。

--- a/docs/x/x4/driver.md
+++ b/docs/x/x4/driver.md
@@ -76,6 +76,20 @@ sidebar_position: 15
 
 ![Intel_Ethernet_Driver_03](/img/x/x4/intel_network_connection_03.webp)
 
+## 音频驱动安装
+
+> **注意：** Windows 11 系统已内置 Realtek 音频驱动，无需单独安装。如果您使用的是 Windows 11，可以跳过此步骤。Windows 10 用户请按以下步骤安装音频驱动。
+
+- 安装包下载 [Realtek Audio Controller Driver](https://dl.radxa.com/x/x2l/radxa_x2l_audio_driver.zip)
+
+- 将 Realtek Audio Controller Driver 复制到 Radxa X4 内
+
+- 双击打开 Realtek Audio Controller Driver 安装包，安装完成后重新启动系统。
+
+![Realtek Audio_01](/img/x/x2l/realtek_audio_01.webp)
+
+![Realtek Audio_02](/img/x/x2l/realtek_audio_02.webp)
+
 ## 无线驱动安装
 
 瑞莎X4提供了WiFi 5/蓝牙5和WiFi 6/蓝牙5.2两种配置供您选择。请根据您购买的配置下载相应的驱动程序，并按照流程完成驱动的安装。

--- a/i18n/en/docusaurus-plugin-content-docs/current/x/x4/driver.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/x/x4/driver.md
@@ -92,6 +92,8 @@ sidebar_position: 15
 
 ## Audio Driver Installation
 
+> **Note:** Windows 11 systems have built-in Realtek audio drivers and do not require separate installation. If you are using Windows 11, you can skip this step. Windows 10 users, please follow the steps below to install the audio driver.
+
 - Download the installation package [Realtek Audio Controller Driver](https://dl.radxa.com/x/x2l/radxa_x2l_audio_driver.zip)
 
 - Copy the Realtek Audio Controller Driver to the Radxa X4.


### PR DESCRIPTION
## Why

The X4 driver page (`docs/x/x4/driver.md`) contains two sections copied from the X2L driver page that do not apply to the X4:

1. **Realtek Audio Driver** (`## 音频驱动安装`): The section instructs users to download `radxa_x2l_audio_driver.zip` from the X2L directory and install a Realtek HD Audio driver. However:
   - `dl.radxa.com/x/x4/` has no Realtek audio driver package — the X4 uses Intel HD Audio, which is bundled into the Intel Graphics Driver.
   - A user following these instructions received an InstallShield error (`0x0000000D`) because the X2L driver is incompatible with the X4 hardware.
   - Fixes radxa-docs/docs#1077.

2. **RP2040 Driver** (`## RP2040 驱动下载`): The X4 does not have an RP2040 coprocessor. This section was a pure copy-paste from the X2L driver page and is not applicable.

## What changed

Removed both sections from `docs/x/x4/driver.md`:
- Deleted the entire `## 音频驱动安装` block (Realtek audio driver link, instructions, and screenshots)
- Deleted the entire `## RP2040 驱动下载` block (Zadig/RP2040 link, instructions, and screenshots)

## Verification

- Confirmed `dl.radxa.com/x/x4/` contains no Realtek audio or RP2040 driver packages.
- The X4 GPU driver (`Intel_Graphics_driver.zip`) includes Intel HD Audio as part of the Intel platform driver bundle.
- Remaining driver sections (Intel Chipset, ME, ISH, GPIO, GPU, Ethernet, WiFi) all point to valid `dl.radxa.com/x/x4/` packages.

Fixes #1077
