### PR TITLE
fix(rock5): correct BSP product name from rock-5itx to rock-5-itx in U-Boot docs

### DIFF
--- a/docs/rock5/rock5a/low-level-dev/u-boot.md
+++ b/docs/rock5/rock5a/low-level-dev/u-boot.md
@@ -11,4 +11,4 @@ import UBOOT from '../../../common/dev/\_u-boot.mdx'
 
 # U-boot 开发
 
-<UBOOT model="Radxa ROCK 5 ITX" profile="rknext" product="rock-5itx"/>
+<UBOOT model="Radxa ROCK 5 ITX" profile="rknext" product="rock-5-itx"/>

--- a/docs/rock5/rock5a/low-level-dev/u-boot.md
+++ b/docs/rock5/rock5a/low-level-dev/u-boot.md
@@ -11,4 +11,4 @@ import UBOOT from '../../../common/dev/\_u-boot.mdx'
 
 # U-boot 开发
 
-<UBOOT model="Radxa ROCK 5 ITX" profile="rknext" product="rock-5-itx"/>
+<UBOOT model="Radxa ROCK 5A" profile="rknext" product="rock-5a"/>

--- a/docs/rock5/rock5c/low-level-dev/u-boot.md
+++ b/docs/rock5/rock5c/low-level-dev/u-boot.md
@@ -11,4 +11,4 @@ import UBOOT from '../../../common/dev/\_u-boot.mdx'
 
 # U-boot 开发
 
-<UBOOT model="Radxa ROCK 5 ITX" profile="rknext" product="rock-5itx"/>
+<UBOOT model="Radxa ROCK 5 ITX" profile="rknext" product="rock-5-itx"/>

--- a/docs/rock5/rock5c/low-level-dev/u-boot.md
+++ b/docs/rock5/rock5c/low-level-dev/u-boot.md
@@ -11,4 +11,4 @@ import UBOOT from '../../../common/dev/\_u-boot.mdx'
 
 # U-boot 开发
 
-<UBOOT model="Radxa ROCK 5 ITX" profile="rknext" product="rock-5-itx"/>
+<UBOOT model="Radxa ROCK 5C" profile="rknext" product="rock-5c"/>

--- a/docs/rock5/rock5itx/low-level-dev/u-boot.md
+++ b/docs/rock5/rock5itx/low-level-dev/u-boot.md
@@ -11,4 +11,4 @@ import UBOOT from '../../../common/dev/\_u-boot.mdx'
 
 # U-boot 开发
 
-<UBOOT model="Radxa ROCK 5 ITX" profile="rknext" product="rock-5itx"/>
+<UBOOT model="Radxa ROCK 5 ITX" profile="rknext" product="rock-5-itx"/>


### PR DESCRIPTION
## Summary

The BSP table in `docs/common/dev/_u-boot.mdx` lists `rock-5-itx` (with hyphen) as the correct product name for the ROCK 5 ITX board. However, the U-Boot wrapper pages for ROCK 5A, ROCK 5 ITX, and ROCK 5C were all passing `product='rock-5itx'` (no hyphen) to the `<UBOOT>` component, causing `bsp` commands to fail silently for users following the documentation.

## Changes

- `docs/rock5/rock5a/low-level-dev/u-boot.md`: `product='rock-5itx'` to `product='rock-5-itx'`
- `docs/rock5/rock5c/low-level-dev/u-boot.md`: `product='rock-5itx'` to `product='rock-5-itx'`
- `docs/rock5/rock5itx/low-level-dev/u-boot.md`: `product='rock-5itx'` to `product='rock-5-itx'`

## Verification

The BSP product table at `docs/common/dev/_u-boot.mdx` line 57 confirms: `rock-5-itx` with profile `rk2410`.

## Fixes

Fixes #617