### PR TITLE
fix(rock5): correct HDMI RX sound card number from 2 to 3 in docs

### DIFF
--- a/docs/common/dev/_hdmi-rx.mdx
+++ b/docs/common/dev/_hdmi-rx.mdx
@@ -101,7 +101,7 @@ card 3: rockchiphdmiin [rockchip,hdmiin], device 0: fddf8000.i2s-dummy_codec hdm
  Subdevice #0: subdevice #0
 ```
 
-你可以看到，HDMI RX（HDMI IN）的声卡号是 2，你可以运行下面的命令，在 HDMI RX 有音频输入时，录制和播放音频。
+你可以看到，HDMI RX（HDMI IN）的声卡号是 3，你可以运行下面的命令，在 HDMI RX 有音频输入时，录制和播放音频。
 
 ```bash
 # get 5 seconds audio file


### PR DESCRIPTION
## Summary

The HDMI RX documentation page () contains an  output that lists HDMI IN as **card 3**:



However, the surrounding Chinese text incorrectly stated:
> 你可以看到，HDMI RX（HDMI IN）的声卡号是 **2**

This has been corrected to **声卡号是 3** to match the actual output.

## Changes

- : Changed "声卡号是 2" to "声卡号是 3"

## Testing

The fix is a single-character text correction that aligns the description with the  output already shown in the same code block.

## Fixes #492