### PR TITLE
fix(x4): correct USB mass storage typo in RP2040 flash guide

### DIFF
--- a/docs/x/x4/software/flash.md
+++ b/docs/x/x4/software/flash.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 <Tabs queryString="flash_way">
     <TabItem value="Hardware">
 
-        - 按一下 BOOTSEL 按键，松开之后，你会发现有一个 USB 大容量存储设（即 RP2040）
+        - 按一下 BOOTSEL 按键，松开之后，你会发现有一个 USB 大容量存储设备（即 RP2040）
 
     </TabItem>
     <TabItem value="Software">


### PR DESCRIPTION
Fixes a one-character typo in the X4 RP2040 flash instructions.

**Change**: 'USB 大容量存储设' -> 'USB 大容量存储设备' (missing '备')

**File**: docs/x/x4/software/flash.md

**Source**: GitHub Issue #532

Note: This page has no English counterpart in the i18n/en directory (no bilingual version exists in this repo for this file).