### PR TITLE
fix(common): remove empty code block in RSDK FAQ section (fixes #1642)

### DIFF
--- a/docs/common/dev/_rsdk.mdx
+++ b/docs/common/dev/_rsdk.mdx
@@ -307,6 +307,4 @@ build-image config.yaml debs manifest output.img rootfs.tar seed.tar.xz
 ### 常见问题
 
 1. 开发容器设置暂停并提示：You might be rate limited by GitHub。您可能受到 GitHub 的速率限制。请按照输出中列出的说明进行操作。
-2. 启动开发容器失败。请编辑 .devcontainer/devcontainer.json，并调整runArgs属性。
-```text
-````
+2. 启动开发容器失败。请编辑 .devcontainer/devcontainer.json，并调整 runArgs 属性。

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rsdk.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rsdk.mdx
@@ -305,5 +305,3 @@ If you need to conduct secondary development based on `rsdk`, please continue re
 
 1. Devcontainer setup paused with the message: You might be rate limited by GitHub. You might be rate limited by GitHub. Please follow the instructions listed in the output.
 2. Failed to launch devcontainer. Please edit .devcontainer/devcontainer.json, and adjust the runArgs property.
-```text
-````


### PR DESCRIPTION
## Summary

Remove empty \`\`\`text\`\`\` code block from the RSDK FAQ section in \`_rsdk.mdx\`. The issue reporter (RadxaYuntian) flagged that the FAQ section contains an empty text box — the code block immediately following FAQ item 2 had no content.

## Changes

- \`docs/common/dev/_rsdk.mdx\`: Remove empty \`\`\`text\`\`\` code block after FAQ item 2
- \`i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rsdk.mdx\`: Same fix applied to English translation

## Testing

- Both Chinese and English versions render correctly without the empty code block
- Bilingual: both versions updated

Fixes #1642