### PR TITLE
docs(x5): add pinout definition V1.1 to hardware design resources

### DIFF
--- a/docs/x/x5/download.md
+++ b/docs/x/x5/download.md
@@ -17,3 +17,4 @@ sidebar_position: 100
 
 - [原理图 V1.20](https://dl.radxa.com/x/x5/docs/hw/radxa_x5_%20v1.20_schematic.pdf)
 - [位号图 V1.20](https://dl.radxa.com/x/x5/docs/hw/radxa_x5_v1.20_components_placement_map.pdf)
+- [引脚定义 V1.1](https://dl.radxa.com/nx5/radxa_nx5_pinout_v1.1.xlsx)

--- a/i18n/en/docusaurus-plugin-content-docs/current/x/x5/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/x/x5/download.md
@@ -17,3 +17,4 @@ sidebar_position: 100
 
 - [Schematic V1.20](https://dl.radxa.com/x/x5/docs/hw/radxa_x5_%20v1.20_schematic.pdf)
 - [Components Placement Map V1.20](https://dl.radxa.com/x/x5/docs/hw/radxa_x5_v1.20_components_placement_map.pdf)
+- [Pinout Definition V1.1](https://dl.radxa.com/nx5/radxa_nx5_pinout_v1.1.xlsx)


### PR DESCRIPTION
## Changes

- docs/x/x5/download.md: Added pinout definition V1.1 link to Hardware Design section
- i18n/en/docusaurus-plugin-content-docs/current/x/x5/download.md: Added Pinout Definition V1.1 link to Hardware Design section

## Verification

- [x] Both Chinese and English versions updated
- [x] Link format consistent with existing hardware design resources
- [x] One PR per issue