### PR TITLE
docs(nx5): add pinout definition V1.1 to hardware design resources

### DIFF
--- a/docs/som/nx/nx5/getting-started/download.md
+++ b/docs/som/nx/nx5/getting-started/download.md
@@ -20,6 +20,8 @@ sidebar_position: 4
 
 [NX5 IO V1.4 平面图 dxf](https://dl.radxa.com/nx5/nx5-io-board/radxa_nx5_io_board_v1400_top_2d.dxf)
 
+[NX5 引脚定义 V1.1 xlsx](https://dl.radxa.com/nx5/radxa_nx5_pinout_v1.1.xlsx)
+
 [NX5 IO 板设计资料](https://github.com/radxa/radxa-cm-projects/tree/main/nx5/radxa-nx5-io-board)
 
 ### 刷机工具

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx5/getting-started/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx5/getting-started/download.md
@@ -21,6 +21,8 @@ NX5 & NX5 IO Board
 
 [NX5 IO V1.4 2D dxf](https://dl.radxa.com/nx5/nx5-io-board/radxa_nx5_io_board_v1400_top_2d.dxf)
 
+[NX5 Pinout Definition V1.1 xlsx](https://dl.radxa.com/nx5/radxa_nx5_pinout_v1.1.xlsx)
+
 [NX5 IO Board Design Resources](https://github.com/radxa/radxa-cm-projects/tree/main/nx5/radxa-nx5-io-board)
 
 ## Tools


### PR DESCRIPTION
## Changes

- docs/som/nx/nx5/getting-started/download.md: Added NX5 pinout definition V1.1 link to Hardware Design section
- i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx5/getting-started/download.md: Added NX5 Pinout Definition V1.1 link to Hardware Info section

## Verification

- [x] Both Chinese and English versions updated
- [x] Link format consistent with existing hardware design resources
- [x] One PR per issue