### PR TITLE
docs(x5): remove wrong pinout link from hardware design resources

### DIFF
--- a/docs/x/x5/download.md
+++ b/docs/x/x5/download.md
@@ -17,4 +17,4 @@ sidebar_position: 100
 
 - [原理图 V1.20](https://dl.radxa.com/x/x5/docs/hw/radxa_x5_%20v1.20_schematic.pdf)
 - [位号图 V1.20](https://dl.radxa.com/x/x5/docs/hw/radxa_x5_v1.20_components_placement_map.pdf)
-- [引脚定义 V1.1](https://dl.radxa.com/nx5/radxa_nx5_pinout_v1.1.xlsx)
+

--- a/i18n/en/docusaurus-plugin-content-docs/current/x/x5/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/x/x5/download.md
@@ -17,4 +17,4 @@ sidebar_position: 100
 
 - [Schematic V1.20](https://dl.radxa.com/x/x5/docs/hw/radxa_x5_%20v1.20_schematic.pdf)
 - [Components Placement Map V1.20](https://dl.radxa.com/x/x5/docs/hw/radxa_x5_v1.20_components_placement_map.pdf)
-- [Pinout Definition V1.1](https://dl.radxa.com/nx5/radxa_nx5_pinout_v1.1.xlsx)
+


### PR DESCRIPTION
## Changes

- docs/x/x5/download.md: Removed wrong pinout link from Hardware Design section
- i18n/en/docusaurus-plugin-content-docs/current/x/x5/download.md: Removed wrong Pinout Definition link from Hardware Design section

## Reason

This pinout link was incorrectly added to X5 docs (it belongs to NX5). The correct NX5 pinout link has been added to the NX5 getting-started/download page via PR #1645.

## Verification

- [x] Only X5 pinout links removed
- [x] NX5 resources remain unchanged