### PR TITLE
fix(rock5t): update Radxa OS download link from r5 to r6

### DIFF
--- a/docs/rock4/rock4d/download.md
+++ b/docs/rock4/rock4d/download.md
@@ -42,9 +42,9 @@ USB 刷机使用，Loader 文件用于 USB 下载初始化。
 
 若没有清除过 SPI Flash，可以直接写入系统镜像到 MicroSD 卡 / UFS 模块 / NVME / eMMC 启动系统。
 
-- 适用于 MicroSD 卡 / NVME SSD / U 盘 / eMMC 等介质启动的系统镜像： [Linux-SD-NVME-UDisk.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-b3/radxa-rk3576_bookworm_kde_b3.output_512.img.xz)
+- 适用于 MicroSD 卡 / NVME SSD / U 盘 / eMMC 等介质启动的系统镜像： [Linux-SD-NVME-UDisk.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_512.img.xz)
 
-- 适用于 UFS 启动的系统镜像： [Linux-UFS.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-b3/radxa-rk3576_bookworm_kde_b3.output_4096.img.xz)
+- 适用于 UFS 启动的系统镜像： [Linux-UFS.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_4096.img.xz)
 
 :::caution
 

--- a/docs/rock4/rock4d/getting-started/install-system/emmc_system/no_emmc_reader.md
+++ b/docs/rock4/rock4d/getting-started/install-system/emmc_system/no_emmc_reader.md
@@ -15,7 +15,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 仅 ROCK 4D 无 SPI Flash 版本支持 eMMC 启动，板载 SPI Flash 的版本不支持 eMMC 启动。
 :::
 
-<InstallSystem tag="emmc_module" board="radxa-4d" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-b3/radxa-rk3576_bookworm_kde_b3.output_512.img.xz" path_to_image_unxz="radxa-rk3576_bookworm_kde_b3.output_512.img.xz" path_to_image="radxa-rk3576_bookworm_kde_b3.output_512.img" />
+<InstallSystem tag="emmc_module" board="radxa-4d" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_512.img.xz" path_to_image_unxz="radxa-rk3576_bookworm_kde_r6.output_512.img.xz" path_to_image="radxa-rk3576_bookworm_kde_r6.output_512.img" />
 
 ## 启动系统
 

--- a/docs/rock4/rock4d/getting-started/install-system/nvme-system/no_nvme_reader.md
+++ b/docs/rock4/rock4d/getting-started/install-system/nvme-system/no_nvme_reader.md
@@ -78,7 +78,7 @@ wget [URL]
 
 <NewCodeBlock tip="radxa@radxa-4d$" type="device">
 ```bash
-sudo xzcat ~/radxa-rk3576_bookworm_kde_t2.output_512.img.xz | sudo dd of=/dev/nvme0n1 bs=1M status=progress
+sudo xzcat ~/radxa-rk3576_bookworm_kde_r6.output_512.img.xz | sudo dd of=/dev/nvme0n1 bs=1M status=progress
 ```
 </NewCodeBlock>
 

--- a/docs/rock4/rock4d/getting-started/install-system/ufs-system/no_ufs_reader.md
+++ b/docs/rock4/rock4d/getting-started/install-system/ufs-system/no_ufs_reader.md
@@ -78,7 +78,7 @@ UFS 模块安装步骤：
 
 <NewCodeBlock tip="radxa@radxa-4d$" type="device">
 ```bash
-sudo xzcat ~/radxa-rk3576_bookworm_kde_b1.output_4096.img.xz | sudo dd of=/dev/sda bs=1M status=progress
+sudo xzcat ~/radxa-rk3576_bookworm_kde_r6.output_4096.img.xz | sudo dd of=/dev/sda bs=1M status=progress
 ```
 </NewCodeBlock>
 

--- a/docs/rock5/rock5t/_image.mdx
+++ b/docs/rock5/rock5t/_image.mdx
@@ -13,9 +13,9 @@ import React, { Fragment } from "react";
 
 <li style={{ display: `${props.rock5t_system_img_61 ? "block" : "none"}` }}>
   {" "}
-  <a href="https://github.com/radxa-build/rock-5t/releases/download/rsdk-r5/rock-5t_bookworm_kde_r5.output_512.img.xz">
+  <a href="https://github.com/radxa-build/rock-5t/releases/download/rsdk-r6/rock-5t_bookworm_kde_r6.output_512.img.xz">
     {" "}
-    ROCK 5T 系统镜像 (6.1 内核) : rock-5t_bookworm_kde_r5{" "}
+    ROCK 5T 系统镜像 (6.1 内核) : rock-5t_bookworm_kde_r6{" "}
   </a>
 </li>
 

--- a/docs/som/cm/cm4/download.md
+++ b/docs/som/cm/cm4/download.md
@@ -16,7 +16,7 @@ USB 刷机使用，Loader 文件用于 USB 下载初始化。
 
 适用于 MicroSD 卡、板载 eMMC、NVMe SSD 启动系统。
 
-[Radxa Debian12 Linux Debian KDE](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-b3/radxa-rk3576_bookworm_kde_b3.output_512.img.xz)
+[Radxa Debian12 Linux Debian KDE](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_512.img.xz)
 
 :::caution
 

--- a/docs/som/cm/cm4/getting-started/install-system/ufs-boot/no-reader.md
+++ b/docs/som/cm/cm4/getting-started/install-system/ufs-boot/no-reader.md
@@ -11,6 +11,6 @@ import DDUse from '../../../../../../common/radxa-os/install-system/\_use_dd_ufs
 
 # 从 microSD 卡 或板载 eMMC 安装系统到 UFS 模块
 
-<DDUse boot_device="microSD 卡或板载 eMMC" tag="ufs_module" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r5/radxa-rk3576_bookworm_kde_r5.output_4096.img.xz" path_to_image_unxz="radxa-rk3576_bookworm_kde_r5.output_4096.img" path_to_image="radxa-rk3576_bookworm_kde_r5.output_4096.img" device_target="/dev/sda" board="cm4" />
+<DDUse boot_device="microSD 卡或板载 eMMC" tag="ufs_module" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_4096.img.xz" path_to_image_unxz="radxa-rk3576_bookworm_kde_r6.output_4096.img" path_to_image="radxa-rk3576_bookworm_kde_r6.output_4096.img" device_target="/dev/sda" board="cm4" />
 
 说明：UFS 启动需要将 UFS BOOT 引脚使用跳线帽或者杜邦线短接（短接后无法从 eMMC 启动），接口位置可以参考 [其它接口](../../../hardware-use/other.md) 文档。

--- a/docs/som/nx/nx4/download.md
+++ b/docs/som/nx/nx4/download.md
@@ -28,7 +28,7 @@ sidebar_position: 150
 
 :::
 
-- [radxa-rk3576_bookworm_kde_r4.output_512.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r4/radxa-rk3576_bookworm_kde_r4.output_512.img.xz)
+- [radxa-rk3576_bookworm_kde_r6.output_512.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_512.img.xz)
 
 ## 硬件设计
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/download.md
@@ -42,9 +42,9 @@ This page provides the latest stable and testing system images. Testing versions
 
 If the SPI Flash has not been erased, you can directly write the system image to a MicroSD card / UFS module / NVMe / eMMC to boot the system.
 
-- System image for booting from MicroSD card / NVMe SSD / USB drive / eMMC: [Linux-SD-NVME-UDisk.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-b3/radxa-rk3576_bookworm_kde_b3.output_512.img.xz)
+- System image for booting from MicroSD card / NVMe SSD / USB drive / eMMC: [Linux-SD-NVME-UDisk.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_512.img.xz)
 
-- System image for booting from UFS: [Linux-UFS.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-b3/radxa-rk3576_bookworm_kde_b3.output_4096.img.xz)
+- System image for booting from UFS: [Linux-UFS.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_4096.img.xz)
 
 :::caution
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/getting-started/install-system/emmc_system/no_emmc_reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/getting-started/install-system/emmc_system/no_emmc_reader.md
@@ -15,7 +15,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 Only the ROCK 4D without SPI Flash version supports eMMC startup, and the version with on-chip SPI Flash does not support eMMC startup.
 :::
 
-<InstallSystem tag="emmc_module" board="radxa-4d" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-b3/radxa-rk3576_bookworm_kde_b3.output_512.img.xz" path_to_image_unxz="radxa-rk3576_bookworm_kde_b3.output_512.img.xz" path_to_image="radxa-rk3576_bookworm_kde_b3.output_512.img" />
+<InstallSystem tag="emmc_module" board="radxa-4d" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_512.img.xz" path_to_image_unxz="radxa-rk3576_bookworm_kde_r6.output_512.img.xz" path_to_image="radxa-rk3576_bookworm_kde_r6.output_512.img" />
 
 ## Boot System
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/getting-started/install-system/nvme-system/no_nvme_reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/getting-started/install-system/nvme-system/no_nvme_reader.md
@@ -77,7 +77,7 @@ Use the following command to extract and write the compressed system image direc
 
 <NewCodeBlock tip="radxa@radxa-4d$" type="device">
 ```bash
-sudo xzcat ~/radxa-rk3576_bookworm_kde_t2.output_512.img.xz | sudo dd of=/dev/nvme0n1 bs=1M status=progress
+sudo xzcat ~/radxa-rk3576_bookworm_kde_r6.output_512.img.xz | sudo dd of=/dev/nvme0n1 bs=1M status=progress
 ```
 </NewCodeBlock>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/getting-started/install-system/ufs-system/no_ufs_reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/getting-started/install-system/ufs-system/no_ufs_reader.md
@@ -78,7 +78,7 @@ Use the following command to extract and write the compressed system image direc
 
 <NewCodeBlock tip="radxa@radxa-4d$" type="device">
 ```bash
-sudo xzcat ~/radxa-rk3576_bookworm_kde_b1.output_4096.img.xz | sudo dd of=/dev/sda bs=1M status=progress
+sudo xzcat ~/radxa-rk3576_bookworm_kde_r6.output_4096.img.xz | sudo dd of=/dev/sda bs=1M status=progress
 ```
 </NewCodeBlock>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/_image.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/_image.mdx
@@ -13,9 +13,9 @@ import React, { Fragment } from "react";
 
 <li style={{ display: `${props.rock5t_system_img_61 ? "block" : "none"}` }}>
   {" "}
-  <a href="https://github.com/radxa-build/rock-5t/releases/download/rsdk-r5/rock-5t_bookworm_kde_r5.output_512.img.xz">
+  <a href="https://github.com/radxa-build/rock-5t/releases/download/rsdk-r6/rock-5t_bookworm_kde_r6.output_512.img.xz">
     {" "}
-    ROCK 5T System Image (6.1 Kernel): rock-5t_bookworm_kde_r5{" "}
+    ROCK 5T System Image (6.1 Kernel): rock-5t_bookworm_kde_r6{" "}
   </a>
 </li>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm4/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm4/download.md
@@ -16,7 +16,7 @@ For USB flashing, the Loader file is used for USB download initialization.
 
 Compatible with MicroSD cards, onboard eMMC, and NVMe SSD for system boot.
 
-[Radxa Debian Linux Debian12 KDE](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-b3/radxa-rk3576_bookworm_kde_b3.output_512.img.xz)
+[Radxa Debian Linux Debian12 KDE](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_512.img.xz)
 
 - Android
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm4/getting-started/install-system/ufs-boot/no-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm4/getting-started/install-system/ufs-boot/no-reader.md
@@ -11,6 +11,6 @@ import DDUse from '../../../../../../common/radxa-os/install-system/\_use_dd_ufs
 
 # Install System to UFS Module from microSD Card or Onboard eMMC
 
-<DDUse boot_device="microSD card or onboard eMMC" tag="ufs_module" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r5/radxa-rk3576_bookworm_kde_r5.output_4096.img.xz" path_to_image_unxz="radxa-rk3576_bookworm_kde_r5.output_4096.img" path_to_image="radxa-rk3576_bookworm_kde_r5.output_4096.img" device_target="/dev/sda" board="cm4" />
+<DDUse boot_device="microSD card or onboard eMMC" tag="ufs_module" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_4096.img.xz" path_to_image_unxz="radxa-rk3576_bookworm_kde_r6.output_4096.img" path_to_image="radxa-rk3576_bookworm_kde_r6.output_4096.img" device_target="/dev/sda" board="cm4" />
 
 Note: To boot from UFS, you need to short the UFS BOOT pins using a jumper cap or DuPont wire (after shorting, the system cannot boot from eMMC). For the connector location, refer to the [Other Interfaces](../../../hardware-use/other.md) document.

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/download.md
@@ -28,7 +28,7 @@ This page publishes the latest stable and test system images. Test releases star
 
 :::
 
-- [radxa-rk3576_bookworm_kde_r4.output_512.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r4/radxa-rk3576_bookworm_kde_r4.output_512.img.xz)
+- [radxa-rk3576_bookworm_kde_r6.output_512.img.xz](https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_512.img.xz)
 
 ## Hardware design
 


### PR DESCRIPTION
## Summary

将 ROCK 5T 资源汇总下载页面的 Radxa OS 镜像下载链接从 r5 更新到 r6。同时将 RK3576 系列产品的系统镜像链接统一更新到最新 r6 版本。

## Changes

### ROCK 5T
- docs/rock5/rock5t/_image.mdx: 更新中文版镜像 URL：rsdk-r5 to rsdk-r6
- i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/_image.mdx: 更新英文版镜像 URL：rsdk-r5 to rsdk-r6

### Radxa NX4
- docs/som/nx/nx4/download.md: rsdk-r4 -> rsdk-r6
- i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/download.md: rsdk-r4 -> rsdk-r6

### Radxa CM4
- docs/som/cm/cm4/download.md: rsdk-b3 -> rsdk-r6
- docs/som/cm/cm4/getting-started/install-system/ufs-boot/no-reader.md: rsdk-r5 -> rsdk-r6 (UFS 4096)
- i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm4/download.md: rsdk-b3 -> rsdk-r6
- i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm4/getting-started/install-system/ufs-boot/no-reader.md: rsdk-r5 -> rsdk-r6 (UFS 4096)

### ROCK 4D
- docs/rock4/rock4d/download.md: rsdk-b3 -> rsdk-r6 (512 和 4096 UFS)
- docs/rock4/rock4d/getting-started/install-system/emmc_system/no_emmc_reader.md: rsdk-b3 -> rsdk-r6
- docs/rock4/rock4d/getting-started/install-system/nvme-system/no_nvme_reader.md: t2 -> r6
- docs/rock4/rock4d/getting-started/install-system/ufs-system/no_ufs_reader.md: b1 -> r6 (UFS 4096)
- i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/download.md: rsdk-b3 -> rsdk-r6
- i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/getting-started/install-system/emmc_system/no_emmc_reader.md: rsdk-b3 -> rsdk-r6
- i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/getting-started/install-system/nvme-system/no_nvme_reader.md: t2 -> r6
- i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/getting-started/install-system/ufs-system/no_ufs_reader.md: b1 -> r6 (UFS 4096)

## Links

- radxa-rk3576 r6 发布页: https://github.com/radxa-build/radxa-rk3576/releases/tag/rsdk-r6
- radxa-rk3576 r6 标准镜像 (512): https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_512.img.xz
- radxa-rk3576 r6 UFS 镜像 (4096): https://github.com/radxa-build/radxa-rk3576/releases/download/rsdk-r6/radxa-rk3576_bookworm_kde_r6.output_4096.img.xz