### PR TITLE
docs(q6a): sync Baidu Netdisk downloads section in English

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/download.md
@@ -59,6 +59,19 @@ If the system fails to boot properly, you can try re-flashing the latest SPI boo
 
 :::
 
+## Baidu Netdisk Downloads
+
+:::tip
+The Baidu Netdisk share link is updated periodically. Use Baidu Netdisk to download the latest images.
+
+**Version notes:**
+
+- **R**: Stable release, recommended
+- **T**: Testing release (evaluation only)
+  :::
+
+- [Baidu Netdisk downloads (radxa-dragon-q6a)](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-dragon-q6a&parentPath=%2Fsharelink3108273493-988411983016443)
+
 ## Boot Firmware
 
 The Dragon Q6A comes with the SPI boot firmware pre-flashed by default. Under normal circumstances, it is not necessary to re-flash the boot firmware. If the system fails to boot properly, you can try re-flashing the SPI boot firmware.


### PR DESCRIPTION
Sync the Dragon Q6A download page: add the Baidu Netdisk downloads section to the English doc to match the existing Chinese doc.\n\n- Link: https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA\n- Path: image-release/radxa-dragon-q6a