### PR TITLE
docs(q6a): fix version notation consistency (`t`/`r` not bold T/R)

### DIFF
--- a/docs/dragon/q6a/download.md
+++ b/docs/dragon/q6a/download.md
@@ -65,8 +65,8 @@ sudo dmidecode -s bios-version
 百度网盘分享链接会定期更新镜像文件，推荐通过百度网盘下载获取最新镜像。
 
 **版本说明：**
-- **R 版本**：经过测试的稳定版本，推荐使用
-- **T 版本**：测试版本（仅用于评估）
+- `r` 版本：经过测试的稳定版本，推荐使用
+- `t` 版本：测试版本（仅用于评估）
 :::
 
 - [百度网盘下载（radxa-dragon-q6a）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-dragon-q6a&parentPath=%2Fsharelink3108273493-988411983016443)

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/download.md
@@ -59,6 +59,19 @@ If the system fails to boot properly, you can try re-flashing the latest SPI boo
 
 :::
 
+## Baidu Netdisk Downloads
+
+:::tip
+The Baidu Netdisk share link is updated periodically. Use Baidu Netdisk to download the latest images.
+
+**Version notes:**
+
+- **R**: Stable release, recommended
+- **T**: Testing release (evaluation only)
+  :::
+
+- [Baidu Netdisk downloads (radxa-dragon-q6a)](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Fradxa-dragon-q6a&parentPath=%2Fsharelink3108273493-988411983016443)
+
 ## Boot Firmware
 
 The Dragon Q6A comes with the SPI boot firmware pre-flashed by default. Under normal circumstances, it is not necessary to re-flash the boot firmware. If the system fails to boot properly, you can try re-flashing the SPI boot firmware.


### PR DESCRIPTION
Fix Copilot review comment on PR #1648: make Baidu Netdisk version labels use inline code (`t`/`r`) consistently with the earlier note on the page (`t` = test, `r` = official), instead of bold uppercase T/R.