### PR TITLE
docs: move multiple DT overlay note before Qt in NIO 12L Ubuntu guide

### DIFF
--- a/docs/nio/nio12l/download/README.md
+++ b/docs/nio/nio12l/download/README.md
@@ -27,7 +27,7 @@ Yocto:
 [NIO-12L-D16 genio-1200-radxa-nio-12l-d16-ufs-kirkstone-k5.15-v24.0-b3-20250109.tar.gz](https://dl.radxa.com/nio12l/images/yocto/genio-1200-radxa-nio-12l-d16-ufs-kirkstone-k5.15-v24.0-b3-20250109.tar.gz)
 
 Ubuntu:
-[baoshan-classic-desktop-2204-x01-20231005-133-g1200-radxa-nio-12l-ufs-b9.tar.gz](https://dl.radxa.com/nio12l/images/ubuntu/baoshan-classic-desktop-2204-x01-20231005-133-g1200-radxa-nio-12l-ufs-b9.tar.gz)
+[baoshan-classic-desktop-2204-x01-20231005-133-g1200-radxa-nio-12l-ufs-b10.tar.gz](https://dl.radxa.com/nio12l/images/ubuntu/baoshan-classic-desktop-2204-x01-20231005-133-g1200-radxa-nio-12l-ufs-b10.tar.gz)
 
 Android:
 [n12l_android11_20240912.zip](https://dl.radxa.com/nio12l/images/android/n12l_android11_20240912.zip)

--- a/docs/nio/nio12l/ubuntu/ubuntu-user-guide.md
+++ b/docs/nio/nio12l/ubuntu/ubuntu-user-guide.md
@@ -346,6 +346,16 @@ ubuntu@mtk-genio:~$ ls /sys/class/pwm/pwmchip0/
 device  export  npwm  power  subsystem  uevent  unexport
 ```
 
+## 同时启用多个 DT overlay
+
+用户可以同时打开多个 dt overlay，如：
+
+```text
+list_dtbo= gpu-mali.dtbo video.dtbo ddr-8g.dtbo i2c3.dtbo i2c4.dtbo gpio104-pwm.dtbo spi1-spidev.dtbo spi2-spidev.dtbo
+```
+
+这样可以在一次配置中启用多个硬件功能，无需多次修改 `u-boot-initial-env` 文件。
+
 ## 安装 QT
 
 安装 qtcreator。
@@ -421,10 +431,3 @@ NeuroPilot Neuron SDK 主要支持以下模型格式：
 
 - [NeuroPilot 主页](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/ai-experience-suite/overview.html)
 - [Neuron SDK 文档](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/ml-guide/ml-neuron-sdk.html)
-
-说明：
-用户可以同时打开多个 dt overlay，如：
-
-```text
-list_dtbo= gpu-mali.dtbo video.dtbo ddr-8g.dtbo i2c3.dtbo i2c4.dtbo gpio104-pwm.dtbo spi1-spidev.dtbo spi2-spidev.dtbo
-```

--- a/i18n/en/docusaurus-plugin-content-docs/current/nio/nio12l/download/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/nio/nio12l/download/README.md
@@ -27,7 +27,7 @@ Yocto:
 [NIO-12L-D16 genio-1200-radxa-nio-12l-d16-ufs-kirkstone-k5.15-v24.0-b3-20250109.tar.gz](https://dl.radxa.com/nio12l/images/yocto/genio-1200-radxa-nio-12l-d16-ufs-kirkstone-k5.15-v24.0-b3-20250109.tar.gz)
 
 Ubuntu:
-[baoshan-classic-desktop-2204-x01-20231005-133-g1200-radxa-nio-12l-ufs-b9.tar.gz](https://dl.radxa.com/nio12l/images/ubuntu/baoshan-classic-desktop-2204-x01-20231005-133-g1200-radxa-nio-12l-ufs-b9.tar.gz)
+[baoshan-classic-desktop-2204-x01-20231005-133-g1200-radxa-nio-12l-ufs-b10.tar.gz](https://dl.radxa.com/nio12l/images/ubuntu/baoshan-classic-desktop-2204-x01-20231005-133-g1200-radxa-nio-12l-ufs-b10.tar.gz)
 
 Android:
 [n12l_android11_20240912.zip](https://dl.radxa.com/nio12l/images/android/n12l_android11_20240912.zip)

--- a/i18n/en/docusaurus-plugin-content-docs/current/nio/nio12l/ubuntu/ubuntu-user-guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/nio/nio12l/ubuntu/ubuntu-user-guide.md
@@ -346,6 +346,16 @@ ubuntu@mtk-genio:~$ ls /sys/class/pwm/pwmchip0/
 device  export  npwm  power  subsystem  uevent  unexport
 ```
 
+## Enable Multiple DT Overlays Simultaneously
+
+You can enable multiple DT overlays at the same time, for example:
+
+```text
+list_dtbo= gpu-mali.dtbo video.dtbo ddr-8g.dtbo i2c3.dtbo i2c4.dtbo gpio104-pwm.dtbo spi1-spidev.dtbo spi2-spidev.dtbo
+```
+
+This allows you to enable multiple hardware features in a single configuration without having to modify the `u-boot-initial-env` file multiple times.
+
 ## Install Qt
 
 Install `qtcreator`:
@@ -421,10 +431,3 @@ For more details, please refer to the official MediaTek NeuroPilot documentation
 
 - [NeuroPilot Overview](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/ai-experience-suite/overview.html)
 - [Neuron SDK Documentation](https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/ml-guide/ml-neuron-sdk.html)
-
-Note:
-You can enable multiple DT overlays at the same time, for example:
-
-```text
-list_dtbo= gpu-mali.dtbo video.dtbo ddr-8g.dtbo i2c3.dtbo i2c4.dtbo gpio104-pwm.dtbo spi1-spidev.dtbo spi2-spidev.dtbo
-```


### PR DESCRIPTION
## Summary

Move the 'enable multiple DT overlays' section from after the NeuroPilot section to before the Qt installation section, making it more visible to users who need to configure hardware overlays early in the setup process.

Also update Ubuntu image download link from b9 to b10.

## Changes

- Move DT overlay section to appear before Qt installation section
- Add explanatory text about enabling multiple overlays in one configuration
- Remove duplicate note from end of NeuroPilot section
- Update both Chinese and English versions
- Update Ubuntu image download link (b9 -> b10)

## Why

The ability to enable multiple DT overlays simultaneously is a key feature that users should be aware of early in the documentation. Placing this information before Qt installation ensures users see it when configuring hardware features.

Fixes: #1623