### PR TITLE
docs(fogwise/airbox-q900): add Qualcomm Real-Time Subsystem guide

### DIFF
--- a/docs/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/docs/fogwise/airbox-q900/other-os/qualcomm.md
@@ -15,3 +15,7 @@ sidebar_position: 1
 ## 高通 Linux Yocto 指南
 
 请参考 [高通 Linux Yocto 指南](https://docs.qualcomm.com/bundle/publicresource/topics/80-70020-27/yocto_landing_page.html)
+
+## 高通 Real-Time Subsystem 指南
+
+请参考 [高通 Real-Time Subsystem 指南](https://docs.qualcomm.com/doc/80-70029-42/topic/rtss-guide.html)

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
@@ -15,3 +15,7 @@ Please refer to [Qualcomm Linux Build Guide](https://docs.qualcomm.com/bundle/pu
 ## Qualcomm Linux Yocto Guide
 
 Please refer to [Qualcomm Linux Yocto Guide](https://docs.qualcomm.com/bundle/publicresource/topics/80-70020-27/yocto_landing_page.html)
+
+## Qualcomm Real-Time Subsystem Guide
+
+Please refer to [Qualcomm Real-Time Subsystem Guide](https://docs.qualcomm.com/doc/80-70029-42/topic/rtss-guide.html)


### PR DESCRIPTION
Add link to Qualcomm Real-Time Subsystem (RTSS) guide on the AIRbox Q900 Qualcomm Linux page.

## Changes
- docs/fogwise/airbox-q900/other-os/qualcomm.md: Added "高通 Real-Time Subsystem 指南" section
- i18n/en/.../qualcomm.md: Added "Qualcomm Real-Time Subsystem Guide" section (English)

## Verification
Visit the local preview or CI preview after merge to confirm the new section renders correctly under the existing Qualcomm Linux Guide sections.