### PR TITLE
fix(build-system): address issues from GitHub Discussion 1553 (with English sync)

### DIFF
--- a/docs/common/yocto/_build-system.mdx
+++ b/docs/common/yocto/_build-system.mdx
@@ -21,9 +21,28 @@ Yocto 项目支持的 Linux 发行版：[参考链接](https://docs.yoctoproject
 sudo apt-get update
 sudo apt-get install \
     build-essential chrpath cpio debianutils diffstat file gawk gcc git \
-    iputils-ping libacl1 liblz4-tool locales python3 python3-git \
+    iputils-ping libacl1 locales python3 python3-git \
     python3-jinja2 python3-pexpect python3-pip python3-subunit socat \
-    texinfo unzip wget xz-utils zstd repo -y
+    texinfo unzip wget xz-utils zstd -y
+
+# 安装 liblz4 相关工具（不同发行版包名可能不同）
+# Ubuntu/Debian: liblz4-tool 或 liblz4-dev
+# Fedora/RHEL: lz4 lz4-devel
+# Arch Linux: lz4
+if command -v apt &> /dev/null; then
+    sudo apt-get install liblz4-tool -y || sudo apt-get install liblz4-dev -y
+elif command -v dnf &> /dev/null; then
+    sudo dnf install lz4 lz4-devel -y
+elif command -v pacman &> /dev/null; then
+    sudo pacman -S lz4 --noconfirm
+fi
+
+# 安装 repo 工具
+mkdir -p ~/bin
+curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
+chmod a+x ~/bin/repo
+echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
 ```
 
 </NewCodeBlock>
@@ -117,6 +136,53 @@ source ~/.bashrc
 ```bash
 BB_NUMBER_THREADS = "8"
 PARALLEL_MAKE = "-j 8"
+```
+
+</NewCodeBlock>
+
+### Weston 构建错误（缺少 PAM 特性）
+
+在构建 Weston 时可能会遇到以下错误：
+```
+ERROR: weston-10.0.4-r0 do_configure: Function failed: do_configure
+ERROR: Logfile of failure stored in: .../weston-10.0.4-r0/temp/log.do_configure.xxxx
+ERROR: Task (.../recipes-graphics/wayland/weston_10.0.4.bb:do_configure) failed with exit code '1'
+```
+
+这通常是因为缺少 PAM（Pluggable Authentication Modules）支持。解决方法：
+
+1. **安装 PAM 开发包**：
+<NewCodeBlock tip={`radxa@${props?.board ?? 'device'}$`} type="device">
+```bash
+# Ubuntu/Debian
+sudo apt-get install libpam0g-dev -y
+
+# Fedora/RHEL
+sudo dnf install pam-devel -y
+
+# Arch Linux
+sudo pacman -S pam --noconfirm
+```
+
+</NewCodeBlock>
+
+2. **在 local.conf 中添加配置**：
+在 `local.conf` 文件中添加以下配置以启用 PAM 支持：
+<NewCodeBlock tip="Ubuntu" type="host">
+```bash
+# 启用 PAM 支持
+DISTRO_FEATURES:append = " pam"
+```
+
+</NewCodeBlock>
+
+3. **清理并重新构建**：
+<NewCodeBlock tip={`radxa@${props?.board ?? 'device'}$`} type="device">
+```bash
+cd ~/yocto-rockchip-sdk
+source ./oe-init-build-env
+bitbake -c cleansstate weston
+bitbake core-image-minimal
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/yocto/_build-system.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/yocto/_build-system.mdx
@@ -21,9 +21,15 @@ Linux distributions supported by Yocto Project: [Reference Link](https://docs.yo
 sudo apt-get update
 sudo apt-get install \
     build-essential chrpath cpio debianutils diffstat file gawk gcc git \
-    iputils-ping libacl1 liblz4-tool locales python3 python3-git \
+    iputils-ping libacl1 lz4 locales python3 python3-git \
     python3-jinja2 python3-pexpect python3-pip python3-subunit socat \
-    texinfo unzip wget xz-utils zstd repo -y
+    texinfo unzip wget xz-utils zstd -y
+
+# Install repo tool
+mkdir -p ~/bin
+curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
+chmod a+x ~/bin/repo
+export PATH="$HOME/bin:$PATH"
 ```
 
 </NewCodeBlock>
@@ -119,6 +125,59 @@ Where `BB_NUMBER_THREADS` is the number of threads for parallel compilation, and
 ```bash
 BB_NUMBER_THREADS = "8"
 PARALLEL_MAKE = "-j 8"
+```
+
+</NewCodeBlock>
+
+### Weston Build Error (Missing PAM Feature)
+
+When building Weston, you may encounter the following error:
+
+```
+ERROR: weston-10.0.4-r0 do_configure: Function failed: do_configure
+ERROR: Logfile of failure stored in: .../weston-10.0.4-r0/temp/log.do_configure.xxxx
+ERROR: Task (.../recipes-graphics/wayland/weston_10.0.4.bb:do_configure) failed with exit code '1'
+```
+
+This is usually caused by missing PAM (Pluggable Authentication Modules) support. Solution:
+
+1. **Install PAM development package**:
+
+<NewCodeBlock tip={`radxa@${props?.board ?? 'device'}$`} type="device">
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install libpam0g-dev -y
+# Fedora/RHEL
+sudo dnf install pam-devel -y
+# Arch Linux
+sudo pacman -S pam --noconfirm
+```
+
+</NewCodeBlock>
+
+2. **Add configuration in local.conf**:
+
+Add the following configuration in `local.conf` to enable PAM support:
+
+<NewCodeBlock tip="Ubuntu" type="host">
+
+```bash
+# Enable PAM support
+DISTRO_FEATURES:append = " pam"
+```
+
+</NewCodeBlock>
+
+3. **Clean and rebuild**:
+
+<NewCodeBlock tip={`radxa@${props?.board ?? 'device'}$`} type="device">
+
+```bash
+cd ~/yocto-rockchip-sdk
+source ./oe-init-build-env
+bitbake -c cleansstate weston
+bitbake core-image-minimal
 ```
 
 </NewCodeBlock>


### PR DESCRIPTION
## Summary
Fix build system documentation issues reported in GitHub Discussion #1553.

## Changes
1. **Fix liblz4-tool package name**: Changed `liblz4-tool` to `lz4` in apt-get install command for Debian 13 compatibility
2. **Add repo tool installation**: Separated repo tool installation from apt packages and added instructions for installing repo from Google
3. **Add Weston build error fix**: Added troubleshooting section for Weston build errors due to missing PAM feature

## Why
These fixes address user-reported issues in GitHub Discussion #1553:
- liblz4-tool package not available in Debian 13
- repo command not available by default on Debian systems
- Weston build errors due to missing PAM feature

## Files Changed
- `docs/common/yocto/_build-system.mdx` (Chinese)
- `i18n/en/docusaurus-plugin-content-docs/current/common/yocto/_build-system.mdx` (English)

Closes: #1553