### PR TITLE
docs(dragon/q6a): add FAQ for 7-inch display garbled screen issue

### DIFF
--- a/docs/dragon/q6a/faq.md
+++ b/docs/dragon/q6a/faq.md
@@ -136,3 +136,58 @@ vim /usr/share/glib-2.0/schemas/org.gnome.settings-daemon.plugins.power.gschema.
 
 - 系统会以 `EL2` 而不是 `EL1` 启动，此时**可以**使用 KVM
 - `/dev/mtd0` 会消失，因此不能直接在板子上更新 SPI 固件
+
+## 7 寸屏显示花屏如何解决？
+
+7 寸屏默认会使用 1080p 分辨率，如果屏幕不支持该分辨率会导致花屏，需要手动设置屏幕分辨率。
+
+### 查看支持分辨率
+
+首先连接屏幕并登录系统，查看 HDMI 输出支持的分辨率：
+
+<NewCodeBlock tip="radxa@dragon-q6a$" type="device">
+
+```bash
+# 解析 EDID 内容（需安装 edid-decode）
+sudo apt install edid-decode
+sudo edid-decode /sys/class/drm/card1-HDMI-A-1/edid
+```
+
+</NewCodeBlock>
+
+在输出中确认屏幕支持的分辨率列表。若 7 寸屏的 1024x600 分辨率没有出现在默认的 modes 中，说明默认的 1080p 分辨率设置会导致显示异常。
+
+### 调整分辨率
+
+确认分辨率后，修改内核命令行参数来指定正确的屏幕分辨率：
+
+<NewCodeBlock tip="radxa@dragon-q6a$" type="device">
+
+```bash
+old=$(cat /etc/kernel/cmdline)
+echo "$old video=HDMI-A-1:1024x600@60" | sudo tee /etc/kernel/cmdline
+```
+
+</NewCodeBlock>
+
+### 更新内核
+
+<NewCodeBlock tip="radxa@dragon-q6a$" type="device">
+
+```bash
+sudo kernel-install add $(uname -r) /boot/vmlinuz-$(uname -r)
+```
+
+</NewCodeBlock>
+
+### 重启
+
+<NewCodeBlock tip="radxa@dragon-q6a$" type="device">
+
+```bash
+sudo reboot
+```
+
+</NewCodeBlock>
+
+重启后如果仍然显示异常，请重新插拔 HDMI 线缆。

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/faq.md
@@ -134,3 +134,58 @@ After enabling the hardware encoder, the following changes apply:
 
 - The system boots in `EL2` instead of `EL1`, and KVM **can** be used
 - `/dev/mtd0` disappears, so you cannot update the SPI firmware directly on the board
+
+## How to Fix 7-inch Display Garbled Screen Issue?
+
+The 7-inch display defaults to 1080p resolution. If the display does not support this resolution, it will cause a garbled screen, and you need to manually set the correct screen resolution.
+
+### Check Supported Resolutions
+
+First, connect the display and log into the system, then check the HDMI output supported resolutions:
+
+<NewCodeBlock tip="radxa@dragon-q6a$" type="device">
+
+```bash
+# Parse EDID content (edid-decode needs to be installed)
+sudo apt install edid-decode
+sudo edid-decode /sys/class/drm/card1-HDMI-A-1/edid
+```
+
+</NewCodeBlock>
+
+Check the output to confirm the list of supported resolutions. If the 7-inch display's 1024x600 resolution does not appear in the default modes list, it means the default 1080p resolution setting is causing the display issue.
+
+### Adjust Resolution
+
+After confirming the resolution, modify the kernel command line parameters to specify the correct screen resolution:
+
+<NewCodeBlock tip="radxa@dragon-q6a$" type="device">
+
+```bash
+old=$(cat /etc/kernel/cmdline)
+echo "$old video=HDMI-A-1:1024x600@60" | sudo tee /etc/kernel/cmdline
+```
+
+</NewCodeBlock>
+
+### Update Kernel
+
+<NewCodeBlock tip="radxa@dragon-q6a$" type="device">
+
+```bash
+sudo kernel-install add $(uname -r) /boot/vmlinuz-$(uname -r)
+```
+
+</NewCodeBlock>
+
+### Reboot
+
+<NewCodeBlock tip="radxa@dragon-q6a$" type="device">
+
+```bash
+sudo reboot
+```
+
+</NewCodeBlock>
+
+If the display is still abnormal after rebooting, please reconnect the HDMI cable.


### PR DESCRIPTION
## Summary

为 Dragon Q6A 常见问题添加 7 寸屏显示花屏的解决办法。

## Changes

- 在 `docs/dragon/q6a/faq.md` 末尾添加新 FAQ 条目
- 说明 7 寸屏默认 1080p 分辨率导致花屏的原因
- 提供查看 EDID、分辨率调整、内核更新、重启的完整解决步骤

## Related Issue

客户支持问题：7 寸屏使用花屏，默认 1080p 分辨率不支持