### PR TITLE
docs: add low-level-dev tutorials for ROCK 4D and NX4

### DIFF
--- a/docs/common/dev/_kernel.mdx
+++ b/docs/common/dev/_kernel.mdx
@@ -71,7 +71,7 @@ cd bsp
 
 若没有找到对应产品的型号，请根据自己产品的 SoC 型号选择对应选项。
 
-示例：瑞莎 CM4 使用瑞芯微 RK3576 SoC，根据表格中的 `radxa-rk3576` 选择 `rk2410` 作为 `profile` 参数。
+示例：Radxa CM4 / NX4 和 ROCK 4D 使用瑞芯微 RK3576 SoC，根据表格中的 `radxa-rk3576` 选择 `rk2410` 作为 `profile` 参数。
 
 :::
 

--- a/docs/common/dev/_rsdk.mdx
+++ b/docs/common/dev/_rsdk.mdx
@@ -192,7 +192,7 @@ sudo apt install ../rsdk\_\*.deb
 :::tip
 若没有找到对应产品的型号，请根据自己产品的 SoC 型号选择对应选项。
 
-示例：瑞莎 CM4 使用瑞芯微 RK3576 SoC，应选择 `radxa-rk3576`。
+示例：Radxa CM4 / NX4 和 ROCK 4D 使用瑞芯微 RK3576 SoC，应选择 `radxa-rk3576`。
 
 :::
 

--- a/docs/common/dev/_u-boot.mdx
+++ b/docs/common/dev/_u-boot.mdx
@@ -71,7 +71,7 @@ cd bsp
 
 若没有找到对应产品的型号，请根据自己产品的 SoC 型号选择对应选项。
 
-示例：瑞莎 CM4 使用瑞芯微 RK3576 SoC，根据表格中的 `radxa-rk3576` 选择 `rk2410` 作为 `profile` 参数。
+示例：Radxa CM4 / NX4 和 ROCK 4D 使用瑞芯微 RK3576 SoC，根据表格中的 `radxa-rk3576` 选择 `rk2410` 作为 `profile` 参数。
 
 :::
 

--- a/docs/rock4/rock4d/low-level-dev/rsdk.md
+++ b/docs/rock4/rock4d/low-level-dev/rsdk.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 3
+description: "使用 RSDK 工具定制您的系统"
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/dev/_rsdk.mdx
+---
+
+import RSDK from '../../../../common/dev/\_rsdk.mdx'
+
+# 编译 RadxaOS
+
+<RSDK />

--- a/docs/rock4/rock4d/low-level-dev/u-boot.md
+++ b/docs/rock4/rock4d/low-level-dev/u-boot.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 1
+description: "用 Radxa BSP 工具，轻松构建个性化 U-boot，开启智能硬件的创新之旅"
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/dev/_u-boot.mdx
+---
+
+import UBOOT from '../../../../common/dev/\_u-boot.mdx'
+
+# U-boot 开发
+
+<UBOOT model="Radxa ROCK 4D" profile="rk2410" product="rock-4d"/>

--- a/docs/som/nx/nx4/low-level-dev/README.md
+++ b/docs/som/nx/nx4/low-level-dev/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 17
+---
+
+# 底层开发
+
+对瑞莎 NX4 进行底层开发做简单的介绍。
+
+<DocCardList />

--- a/docs/som/nx/nx4/low-level-dev/kernel.md
+++ b/docs/som/nx/nx4/low-level-dev/kernel.md
@@ -8,8 +8,8 @@ imports_resolve_to:
   - docs/common/dev/_kernel.mdx
 ---
 
-import KERNEL from '../../../../common/dev/\_kernel.mdx'
+import KERNEL from '../../../../../common/dev/\_kernel.mdx'
 
 # Kernel 开发
 
-<KERNEL model="Radxa ROCK 4D" soc="rk3576" />
+<KERNEL model="Radxa NX4" soc="rk3576" />

--- a/docs/som/nx/nx4/low-level-dev/rsdk.md
+++ b/docs/som/nx/nx4/low-level-dev/rsdk.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 3
+description: "使用 RSDK 工具定制您的系统"
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/dev/_rsdk.mdx
+---
+
+import RSDK from '../../../../../common/dev/\_rsdk.mdx'
+
+# 编译 RadxaOS
+
+<RSDK />

--- a/docs/som/nx/nx4/low-level-dev/u-boot.md
+++ b/docs/som/nx/nx4/low-level-dev/u-boot.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 1
+description: "用 Radxa BSP 工具，轻松构建个性化 U-boot，开启智能硬件的创新之旅"
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/dev/_u-boot.mdx
+---
+
+import UBOOT from '../../../../../common/dev/\_u-boot.mdx'
+
+# U-boot 开发
+
+<UBOOT model="Radxa NX4" profile="rk2410" product="nx4"/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_kernel.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_kernel.mdx
@@ -71,7 +71,7 @@ Taking Radxa ROCK 5B as an example, the linux profile is "rk2410". The following
 
 If the product model is not found in the table, select the corresponding option based on your product's SoC model.
 
-Example: Radxa CM4 uses the Rockchip RK3576 SoC. According to the table, select `rk2410` as the `profile` parameter for `radxa-rk3576`.
+Example: Radxa CM4 / NX4 and ROCK 4D use the Rockchip RK3576 SoC. According to the table, select `rk2410` as the `profile` parameter for `radxa-rk3576`.
 
 :::
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rsdk.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rsdk.mdx
@@ -189,7 +189,7 @@ Select the product to build. **Note**: Use the **space key** to select the produ
 :::tip
 If you cannot find your product model, select the option corresponding to your product's SoC model.
 
-Example: Radxa CM4 uses the Rockchip RK3576 SoC, so you should select `radxa-rk3576`.
+Example: Radxa CM4 / NX4 and ROCK 4D use the Rockchip RK3576 SoC, so you should select `radxa-rk3576`.
 
 :::
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_u-boot.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_u-boot.mdx
@@ -75,7 +75,7 @@ Taking Radxa ROCK 5B as an example, the U-Boot profile is "rk2410". The followin
 
 If the product model is not found in the table, select the corresponding option based on your product's SoC model.
 
-Example: Radxa CM4 uses the Rockchip RK3576 SoC. According to the table, select `rk2410` as the `profile` parameter for `radxa-rk3576`.
+Example: Radxa CM4 / NX4 and ROCK 4D use the Rockchip RK3576 SoC. According to the table, select `rk2410` as the `profile` parameter for `radxa-rk3576`.
 
 :::
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/low-level-dev/rsdk.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/low-level-dev/rsdk.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 4
+description: "Customise your system with the RSDK tool"
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rsdk.mdx
+---
+
+import RSDK from '../../../common/dev/\_rsdk.mdx'
+
+# Build RadxaOS
+
+<RSDK />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/low-level-dev/u-boot.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/low-level-dev/u-boot.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 1
+description: "Easily build a personalised U-boot with the Radxa BSP tool to start the innovation journey of smart hardware"
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_u-boot.mdx
+---
+
+import UBOOT from '../../../common/dev/\_u-boot.mdx'
+
+# U-boot Development
+
+<UBOOT model="Radxa ROCK 4D" profile="rk2410" product="rock-4d"/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 17
+---
+
+# Low-Level Development
+
+A brief introduction to low-level development for the Radxa NX4.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/kernel.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/kernel.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 description: "Easily build personalised Linux kernels and enjoy custom hardware development with the Radxa BSP tool"
 
 doc_kind: wrapper
@@ -12,4 +12,4 @@ import KERNEL from '../../../common/dev/\_kernel.mdx'
 
 # Kernel Development
 
-<KERNEL model="Radxa ROCK 4D" soc="rk3576" />
+<KERNEL model="Radxa NX4" soc="rk3576" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/rsdk.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/rsdk.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 3
+description: "Customise your system with the RSDK tool"
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rsdk.mdx
+---
+
+import RSDK from '../../../common/dev/\_rsdk.mdx'
+
+# Build RadxaOS
+
+<RSDK />

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/u-boot.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/u-boot.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 1
+description: "Easily build a personalised U-boot with the Radxa BSP tool to start the innovation journey of smart hardware"
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_u-boot.mdx
+---
+
+import UBOOT from '../../../common/dev/\_u-boot.mdx'
+
+# U-boot Development
+
+<UBOOT model="Radxa NX4" profile="rk2410" product="nx4"/>


### PR DESCRIPTION
## Changes

### ROCK 4D (Chinese + English)
- Replace old Dev Container-based Kernel development tutorial with bsp approach
- Add U-boot development tutorial (bsp approach)
- Add RSDK (Build RadxaOS) tutorial

### NX4 (Chinese + English)
- Create new low-level-dev directory between hardware-use and accessories-use
- Add U-boot development tutorial
- Add Kernel development tutorial
- Add RSDK (Build RadxaOS) tutorial

### Common (Chinese + English)
- Update RK3576 SoC note in _kernel.mdx, _u-boot.mdx, _rsdk.mdx (both zh and en):
  - From: Radxa CM4 uses Rockchip RK3576 SoC
  - To: Radxa CM4 / NX4 and ROCK 4D use Rockchip RK3576 SoC

## Files Changed

### Chinese
- docs/rock4/rock4d/low-level-dev/kernel.md (replaced)
- docs/rock4/rock4d/low-level-dev/u-boot.md (new)
- docs/rock4/rock4d/low-level-dev/rsdk.md (new)
- docs/som/nx/nx4/low-level-dev/* (new directory)
- docs/common/dev/_kernel.mdx (updated note)
- docs/common/dev/_u-boot.mdx (updated note)
- docs/common/dev/_rsdk.mdx (updated note)

### English i18n
- i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/low-level-dev/kernel.md (fixed import source)
- i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/low-level-dev/u-boot.md (new)
- i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/low-level-dev/rsdk.md (new)
- i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/* (new directory)
- i18n/en/docusaurus-plugin-content-docs/current/common/dev/_kernel.mdx (updated note)
- i18n/en/docusaurus-plugin-content-docs/current/common/dev/_u-boot.mdx (updated note)
- i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rsdk.mdx (updated note)
