### PR TITLE
fix: docs path error

### DIFF
--- a/docs/rock4/rock4d/low-level-dev/kernel.md
+++ b/docs/rock4/rock4d/low-level-dev/kernel.md
@@ -8,7 +8,7 @@ imports_resolve_to:
   - docs/common/dev/_kernel.mdx
 ---
 
-import KERNEL from '../../../../common/dev/\_kernel.mdx'
+import KERNEL from '../../../common/dev/\_kernel.mdx'
 
 # Kernel 开发
 

--- a/docs/rock4/rock4d/low-level-dev/rsdk.md
+++ b/docs/rock4/rock4d/low-level-dev/rsdk.md
@@ -8,7 +8,7 @@ imports_resolve_to:
   - docs/common/dev/_rsdk.mdx
 ---
 
-import RSDK from '../../../../common/dev/\_rsdk.mdx'
+import RSDK from '../../../common/dev/\_rsdk.mdx'
 
 # 编译 RadxaOS
 

--- a/docs/rock4/rock4d/low-level-dev/u-boot.md
+++ b/docs/rock4/rock4d/low-level-dev/u-boot.md
@@ -8,7 +8,7 @@ imports_resolve_to:
   - docs/common/dev/_u-boot.mdx
 ---
 
-import UBOOT from '../../../../common/dev/\_u-boot.mdx'
+import UBOOT from '../../../common/dev/\_u-boot.mdx'
 
 # U-boot 开发
 

--- a/docs/som/nx/nx4/low-level-dev/kernel.md
+++ b/docs/som/nx/nx4/low-level-dev/kernel.md
@@ -8,7 +8,7 @@ imports_resolve_to:
   - docs/common/dev/_kernel.mdx
 ---
 
-import KERNEL from '../../../../../common/dev/\_kernel.mdx'
+import KERNEL from '../../../../common/dev/\_kernel.mdx'
 
 # Kernel 开发
 

--- a/docs/som/nx/nx4/low-level-dev/rsdk.md
+++ b/docs/som/nx/nx4/low-level-dev/rsdk.md
@@ -8,7 +8,7 @@ imports_resolve_to:
   - docs/common/dev/_rsdk.mdx
 ---
 
-import RSDK from '../../../../../common/dev/\_rsdk.mdx'
+import RSDK from '../../../../common/dev/\_rsdk.mdx'
 
 # 编译 RadxaOS
 

--- a/docs/som/nx/nx4/low-level-dev/u-boot.md
+++ b/docs/som/nx/nx4/low-level-dev/u-boot.md
@@ -8,7 +8,7 @@ imports_resolve_to:
   - docs/common/dev/_u-boot.mdx
 ---
 
-import UBOOT from '../../../../../common/dev/\_u-boot.mdx'
+import UBOOT from '../../../../common/dev/\_u-boot.mdx'
 
 # U-boot 开发
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/kernel.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/kernel.md
@@ -8,7 +8,7 @@ imports_resolve_to:
   - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_kernel.mdx
 ---
 
-import KERNEL from '../../../common/dev/\_kernel.mdx'
+import KERNEL from '../../../../common/dev/\_kernel.mdx'
 
 # Kernel Development
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/rsdk.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/rsdk.md
@@ -8,7 +8,7 @@ imports_resolve_to:
   - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rsdk.mdx
 ---
 
-import RSDK from '../../../common/dev/\_rsdk.mdx'
+import RSDK from '../../../../common/dev/\_rsdk.mdx'
 
 # Build RadxaOS
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/u-boot.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/low-level-dev/u-boot.md
@@ -8,7 +8,7 @@ imports_resolve_to:
   - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_u-boot.mdx
 ---
 
-import UBOOT from '../../../common/dev/\_u-boot.mdx'
+import UBOOT from '../../../../common/dev/\_u-boot.mdx'
 
 # U-boot Development
 


### PR DESCRIPTION
## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
