### PR TITLE
docs: add motherboard overview and interface description to ROCK 5 ITX hardware-interface page

### DIFF
--- a/docs/common/ai/_qai-appbuilder.mdx
+++ b/docs/common/ai/_qai-appbuilder.mdx
@@ -123,8 +123,8 @@ pip3 install ./qai_appbuilder-2.34.0-cp312-cp312-linux_aarch64.whl
 <NewCodeBlock tip="Device" type="device">
 
 ```bash
-cd ../../
-ln -s qairt/2.37.1.250807/lib/aarch64-oe-linux-gcc11.2/ ai-engine-direct-helper/samples/python/qai_libs
+cd ../..
+ln -s $QAIRT_SDK_ROOT/lib/aarch64-oe-linux-gcc11.2 ai-engine-direct-helper/samples/python/qai_libs
 ```
 
 </NewCodeBlock>

--- a/docs/rock5/rock5itx/hardware-design/hardware-interface.md
+++ b/docs/rock5/rock5itx/hardware-design/hardware-interface.md
@@ -12,9 +12,318 @@ sidebar_position: 4
 
 <img src="/img/rock5itx/rock5itx-system-block-diagram.webp" alt="rk3588 system diagram" width="700" />
 
-## 实物照片
+## 主板概览
 
-<img src="/img/rock5itx/rock5itx-real.webp" width="600" />
+<Tabs queryString="HardwareVersion">
+
+<TabItem value="ROCK 5ITX v1.11">
+<img src="/img/rock5itx/rock5itx-real-side-v-1-11.webp" width="800" alt="rock 5itx side v1.11" />
+<img src="/img/rock5itx/rock5itx-real-up1-v-1-11.webp" width="800" alt="rock 5itx up v1.11" />
+</TabItem>
+<TabItem value="ROCK 5ITX v1.12">
+<img src="/img/rock5itx/rock5itx-real-side-v-1-12.webp" width="800" alt="rock 5itx side v1.12" />
+</TabItem>
+<TabItem value="ROCK 5ITX+ V1.2">
+<img src="/img/rock5itx/rock5itx-real-side-v-1-2.webp" width="800" alt="rock 5itx side v1.2" />
+<img src="/img/rock5itx/rock5itx-real-up1-v-1-2.webp" width="800" alt="rock 5itx up v1.2" />
+</TabItem>
+
+</Tabs>
+
+## 接口说明
+
+<Tabs queryString="HardwareVersion">
+  <TabItem value="ROCK 5ITX v1.11">
+    <table>
+      <tr>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+      </tr>
+      <tr>
+        <th>1</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#tp-接口">TP 接口</a></th>
+        <th>9</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#spdif-音频接口">SPDIF 音频接口</a></th>
+        <th>17</th>
+        <th>DC 电源接口</th>
+        <th>25</th>
+        <th>Recovery Header</th>
+        <th>33</th>
+        <th>eMMC</th>
+      </tr>
+      <tr>
+        <th>2</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#lcd0">LCD 屏接口</a></th>
+        <th>10</th>
+        <th><a href="">上： Headphone Jack; 下： Microphone Jack</a></th>
+        <th>18</th>
+        <th>POE Header</th>
+        <th>26</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-m-key">M.2 M Key</a></th>
+      </tr>
+      <tr>
+        <th>3</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#摄像头接口">摄像头接口</a></th>
+        <th>11</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-10">USB 3.0 + HDMI</a></th>
+        <th>19</th>
+        <th>标准 24-Pin ATX 电源接口</th>
+        <th>27</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-e-key">M.2 E Key</a></th>
+      </tr>
+      <tr>
+        <th>4</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#miscro-sd">MicroSD</a></th>
+        <th>12</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
+        <th>20</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4个带供电的 SATA 接口</a></th>
+        <th>28</th>
+        <th>Rockchip RK3588</th>
+      </tr>
+      <tr>
+        <th>5</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#debug-uart">DEBUG UART</a></th>
+        <th>13</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#以太网--usb-20-12">以太网 + USB 2.0</a></th>
+        <th>21</th>
+        <th>5V/GND/GND/12V</th>
+        <th>29</th>
+        <th>LPDDR5 RAM</th>
+      </tr>
+      <tr>
+        <th>6</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_usb">F_USB</a></th>
+        <th>14</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#以太网--usb-20-13">以太网 + USB 2.0</a></th>
+        <th>22</th>
+        <th>EDP</th>
+        <th>30</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#fan">FAN</a></th>
+      </tr>
+      <tr>
+        <th>7</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_audio">F_AUDIO</a></th>
+        <th>15</th>
+        <th>HDMI IN</th>
+        <th>23</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#rtc">RTC</a></th>
+        <th>31</th>
+        <th>风扇螺丝孔</th>
+      </tr>
+      <tr>
+        <th>8</th>
+        <th>F_PANEL</th>
+        <th>16</th>
+        <th>全功能 Type C</th>
+        <th>24</th>
+        <th>Maskrom 按键</th>
+        <th>32</th>
+        <th>SPI Flash</th>
+      </tr>
+    </table>
+  </TabItem>
+  <TabItem value="ROCK 5ITX v1.12">
+    <table>
+      <tr>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+      </tr>
+      <tr>
+        <th>1</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#tp-接口">TP 接口</a></th>
+        <th>9</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#spdif-音频接口">SPDIF 音频接口</a></th>
+        <th>17</th>
+        <th>DC 电源接口</th>
+        <th>25</th>
+        <th>Recovery Header</th>
+        <th>33</th>
+        <th>eMMC</th>
+      </tr>
+      <tr>
+        <th>2</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#lcd0">LCD 屏接口</a></th>
+        <th>10</th>
+        <th><a href="">上： Headphone Jack; 下： Microphone Jack</a></th>
+        <th>18</th>
+        <th>POE Header</th>
+        <th>26</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-m-key">M.2 M Key</a></th>
+      </tr>
+      <tr>
+        <th>3</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#摄像头接口">摄像头接口</a></th>
+        <th>11</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-10">USB 3.0 + HDMI</a></th>
+        <th>19</th>
+        <th>标准 24-Pin ATX 电源接口</th>
+        <th>27</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-e-key">M.2 E Key</a></th>
+      </tr>
+      <tr>
+        <th>4</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#miscro-sd">MicroSD</a></th>
+        <th>12</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
+        <th>20</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4个带供电的 SATA 接口</a></th>
+        <th>28</th>
+        <th>Rockchip RK3588</th>
+      </tr>
+      <tr>
+        <th>5</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#debug-uart">DEBUG UART</a></th>
+        <th>13</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#以太网--usb-20-12">以太网 + USB 2.0</a></th>
+        <th>21</th>
+        <th>5V/GND/GND/12V</th>
+        <th>29</th>
+        <th>LPDDR5 RAM</th>
+      </tr>
+      <tr>
+        <th>6</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_usb">F_USB</a></th>
+        <th>14</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#以太网--usb-20-13">以太网 + USB 2.0</a></th>
+        <th>22</th>
+        <th>EDP</th>
+        <th>30</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#fan">FAN</a></th>
+      </tr>
+      <tr>
+        <th>7</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_audio">F_AUDIO</a></th>
+        <th>15</th>
+        <th>HDMI IN</th>
+        <th>23</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#rtc">立式 RTC 座子</a></th>
+        <th>31</th>
+        <th>风扇螺丝孔</th>
+      </tr>
+      <tr>
+        <th>8</th>
+        <th>F_PANEL</th>
+        <th>16</th>
+        <th>全功能 Type C</th>
+        <th>24</th>
+        <th>Maskrom 按键</th>
+        <th>32</th>
+        <th>SPI Flash</th>
+      </tr>
+    </table>
+  </TabItem>
+  <TabItem value="ROCK 5ITX+ V1.2">
+    <table>
+      <tr>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+        <th>编号</th>
+        <th>接口名</th>
+      </tr>
+      <tr>
+        <th>1</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#tp-接口">TP 接口</a></th>
+        <th>9</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#spdif-音频接口">SPDIF 音频接口</a></th>
+        <th>17</th>
+        <th>DC 电源接口</th>
+        <th>25</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-m-key">M.2 M Key</a></th>
+      </tr>
+      <tr>
+        <th>2</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#lcd0">LCD 屏接口</a></th>
+        <th>10</th>
+        <th><a href="">上： Headphone Jack; 下： Microphone Jack</a></th>
+        <th>18</th>
+        <th>POE Header</th>
+        <th>26</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-e-key">M.2 E Key</a></th>
+      </tr>
+      <tr>
+        <th>3</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#摄像头接口">摄像头接口</a></th>
+        <th>11</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-10">USB 3.0 + HDMI</a></th>
+        <th>19</th>
+        <th>标准 24-Pin ATX 电源接口</th>
+        <th>27</th>
+        <th>Rockchip RK3588</th>
+      </tr>
+      <tr>
+        <th>4</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#miscro-sd">MicroSD</a></th>
+        <th>12</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
+        <th>20</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-m-key">M.2 M Key</a></th>
+        <th>28</th>
+        <th>LPDDR5 RAM</th>
+      </tr>
+      <tr>
+        <th>5</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#debug-uart">DEBUG UART</a></th>
+        <th>13</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#以太网--usb-20-12">以太网 + USB 2.0</a></th>
+        <th>21</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#rtc">RTC</a></th>
+        <th>29</th>
+        <th>SPI Flash</th>
+      </tr>
+      <tr>
+        <th>6</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_usb">F_USB</a></th>
+        <th>14</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#以太网--usb-20-13">以太网 + USB 2.0</a></th>
+        <th>22</th>
+        <th>EDP</th>
+        <th>30</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#fan">FAN</a></th>
+      </tr>
+      <tr>
+        <th>7</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_audio">F_AUDIO</a></th>
+        <th>15</th>
+        <th>HDMI IN</th>
+        <th>23</th>
+        <th>Maskrom 按键</th>
+        <th>31</th>
+        <th>eMMC</th>
+      </tr>
+      <tr>
+        <th>8</th>
+        <th>F_PANEL</th>
+        <th>16</th>
+        <th>全功能 Type C</th>
+        <th>24</th>
+        <th>Recovery</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </table>
+  </TabItem>
+</Tabs>
 
 以下是各个硬件接口的详细接口线序以及说明。
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_qai-appbuilder.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_qai-appbuilder.mdx
@@ -126,8 +126,8 @@ Create a `qai_libs` symlink in `ai-engine-direct-helper/samples/python` to link 
 <NewCodeBlock tip="Device" type="device">
 
 ```bash
-cd ../../
-ln -s qairt/2.37.1.250807/lib/aarch64-oe-linux-gcc11.2/ ai-engine-direct-helper/samples/python/qai_libs
+cd ../..
+ln -s $QAIRT_SDK_ROOT/lib/aarch64-oe-linux-gcc11.2 ai-engine-direct-helper/samples/python/qai_libs
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/hardware-design/hardware-interface.md
@@ -12,9 +12,318 @@ sidebar_position: 4
 
 <img src="/img/rock5itx/rock5itx-system-block-diagram.webp" alt="rk3588 system diagram" width="700" />
 
-## Physical image
+## Motherboard Overview
 
-<img src="/img/rock5itx/rock5itx-real.webp" width="600" />
+<Tabs queryString="HardwareVersion">
+
+<TabItem value="ROCK 5ITX v1.11">
+<img src="/img/rock5itx/rock5itx-real-side-v-1-11.webp" width="800" alt="rock 5itx side v1.11" />
+<img src="/img/rock5itx/rock5itx-real-up1-v-1-11.webp" width="800" alt="rock 5itx up v1.11" />
+</TabItem>
+<TabItem value="ROCK 5ITX v1.12">
+<img src="/img/rock5itx/rock5itx-real-side-v-1-12.webp" width="800" alt="rock 5itx side v1.12" />
+</TabItem>
+<TabItem value="ROCK 5ITX+ V1.2">
+<img src="/img/rock5itx/rock5itx-real-side-v-1-2.webp" width="800" alt="rock 5itx side v1.2" />
+<img src="/img/rock5itx/rock5itx-real-up1-v-1-2.webp" width="800" alt="rock 5itx up v1.2" />
+</TabItem>
+
+</Tabs>
+
+## Interface description
+
+<Tabs queryString="HardwareVersion">
+  <TabItem value="ROCK 5ITX v1.11">
+    <table>
+      <tr>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+      </tr>
+      <tr>
+        <th>1</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#tp-interface">TP Interface</a></th>
+        <th>9</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#spdif-audio-interface">SPDIF Audio Interface</a></th>
+        <th>17</th>
+        <th>DC Power Interface</th>
+        <th>25</th>
+        <th>Recovery Header</th>
+        <th>33</th>
+        <th>eMMC</th>
+      </tr>
+      <tr>
+        <th>2</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#lcd0">LCD screen interface</a></th>
+        <th>10</th>
+        <th><a >Top: Headphone Jack; Bottom: Microphone Jack</a></th>
+        <th>18</th>
+        <th>POE Header</th>
+        <th>26</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-m-key">M.2 M Key</a></th>
+      </tr>
+      <tr>
+        <th>3</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#camera-interface">Camera Interface</a></th>
+        <th>11</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-10">USB 3.0 + HDMI</a></th>
+        <th>19</th>
+        <th>Standard 24-Pin ATX Power Supply Interface</th>
+        <th>27</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-e-key">M.2 E Key</a></th>
+      </tr>
+      <tr>
+        <th>4</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#miscro-sd">MicroSD</a></th>
+        <th>12</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
+        <th>20</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4 Powered SATA Interfaces</a></th>
+        <th>28</th>
+        <th>Rockchip RK3588</th>
+      </tr>
+      <tr>
+        <th>5</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#debug-uart">DEBUG UART</a></th>
+        <th>13</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#ethernet--usb-20-12">Ethernet + USB 2.0</a></th>
+        <th>21</th>
+        <th>5V/GND/GND/12V</th>
+        <th>29</th>
+        <th>LPDDR5 RAM</th>
+      </tr>
+      <tr>
+        <th>6</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_usb">F_USB</a></th>
+        <th>14</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#ethernet--usb-20-13">Ethernet + USB 2.0</a></th>
+        <th>22</th>
+        <th>EDP</th>
+        <th>30</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#fan">FAN</a></th>
+      </tr>
+      <tr>
+        <th>7</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_audio">F_AUDIO</a></th>
+        <th>15</th>
+        <th>HDMI IN</th>
+        <th>23</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#rtc">RTC</a></th>
+        <th>31</th>
+        <th>Fan screw holes</th>
+      </tr>
+      <tr>
+        <th>8</th>
+        <th>F_PANEL</th>
+        <th>16</th>
+        <th>Full Feature Type C</th>
+        <th>24</th>
+        <th>Maskrom Button</th>
+        <th>32</th>
+        <th>SPI Flash</th>
+      </tr>
+    </table>
+  </TabItem>
+  <TabItem value="ROCK 5ITX v1.12">
+    <table>
+      <tr>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+      </tr>
+      <tr>
+        <th>1</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#tp-interface">TP Interface</a></th>
+        <th>9</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#spdif-audio-interface">SPDIF Audio Interface</a></th>
+        <th>17</th>
+        <th>DC Power Interface</th>
+        <th>25</th>
+        <th>Recovery Header</th>
+        <th>33</th>
+        <th>eMMC</th>
+      </tr>
+      <tr>
+        <th>2</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#lcd0">LCD screen interface</a></th>
+        <th>10</th>
+        <th><a >Top: Headphone Jack; Bottom: Microphone Jack</a></th>
+        <th>18</th>
+        <th>POE Header</th>
+        <th>26</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-m-key">M.2 M Key</a></th>
+      </tr>
+      <tr>
+        <th>3</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#camera-interface">Camera Interface</a></th>
+        <th>11</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-10">USB 3.0 + HDMI</a></th>
+        <th>19</th>
+        <th>Standard 24-Pin ATX Power Supply Interface</th>
+        <th>27</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-e-key">M.2 E Key</a></th>
+      </tr>
+      <tr>
+        <th>4</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#miscro-sd">MicroSD</a></th>
+        <th>12</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
+        <th>20</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4 Powered SATA Interfaces</a></th>
+        <th>28</th>
+        <th>Rockchip RK3588</th>
+      </tr>
+      <tr>
+        <th>5</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#debug-uart">DEBUG UART</a></th>
+        <th>13</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#ethernet--usb-20-12">Ethernet + USB 2.0</a></th>
+        <th>21</th>
+        <th>5V/GND/GND/12V</th>
+        <th>29</th>
+        <th>LPDDR5 RAM</th>
+      </tr>
+      <tr>
+        <th>6</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_usb">F_USB</a></th>
+        <th>14</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#ethernet--usb-20-13">Ethernet + USB 2.0</a></th>
+        <th>22</th>
+        <th>EDP</th>
+        <th>30</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#fan">FAN</a></th>
+      </tr>
+      <tr>
+        <th>7</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_audio">F_AUDIO</a></th>
+        <th>15</th>
+        <th>HDMI IN</th>
+        <th>23</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#rtc">Desktop RTC Socket</a></th>
+        <th>31</th>
+        <th>Fan screw holes</th>
+      </tr>
+      <tr>
+        <th>8</th>
+        <th>F_PANEL</th>
+        <th>16</th>
+        <th>Full Feature Type C</th>
+        <th>24</th>
+        <th>Maskrom Button</th>
+        <th>32</th>
+        <th>SPI Flash</th>
+      </tr>
+    </table>
+  </TabItem>
+  <TabItem value="ROCK 5ITX+ V1.2">
+    <table>
+      <tr>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+        <th>Number</th>
+        <th>Interface name</th>
+      </tr>
+      <tr>
+        <th>1</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#tp-interface">TP Interface</a></th>
+        <th>9</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#spdif-audio-interface">SPDIF Audio Interface</a></th>
+        <th>17</th>
+        <th>DC Power Interface</th>
+        <th>25</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-m-key">M.2 M Key</a></th>
+      </tr>
+      <tr>
+        <th>2</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#lcd0">LCD screen interface</a></th>
+        <th>10</th>
+        <th><a >Top: Headphone Jack; Bottom: Microphone Jack</a></th>
+        <th>18</th>
+        <th>POE Header</th>
+        <th>26</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-e-key">M.2 E Key</a></th>
+      </tr>
+      <tr>
+        <th>3</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#camera-interface">Camera Interface</a></th>
+        <th>11</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-10">USB 3.0 + HDMI</a></th>
+        <th>19</th>
+        <th>Standard 24-Pin ATX Power Supply Interface</th>
+        <th>27</th>
+        <th>Rockchip RK3588</th>
+      </tr>
+      <tr>
+        <th>4</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#miscro-sd">MicroSD</a></th>
+        <th>12</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
+        <th>20</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#pcie-m-key">M.2 M Key</a></th>
+        <th>28</th>
+        <th>LPDDR5 RAM</th>
+      </tr>
+      <tr>
+        <th>5</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#debug-uart">DEBUG UART</a></th>
+        <th>13</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#ethernet--usb-20-12">Ethernet + USB 2.0</a></th>
+        <th>21</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#rtc">RTC</a></th>
+        <th>29</th>
+        <th>SPI Flash</th>
+      </tr>
+      <tr>
+        <th>6</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_usb">F_USB</a></th>
+        <th>14</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#ethernet--usb-20-13">Ethernet + USB 2.0</a></th>
+        <th>22</th>
+        <th>EDP</th>
+        <th>30</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#fan">FAN</a></th>
+      </tr>
+      <tr>
+        <th>7</th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#f_audio">F_AUDIO</a></th>
+        <th>15</th>
+        <th>HDMI IN</th>
+        <th>23</th>
+        <th>Maskrom Button</th>
+        <th>31</th>
+        <th>eMMC</th>
+      </tr>
+      <tr>
+        <th>8</th>
+        <th>F_PANEL</th>
+        <th>16</th>
+        <th>Full Feature Type C</th>
+        <th>24</th>
+        <th>Recovery</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </table>
+  </TabItem>
+</Tabs>
 
 The following are the detailed interface wiring sequences and descriptions for each hardware interface.
 


### PR DESCRIPTION
Move board overview photos and interface description tables from the getting-started introduction page into the hardware-interface page, replacing the original single physical image section. Changes applied to both zh and en versions.