### PR TITLE
docs(orion): add Debian 13 CIX PPA guides for O6 and O6N

### DIFF
--- a/docs/orion/download.md
+++ b/docs/orion/download.md
@@ -9,7 +9,7 @@ sidebar_position: 150
 :::info 快速导航
 
 - [BIOS 固件](#bios-固件)
-- [系统镜像（Radxa OS / Android / OpenHarmony / Fedora）](#系统镜像)
+- [系统镜像（Radxa OS / Android / OpenHarmony / Fedora / Debian 13）](#系统镜像)
 - [硬件设计资料](#硬件设计)
 - [社区资源](#社区资源)
 - [参考手册](#参考手册)
@@ -133,6 +133,15 @@ Fedora 系统的默认凭据如下：
 | :----- | :-------- |
 | 用户名 | `root`    |
 | 密码   | `aarch64` |
+
+### Debian 13
+
+Debian 13 适合需要使用 CIX 社区开源驱动栈的开发者。该方案现已支持瑞莎星睿 O6 和 O6N，采用手动安装 Debian 13 (trixie) 后再通过 CIX PPA 安装开源驱动的方式，不提供现成的 DD 系统镜像。
+
+- Orion O6 使用说明：[Orion O6 Debian 13](./o6/other-os/debian13.md)
+- Orion O6N 使用说明：[Orion O6N Debian 13](./o6n/other-os/debian13.md)
+- 适用场景：主线内核验证、NPU / VPU 驱动调试、社区开发测试
+- 注意：该方案基于开发内核 `7.0.0-rc5-generic`，安装前需在 BIOS 中启用 `Enable ACPI SCMI`
 
 ## 硬件设计
 

--- a/docs/orion/o6/other-os/README.md
+++ b/docs/orion/o6/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 40
+---
+
+# 其他系统
+
+介绍 Orion O6 上除官方 Radxa OS 之外的其他系统与相关说明。
+
+<DocCardList />

--- a/docs/orion/o6/other-os/debian13.md
+++ b/docs/orion/o6/other-os/debian13.md
@@ -90,13 +90,13 @@ CIX 的开源驱动方案基于主线开发内核，核心内容包括：
 开源驱动方案依赖 Debian 13 backports 中的较新固件。先执行：
 
 ```bash
-echo "deb http://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee -a /etc/apt/sources.list
+echo "deb https://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee /etc/apt/sources.list.d/debian-trixie-backports.list
 sudo apt update
 sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
 ```
 
 :::tip 国内镜像
-如果你的网络环境更适合国内镜像，可以将 `deb.debian.org` 替换为常用的 Debian 镜像站。
+如果你的网络环境更适合国内镜像，可以将 `deb.debian.org` 替换为常用的 Debian 镜像站，并保持使用独立的 `.list` 文件。
 :::
 
 ### 2. 运行 CIX 配置脚本

--- a/docs/orion/o6/other-os/debian13.md
+++ b/docs/orion/o6/other-os/debian13.md
@@ -106,7 +106,13 @@ curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-communi
 sudo sh ./cix-repo-community.sh
 ```
 
-脚本运行后会提示选择驱动方案，请输入 `2` 安装开源驱动。
+脚本运行后会提示选择操作项，常见选项如下：
+
+- `1`：安装闭源驱动方案
+- `2`：安装开源驱动方案
+- `3`：卸载已安装的 CIX 驱动方案
+
+如果你要安装本文所述的开源驱动方案，请输入 `2`。
 
 :::warning 执行脚本前请先检查内容
 请先检查下载到本地的脚本内容，再使用 `sudo sh` 执行，避免直接以 root 权限执行远端返回内容。

--- a/docs/orion/o6/other-os/debian13.md
+++ b/docs/orion/o6/other-os/debian13.md
@@ -103,7 +103,6 @@ sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
 
 ```bash
 curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
-less cix-repo-community.sh
 sudo sh ./cix-repo-community.sh
 ```
 
@@ -176,7 +175,6 @@ apt search cix-
 
 ```bash
 curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
-less cix-repo-community.sh
 sudo sh ./cix-repo-community.sh
 ```
 

--- a/docs/orion/o6/other-os/debian13.md
+++ b/docs/orion/o6/other-os/debian13.md
@@ -102,10 +102,16 @@ sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
 ### 2. 运行 CIX 配置脚本
 
 ```bash
-curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
+less cix-repo-community.sh
+sudo sh ./cix-repo-community.sh
 ```
 
 脚本运行后会提示选择驱动方案，请输入 `2` 安装开源驱动。
+
+:::warning 执行脚本前请先检查内容
+请先检查下载到本地的脚本内容，再使用 `sudo sh` 执行，避免直接以 root 权限执行远端返回内容。
+:::
 
 ### 3. 重启系统
 
@@ -144,9 +150,10 @@ CIX 配置脚本会自动完成以下操作：
 
 ### 更新系统
 
+建议直接使用以下命令完成系统更新：
+
 ```bash
 sudo apt update
-sudo apt upgrade
 sudo apt full-upgrade
 ```
 
@@ -168,7 +175,9 @@ apt search cix-
 再次运行脚本，并在交互菜单中选择 `3`：
 
 ```bash
-curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
+less cix-repo-community.sh
+sudo sh ./cix-repo-community.sh
 ```
 
 脚本会移除开源内核包、CIX 相关配置，并尝试将系统恢复到安装前状态。

--- a/docs/orion/o6/other-os/debian13.md
+++ b/docs/orion/o6/other-os/debian13.md
@@ -32,7 +32,8 @@ CIX 的开源驱动方案基于主线开发内核，核心内容包括：
 - 已将设备 BIOS 更新到较新版本：
   - Orion O6：请参考 [BIOS 更新](../low-level-dev/bios.md)
   - Orion O6N：请参考 [Orion O6N BIOS 更新](../../o6n/low-level-dev/bios.md)
-- 已手动安装 **Debian 13 (trixie)**，并可以正常联网
+- 已准备一个容量不小于 8GB 的 U 盘
+- 已准备一台可用于下载镜像并写入 U 盘的电脑
 - 当前用户具备 `sudo` 权限
 
 :::warning BIOS 必选配置
@@ -43,7 +44,46 @@ CIX 的开源驱动方案基于主线开发内核，核心内容包括：
 
 :::
 
-## 快速安装
+## 安装 Debian 13
+
+### 1. 下载 Debian 13 安装镜像
+
+请下载 **Debian 13 arm64** 安装镜像。若希望直接安装桌面系统，建议选择带 GNOME 的安装镜像；如果选择 `netinst`，也可以在安装过程中手动选择 GNOME 桌面环境。
+
+可参考以下镜像目录：
+
+- Debian 官方：<https://cdimage.debian.org/debian-cd/current/arm64/>
+- 清华大学：<https://mirrors.tuna.tsinghua.edu.cn/debian-cd/current/arm64/>
+- 中国科学技术大学：<https://mirrors.ustc.edu.cn/debian-cd/current/arm64/>
+- 阿里云：<https://mirrors.aliyun.com/debian-cd/current/arm64/>
+
+### 2. 将镜像写入 U 盘
+
+将下载好的 Debian 13 安装镜像写入 U 盘。可以使用以下任意工具：
+
+- Balena Etcher
+- Rufus
+- `dd`
+
+### 3. 从 U 盘启动并安装系统
+
+将 U 盘插入设备后，从 BIOS 启动菜单选择 U 盘启动，并按照 Debian 安装程序提示完成系统安装。
+
+安装目标介质建议如下：
+
+- Orion O6：安装到 NVMe SSD
+- Orion O6N：安装到 NVMe SSD 或 UFS 模块
+
+### 4. 首次进入系统
+
+安装完成后，进入 Debian 13 系统并确认：
+
+- 系统可以正常联网
+- 当前用户具备 `sudo` 权限
+
+然后继续下一节配置 CIX PPA 并安装开源驱动。
+
+## 配置 CIX PPA 并安装开源驱动
 
 ### 1. 配置 backports 并安装依赖
 

--- a/docs/orion/o6/other-os/debian13.md
+++ b/docs/orion/o6/other-os/debian13.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 1
+---
+
+# Debian 13
+
+本文介绍如何在 **Radxa Orion O6 / Orion O6N** 上使用 **Debian 13 (trixie)**，并通过 CIX 提供的社区软件源安装开源驱动方案。
+
+:::warning 适用范围
+
+- 本文档仅适用于 **Debian 13 (trixie)**
+- 本方案面向内核开发、驱动验证和社区尝鲜用户
+- 如需稳定的日常使用或生产部署，建议优先使用瑞莎官方系统镜像；如需 CIX 的稳定驱动方案，请参考其闭源驱动分支（内核 6.6）
+
+:::
+
+## 方案说明
+
+CIX 的开源驱动方案基于主线开发内核，核心内容包括：
+
+- `linux-image-7.0.0-rc5-generic`
+- `linux-headers-7.0.0-rc5-generic`
+- `cix-npu-driver-dkms`
+- `cix-vpu-driver-dkms`
+
+与整盘 DD 镜像相比，这种方式可以直接通过 `apt` 管理安装、更新和卸载，更适合开发调试场景。
+
+## 前置准备
+
+开始前请确认：
+
+- 已将设备 BIOS 更新到较新版本：
+  - Orion O6：请参考 [BIOS 更新](../low-level-dev/bios.md)
+  - Orion O6N：请参考 [Orion O6N BIOS 更新](../../o6n/low-level-dev/bios.md)
+- 已手动安装 **Debian 13 (trixie)**，并可以正常联网
+- 当前用户具备 `sudo` 权限
+
+:::warning BIOS 必选配置
+
+刷写 BIOS 完成后，请手动进入 BIOS 开启以下选项，否则 `7.0` 内核下部分驱动可能加载失败：
+
+`Device Manager` -> `Platform Configuration` -> `Compliance Configuration` -> `Enable ACPI SCMI`
+
+:::
+
+## 快速安装
+
+### 1. 配置 backports 并安装依赖
+
+开源驱动方案依赖 Debian 13 backports 中的较新固件。先执行：
+
+```bash
+echo "deb http://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee -a /etc/apt/sources.list
+sudo apt update
+sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
+```
+
+:::tip 国内镜像
+如果你的网络环境更适合国内镜像，可以将 `deb.debian.org` 替换为常用的 Debian 镜像站。
+:::
+
+### 2. 运行 CIX 配置脚本
+
+```bash
+curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+```
+
+脚本运行后会提示选择驱动方案，请输入 `2` 安装开源驱动。
+
+### 3. 重启系统
+
+```bash
+sudo reboot
+```
+
+## 安装后验证
+
+重启后，可以用下面的命令确认系统已切换到开源驱动方案：
+
+```bash
+uname -r
+dpkg -l | grep firmware-misc-nonfree
+dpkg -l | grep cix
+```
+
+正常情况下，`uname -r` 应显示 `7.0.0-rc5-generic`。
+
+## 软件源与关键路径
+
+CIX 配置脚本会自动完成以下操作：
+
+- 导入软件源 GPG 密钥
+- 写入 CIX APT 源配置
+- 安装开源内核与 DKMS 驱动
+- 更新 GRUB 默认启动项
+
+相关路径如下：
+
+- APT 源配置：`/etc/apt/sources.list.d/cix-deb-repo.list`
+- GPG 密钥：`/usr/share/keyrings/cix-deb-repo.gpg`
+- GRUB 配置：`/etc/cix/grub-config.env`
+
+## 日常维护
+
+### 更新系统
+
+```bash
+sudo apt update
+sudo apt upgrade
+sudo apt full-upgrade
+```
+
+### 查看已安装的 CIX 软件包
+
+```bash
+dpkg -l | grep cix
+apt list --installed | grep cix
+```
+
+### 搜索可用软件包
+
+```bash
+apt search cix-
+```
+
+## 卸载开源驱动
+
+再次运行脚本，并在交互菜单中选择 `3`：
+
+```bash
+curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+```
+
+脚本会移除开源内核包、CIX 相关配置，并尝试将系统恢复到安装前状态。
+
+## 参考资料
+
+- [CIX PPA 用户手册（开源驱动版）](https://github.com/cixtech/cix-developer-docs/wiki/CIX%20PPA%20%E7%94%A8%E6%88%B7%E6%89%8B%E5%86%8C%EF%BC%88%E5%BC%80%E6%BA%90%E9%A9%B1%E5%8A%A8%E7%89%88%EF%BC%89)
+- [CIX 平台主线支持](https://github.com/cixtech/linux-mainline/wiki)

--- a/docs/orion/o6n/other-os/README.md
+++ b/docs/orion/o6n/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 40
+---
+
+# 其他系统
+
+介绍 Orion O6N 上除官方 Radxa OS 之外的其他系统与相关说明。
+
+<DocCardList />

--- a/docs/orion/o6n/other-os/debian13.md
+++ b/docs/orion/o6n/other-os/debian13.md
@@ -32,7 +32,8 @@ CIX 的开源驱动方案基于主线开发内核，核心内容包括：
 - 已将设备 BIOS 更新到较新版本：
   - Orion O6：请参考 [Orion O6 BIOS 更新](../../o6/low-level-dev/bios.md)
   - Orion O6N：请参考 [BIOS 更新](../low-level-dev/bios.md)
-- 已手动安装 **Debian 13 (trixie)**，并可以正常联网
+- 已准备一个容量不小于 8GB 的 U 盘
+- 已准备一台可用于下载镜像并写入 U 盘的电脑
 - 当前用户具备 `sudo` 权限
 
 :::warning BIOS 必选配置
@@ -43,7 +44,46 @@ CIX 的开源驱动方案基于主线开发内核，核心内容包括：
 
 :::
 
-## 快速安装
+## 安装 Debian 13
+
+### 1. 下载 Debian 13 安装镜像
+
+请下载 **Debian 13 arm64** 安装镜像。若希望直接安装桌面系统，建议选择带 GNOME 的安装镜像；如果选择 `netinst`，也可以在安装过程中手动选择 GNOME 桌面环境。
+
+可参考以下镜像目录：
+
+- Debian 官方：<https://cdimage.debian.org/debian-cd/current/arm64/>
+- 清华大学：<https://mirrors.tuna.tsinghua.edu.cn/debian-cd/current/arm64/>
+- 中国科学技术大学：<https://mirrors.ustc.edu.cn/debian-cd/current/arm64/>
+- 阿里云：<https://mirrors.aliyun.com/debian-cd/current/arm64/>
+
+### 2. 将镜像写入 U 盘
+
+将下载好的 Debian 13 安装镜像写入 U 盘。可以使用以下任意工具：
+
+- Balena Etcher
+- Rufus
+- `dd`
+
+### 3. 从 U 盘启动并安装系统
+
+将 U 盘插入设备后，从 BIOS 启动菜单选择 U 盘启动，并按照 Debian 安装程序提示完成系统安装。
+
+安装目标介质建议如下：
+
+- Orion O6：安装到 NVMe SSD
+- Orion O6N：安装到 NVMe SSD 或 UFS 模块
+
+### 4. 首次进入系统
+
+安装完成后，进入 Debian 13 系统并确认：
+
+- 系统可以正常联网
+- 当前用户具备 `sudo` 权限
+
+然后继续下一节配置 CIX PPA 并安装开源驱动。
+
+## 配置 CIX PPA 并安装开源驱动
 
 ### 1. 配置 backports 并安装依赖
 

--- a/docs/orion/o6n/other-os/debian13.md
+++ b/docs/orion/o6n/other-os/debian13.md
@@ -90,13 +90,13 @@ CIX 的开源驱动方案基于主线开发内核，核心内容包括：
 开源驱动方案依赖 Debian 13 backports 中的较新固件。先执行：
 
 ```bash
-echo "deb http://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee -a /etc/apt/sources.list
+echo "deb https://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee /etc/apt/sources.list.d/debian-trixie-backports.list
 sudo apt update
 sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
 ```
 
 :::tip 国内镜像
-如果你的网络环境更适合国内镜像，可以将 `deb.debian.org` 替换为常用的 Debian 镜像站。
+如果你的网络环境更适合国内镜像，可以将 `deb.debian.org` 替换为常用的 Debian 镜像站，并保持使用独立的 `.list` 文件。
 :::
 
 ### 2. 运行 CIX 配置脚本

--- a/docs/orion/o6n/other-os/debian13.md
+++ b/docs/orion/o6n/other-os/debian13.md
@@ -106,7 +106,13 @@ curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-communi
 sudo sh ./cix-repo-community.sh
 ```
 
-脚本运行后会提示选择驱动方案，请输入 `2` 安装开源驱动。
+脚本运行后会提示选择操作项，常见选项如下：
+
+- `1`：安装闭源驱动方案
+- `2`：安装开源驱动方案
+- `3`：卸载已安装的 CIX 驱动方案
+
+如果你要安装本文所述的开源驱动方案，请输入 `2`。
 
 :::warning 执行脚本前请先检查内容
 请先检查下载到本地的脚本内容，再使用 `sudo sh` 执行，避免直接以 root 权限执行远端返回内容。

--- a/docs/orion/o6n/other-os/debian13.md
+++ b/docs/orion/o6n/other-os/debian13.md
@@ -103,7 +103,6 @@ sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
 
 ```bash
 curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
-less cix-repo-community.sh
 sudo sh ./cix-repo-community.sh
 ```
 
@@ -176,7 +175,6 @@ apt search cix-
 
 ```bash
 curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
-less cix-repo-community.sh
 sudo sh ./cix-repo-community.sh
 ```
 

--- a/docs/orion/o6n/other-os/debian13.md
+++ b/docs/orion/o6n/other-os/debian13.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 1
+---
+
+# Debian 13
+
+本文介绍如何在 **Radxa Orion O6 / Orion O6N** 上使用 **Debian 13 (trixie)**，并通过 CIX 提供的社区软件源安装开源驱动方案。
+
+:::warning 适用范围
+
+- 本文档仅适用于 **Debian 13 (trixie)**
+- 本方案面向内核开发、驱动验证和社区尝鲜用户
+- 如需稳定的日常使用或生产部署，建议优先使用瑞莎官方系统镜像；如需 CIX 的稳定驱动方案，请参考其闭源驱动分支（内核 6.6）
+
+:::
+
+## 方案说明
+
+CIX 的开源驱动方案基于主线开发内核，核心内容包括：
+
+- `linux-image-7.0.0-rc5-generic`
+- `linux-headers-7.0.0-rc5-generic`
+- `cix-npu-driver-dkms`
+- `cix-vpu-driver-dkms`
+
+与整盘 DD 镜像相比，这种方式可以直接通过 `apt` 管理安装、更新和卸载，更适合开发调试场景。
+
+## 前置准备
+
+开始前请确认：
+
+- 已将设备 BIOS 更新到较新版本：
+  - Orion O6：请参考 [Orion O6 BIOS 更新](../../o6/low-level-dev/bios.md)
+  - Orion O6N：请参考 [BIOS 更新](../low-level-dev/bios.md)
+- 已手动安装 **Debian 13 (trixie)**，并可以正常联网
+- 当前用户具备 `sudo` 权限
+
+:::warning BIOS 必选配置
+
+刷写 BIOS 完成后，请手动进入 BIOS 开启以下选项，否则 `7.0` 内核下部分驱动可能加载失败：
+
+`Device Manager` -> `Platform Configuration` -> `Compliance Configuration` -> `Enable ACPI SCMI`
+
+:::
+
+## 快速安装
+
+### 1. 配置 backports 并安装依赖
+
+开源驱动方案依赖 Debian 13 backports 中的较新固件。先执行：
+
+```bash
+echo "deb http://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee -a /etc/apt/sources.list
+sudo apt update
+sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
+```
+
+:::tip 国内镜像
+如果你的网络环境更适合国内镜像，可以将 `deb.debian.org` 替换为常用的 Debian 镜像站。
+:::
+
+### 2. 运行 CIX 配置脚本
+
+```bash
+curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+```
+
+脚本运行后会提示选择驱动方案，请输入 `2` 安装开源驱动。
+
+### 3. 重启系统
+
+```bash
+sudo reboot
+```
+
+## 安装后验证
+
+重启后，可以用下面的命令确认系统已切换到开源驱动方案：
+
+```bash
+uname -r
+dpkg -l | grep firmware-misc-nonfree
+dpkg -l | grep cix
+```
+
+正常情况下，`uname -r` 应显示 `7.0.0-rc5-generic`。
+
+## 软件源与关键路径
+
+CIX 配置脚本会自动完成以下操作：
+
+- 导入软件源 GPG 密钥
+- 写入 CIX APT 源配置
+- 安装开源内核与 DKMS 驱动
+- 更新 GRUB 默认启动项
+
+相关路径如下：
+
+- APT 源配置：`/etc/apt/sources.list.d/cix-deb-repo.list`
+- GPG 密钥：`/usr/share/keyrings/cix-deb-repo.gpg`
+- GRUB 配置：`/etc/cix/grub-config.env`
+
+## 日常维护
+
+### 更新系统
+
+```bash
+sudo apt update
+sudo apt upgrade
+sudo apt full-upgrade
+```
+
+### 查看已安装的 CIX 软件包
+
+```bash
+dpkg -l | grep cix
+apt list --installed | grep cix
+```
+
+### 搜索可用软件包
+
+```bash
+apt search cix-
+```
+
+## 卸载开源驱动
+
+再次运行脚本，并在交互菜单中选择 `3`：
+
+```bash
+curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+```
+
+脚本会移除开源内核包、CIX 相关配置，并尝试将系统恢复到安装前状态。
+
+## 参考资料
+
+- [CIX PPA 用户手册（开源驱动版）](https://github.com/cixtech/cix-developer-docs/wiki/CIX%20PPA%20%E7%94%A8%E6%88%B7%E6%89%8B%E5%86%8C%EF%BC%88%E5%BC%80%E6%BA%90%E9%A9%B1%E5%8A%A8%E7%89%88%EF%BC%89)
+- [CIX 平台主线支持](https://github.com/cixtech/linux-mainline/wiki)

--- a/docs/orion/o6n/other-os/debian13.md
+++ b/docs/orion/o6n/other-os/debian13.md
@@ -102,10 +102,16 @@ sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
 ### 2. 运行 CIX 配置脚本
 
 ```bash
-curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
+less cix-repo-community.sh
+sudo sh ./cix-repo-community.sh
 ```
 
 脚本运行后会提示选择驱动方案，请输入 `2` 安装开源驱动。
+
+:::warning 执行脚本前请先检查内容
+请先检查下载到本地的脚本内容，再使用 `sudo sh` 执行，避免直接以 root 权限执行远端返回内容。
+:::
 
 ### 3. 重启系统
 
@@ -144,9 +150,10 @@ CIX 配置脚本会自动完成以下操作：
 
 ### 更新系统
 
+建议直接使用以下命令完成系统更新：
+
 ```bash
 sudo apt update
-sudo apt upgrade
 sudo apt full-upgrade
 ```
 
@@ -168,7 +175,9 @@ apt search cix-
 再次运行脚本，并在交互菜单中选择 `3`：
 
 ```bash
-curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
+less cix-repo-community.sh
+sudo sh ./cix-repo-community.sh
 ```
 
 脚本会移除开源内核包、CIX 相关配置，并尝试将系统恢复到安装前状态。

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/download.md
@@ -9,7 +9,7 @@ This page organizes the download resources for Radxa Orion O6 / O6N by use case.
 :::info Quick Navigation
 
 - [BIOS Firmware](#bios-firmware)
-- [System Images (Radxa OS / Android / OpenHarmony / Fedora)](#system-images)
+- [System Images (Radxa OS / Android / OpenHarmony / Fedora / Debian 13)](#system-images)
 - [Hardware Design Resources](#hardware-design)
 - [Community Resources](#community-resources)
 - [Reference Manuals](#reference-manuals)
@@ -134,6 +134,15 @@ Default Fedora system credentials:
 | :------- | :-------- |
 | Username | `root`    |
 | Password | `aarch64` |
+
+### Debian 13
+
+Debian 13 is intended for developers who want to use the CIX community open-source driver stack. This path now supports both Radxa Orion O6 and O6N. It uses a manually installed Debian 13 (trixie) system together with the CIX PPA open-source driver stack, so there is no prebuilt DD image on this page.
+
+- Orion O6 guide: [Orion O6 Debian 13](./o6/other-os/debian13.md)
+- Orion O6N guide: [Orion O6N Debian 13](./o6n/other-os/debian13.md)
+- Suitable for: mainline kernel validation, NPU / VPU driver debugging, and community development testing
+- Note: this stack is based on the development kernel `7.0.0-rc5-generic`; enable `Enable ACPI SCMI` in BIOS before installation
 
 ## Hardware Design
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 40
+---
+
+# Other OS
+
+Introduces operating systems and related notes for Orion O6 other than the official Radxa OS.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 1
+---
+
+# Debian 13
+
+This document explains how to use **Debian 13 (trixie)** on **Radxa Orion O6 / Orion O6N** and install the open-source driver stack through the CIX community repository.
+
+:::warning Scope
+
+- This document only applies to **Debian 13 (trixie)**
+- This stack is intended for kernel development, driver validation, and early community testing
+- For stable daily use or production deployment, prefer the official Radxa system images; for the stable CIX driver stack, refer to the closed-source branch based on kernel 6.6
+
+:::
+
+## Overview
+
+The CIX open-source driver solution is based on a mainline development kernel and mainly installs:
+
+- `linux-image-7.0.0-rc5-generic`
+- `linux-headers-7.0.0-rc5-generic`
+- `cix-npu-driver-dkms`
+- `cix-vpu-driver-dkms`
+
+Compared with flashing a full DD image, this method is easier to install, update, and remove through `apt`, so it is better suited to development and validation work.
+
+## Prerequisites
+
+Before you begin, make sure:
+
+- Your device BIOS is already updated:
+  - Orion O6: see [BIOS Update](../low-level-dev/bios.md)
+  - Orion O6N: see [Orion O6N BIOS Update](../../o6n/low-level-dev/bios.md)
+- You have manually installed **Debian 13 (trixie)** and have working network access
+- Your current user has `sudo` privileges
+
+:::warning Required BIOS Setting
+
+After flashing the BIOS, enter BIOS Setup and enable the option below. Otherwise, some drivers may fail to load under the `7.0` kernel:
+
+`Device Manager` -> `Platform Configuration` -> `Compliance Configuration` -> `Enable ACPI SCMI`
+
+:::
+
+## Quick Start
+
+### 1. Enable backports and install required packages
+
+The open-source driver stack depends on newer firmware from Debian 13 backports:
+
+```bash
+echo "deb http://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee -a /etc/apt/sources.list
+sudo apt update
+sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
+```
+
+:::tip Local mirrors
+If a regional Debian mirror works better in your network environment, you can replace `deb.debian.org` with that mirror.
+:::
+
+### 2. Run the CIX setup script
+
+```bash
+curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+```
+
+When prompted, enter `2` to install the open-source driver option.
+
+### 3. Reboot
+
+```bash
+sudo reboot
+```
+
+## Verify the Installation
+
+After rebooting, run:
+
+```bash
+uname -r
+dpkg -l | grep firmware-misc-nonfree
+dpkg -l | grep cix
+```
+
+Under normal conditions, `uname -r` should report `7.0.0-rc5-generic`.
+
+## Repository and Important Paths
+
+The CIX setup script automatically:
+
+- imports the repository GPG key
+- writes the CIX APT source entry
+- installs the open-source kernel and DKMS drivers
+- updates the default GRUB boot target
+
+Related paths:
+
+- APT source: `/etc/apt/sources.list.d/cix-deb-repo.list`
+- GPG key: `/usr/share/keyrings/cix-deb-repo.gpg`
+- GRUB config: `/etc/cix/grub-config.env`
+
+## Maintenance
+
+### Update the system
+
+```bash
+sudo apt update
+sudo apt upgrade
+sudo apt full-upgrade
+```
+
+### List installed CIX packages
+
+```bash
+dpkg -l | grep cix
+apt list --installed | grep cix
+```
+
+### Search available packages
+
+```bash
+apt search cix-
+```
+
+## Remove the Open-Source Driver Stack
+
+Run the script again and choose option `3`:
+
+```bash
+curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+```
+
+The script removes the open-source kernel packages, CIX-related configuration, and attempts to restore the system to its previous state.
+
+## References
+
+- [CIX PPA User Manual (Open-Source Driver Edition)](https://github.com/cixtech/cix-developer-docs/wiki/CIX%20PPA%20%E7%94%A8%E6%88%B7%E6%89%8B%E5%86%8C%EF%BC%88%E5%BC%80%E6%BA%90%E9%A9%B1%E5%8A%A8%E7%89%88%EF%BC%89)
+- [CIX SoC Mainline Support](https://github.com/cixtech/linux-mainline/wiki)

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
@@ -90,13 +90,13 @@ Then continue with the next section to configure the CIX PPA and install the ope
 The open-source driver stack depends on newer firmware from Debian 13 backports:
 
 ```bash
-echo "deb http://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee -a /etc/apt/sources.list
+echo "deb https://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee /etc/apt/sources.list.d/debian-trixie-backports.list
 sudo apt update
 sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
 ```
 
 :::tip Local mirrors
-If a regional Debian mirror works better in your network environment, you can replace `deb.debian.org` with that mirror.
+If a regional Debian mirror works better in your network environment, you can replace `deb.debian.org` with that mirror while still using a dedicated `.list` file.
 :::
 
 ### 2. Run the CIX setup script

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
@@ -106,7 +106,13 @@ curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-communi
 sudo sh ./cix-repo-community.sh
 ```
 
-When prompted, enter `2` to install the open-source driver option.
+The script prompts you to choose an action. The common options are:
+
+- `1`: install the closed-source driver stack
+- `2`: install the open-source driver stack
+- `3`: remove the installed CIX driver stack
+
+If you want to install the open-source driver stack described in this document, enter `2`.
 
 :::warning Review the script before execution
 Download the script locally and review it before running `sudo sh`, instead of piping remote content directly into a root shell.

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
@@ -50,12 +50,9 @@ After flashing the BIOS, enter BIOS Setup and enable the option below. Otherwise
 
 Download a **Debian 13 arm64** installation image. If you want a desktop system directly, choose an installer image with GNOME. If you use `netinst`, you can also select the GNOME desktop environment during installation.
 
-You can use one of these mirror directories:
+Use the official Debian image directory:
 
 - Debian official: <https://cdimage.debian.org/debian-cd/current/arm64/>
-- Tsinghua University: <https://mirrors.tuna.tsinghua.edu.cn/debian-cd/current/arm64/>
-- USTC: <https://mirrors.ustc.edu.cn/debian-cd/current/arm64/>
-- Aliyun: <https://mirrors.aliyun.com/debian-cd/current/arm64/>
 
 ### 2. Write the image to a USB drive
 
@@ -94,10 +91,6 @@ echo "deb https://deb.debian.org/debian trixie-backports main contrib non-free n
 sudo apt update
 sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
 ```
-
-:::tip Local mirrors
-If a regional Debian mirror works better in your network environment, you can replace `deb.debian.org` with that mirror while still using a dedicated `.list` file.
-:::
 
 ### 2. Run the CIX setup script
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
@@ -32,7 +32,8 @@ Before you begin, make sure:
 - Your device BIOS is already updated:
   - Orion O6: see [BIOS Update](../low-level-dev/bios.md)
   - Orion O6N: see [Orion O6N BIOS Update](../../o6n/low-level-dev/bios.md)
-- You have manually installed **Debian 13 (trixie)** and have working network access
+- You have prepared a USB flash drive with at least 8GB capacity
+- You have a computer available to download the image and write it to the USB drive
 - Your current user has `sudo` privileges
 
 :::warning Required BIOS Setting
@@ -43,7 +44,46 @@ After flashing the BIOS, enter BIOS Setup and enable the option below. Otherwise
 
 :::
 
-## Quick Start
+## Install Debian 13
+
+### 1. Download the Debian 13 installation image
+
+Download a **Debian 13 arm64** installation image. If you want a desktop system directly, choose an installer image with GNOME. If you use `netinst`, you can also select the GNOME desktop environment during installation.
+
+You can use one of these mirror directories:
+
+- Debian official: <https://cdimage.debian.org/debian-cd/current/arm64/>
+- Tsinghua University: <https://mirrors.tuna.tsinghua.edu.cn/debian-cd/current/arm64/>
+- USTC: <https://mirrors.ustc.edu.cn/debian-cd/current/arm64/>
+- Aliyun: <https://mirrors.aliyun.com/debian-cd/current/arm64/>
+
+### 2. Write the image to a USB drive
+
+Write the downloaded Debian 13 installation image to a USB drive. You can use any of the following tools:
+
+- Balena Etcher
+- Rufus
+- `dd`
+
+### 3. Boot from the USB drive and install the system
+
+Insert the USB drive into the device, select USB boot from the BIOS boot menu, and complete the installation by following the Debian installer.
+
+Recommended target media:
+
+- Orion O6: install to an NVMe SSD
+- Orion O6N: install to an NVMe SSD or UFS module
+
+### 4. First boot into the system
+
+After installation, boot into Debian 13 and confirm:
+
+- the system has working network access
+- the current user has `sudo` privileges
+
+Then continue with the next section to configure the CIX PPA and install the open-source drivers.
+
+## Configure the CIX PPA and Install the Open-Source Driver Stack
 
 ### 1. Enable backports and install required packages
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
@@ -175,5 +175,5 @@ The script removes the open-source kernel packages, CIX-related configuration, a
 
 ## References
 
-- [CIX PPA User Manual (Open-Source Driver Edition)](https://github.com/cixtech/cix-developer-docs/wiki/CIX%20PPA%20%E7%94%A8%E6%88%B7%E6%89%8B%E5%86%8C%EF%BC%88%E5%BC%80%E6%BA%90%E9%A9%B1%E5%8A%A8%E7%89%88%EF%BC%89)
+- [CIX PPA User Manual (Open-Source Driver Edition)](https://github.com/cixtech/cix-developer-docs/wiki/CIX%20PPA%20User%20Manual%20%28Open%E2%80%90Source%20Driver%20Edition%29)
 - [CIX SoC Mainline Support](https://github.com/cixtech/linux-mainline/wiki)

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
@@ -103,7 +103,6 @@ If a regional Debian mirror works better in your network environment, you can re
 
 ```bash
 curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
-less cix-repo-community.sh
 sudo sh ./cix-repo-community.sh
 ```
 
@@ -176,7 +175,6 @@ Run the script again and choose option `3`:
 
 ```bash
 curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
-less cix-repo-community.sh
 sudo sh ./cix-repo-community.sh
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
@@ -102,10 +102,16 @@ If a regional Debian mirror works better in your network environment, you can re
 ### 2. Run the CIX setup script
 
 ```bash
-curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
+less cix-repo-community.sh
+sudo sh ./cix-repo-community.sh
 ```
 
 When prompted, enter `2` to install the open-source driver option.
+
+:::warning Review the script before execution
+Download the script locally and review it before running `sudo sh`, instead of piping remote content directly into a root shell.
+:::
 
 ### 3. Reboot
 
@@ -144,9 +150,10 @@ Related paths:
 
 ### Update the system
 
+Use the following command sequence as the recommended update path:
+
 ```bash
 sudo apt update
-sudo apt upgrade
 sudo apt full-upgrade
 ```
 
@@ -168,7 +175,9 @@ apt search cix-
 Run the script again and choose option `3`:
 
 ```bash
-curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
+less cix-repo-community.sh
+sudo sh ./cix-repo-community.sh
 ```
 
 The script removes the open-source kernel packages, CIX-related configuration, and attempts to restore the system to its previous state.

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 40
+---
+
+# Other OS
+
+Introduces operating systems and related notes for Orion O6N other than the official Radxa OS.
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 1
+---
+
+# Debian 13
+
+This document explains how to use **Debian 13 (trixie)** on **Radxa Orion O6 / Orion O6N** and install the open-source driver stack through the CIX community repository.
+
+:::warning Scope
+
+- This document only applies to **Debian 13 (trixie)**
+- This stack is intended for kernel development, driver validation, and early community testing
+- For stable daily use or production deployment, prefer the official Radxa system images; for the stable CIX driver stack, refer to the closed-source branch based on kernel 6.6
+
+:::
+
+## Overview
+
+The CIX open-source driver solution is based on a mainline development kernel and mainly installs:
+
+- `linux-image-7.0.0-rc5-generic`
+- `linux-headers-7.0.0-rc5-generic`
+- `cix-npu-driver-dkms`
+- `cix-vpu-driver-dkms`
+
+Compared with flashing a full DD image, this method is easier to install, update, and remove through `apt`, so it is better suited to development and validation work.
+
+## Prerequisites
+
+Before you begin, make sure:
+
+- Your device BIOS is already updated:
+  - Orion O6: see [Orion O6 BIOS Update](../../o6/low-level-dev/bios.md)
+  - Orion O6N: see [BIOS Update](../low-level-dev/bios.md)
+- You have manually installed **Debian 13 (trixie)** and have working network access
+- Your current user has `sudo` privileges
+
+:::warning Required BIOS Setting
+
+After flashing the BIOS, enter BIOS Setup and enable the option below. Otherwise, some drivers may fail to load under the `7.0` kernel:
+
+`Device Manager` -> `Platform Configuration` -> `Compliance Configuration` -> `Enable ACPI SCMI`
+
+:::
+
+## Quick Start
+
+### 1. Enable backports and install required packages
+
+The open-source driver stack depends on newer firmware from Debian 13 backports:
+
+```bash
+echo "deb http://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee -a /etc/apt/sources.list
+sudo apt update
+sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
+```
+
+:::tip Local mirrors
+If a regional Debian mirror works better in your network environment, you can replace `deb.debian.org` with that mirror.
+:::
+
+### 2. Run the CIX setup script
+
+```bash
+curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+```
+
+When prompted, enter `2` to install the open-source driver option.
+
+### 3. Reboot
+
+```bash
+sudo reboot
+```
+
+## Verify the Installation
+
+After rebooting, run:
+
+```bash
+uname -r
+dpkg -l | grep firmware-misc-nonfree
+dpkg -l | grep cix
+```
+
+Under normal conditions, `uname -r` should report `7.0.0-rc5-generic`.
+
+## Repository and Important Paths
+
+The CIX setup script automatically:
+
+- imports the repository GPG key
+- writes the CIX APT source entry
+- installs the open-source kernel and DKMS drivers
+- updates the default GRUB boot target
+
+Related paths:
+
+- APT source: `/etc/apt/sources.list.d/cix-deb-repo.list`
+- GPG key: `/usr/share/keyrings/cix-deb-repo.gpg`
+- GRUB config: `/etc/cix/grub-config.env`
+
+## Maintenance
+
+### Update the system
+
+```bash
+sudo apt update
+sudo apt upgrade
+sudo apt full-upgrade
+```
+
+### List installed CIX packages
+
+```bash
+dpkg -l | grep cix
+apt list --installed | grep cix
+```
+
+### Search available packages
+
+```bash
+apt search cix-
+```
+
+## Remove the Open-Source Driver Stack
+
+Run the script again and choose option `3`:
+
+```bash
+curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+```
+
+The script removes the open-source kernel packages, CIX-related configuration, and attempts to restore the system to its previous state.
+
+## References
+
+- [CIX PPA User Manual (Open-Source Driver Edition)](https://github.com/cixtech/cix-developer-docs/wiki/CIX%20PPA%20%E7%94%A8%E6%88%B7%E6%89%8B%E5%86%8C%EF%BC%88%E5%BC%80%E6%BA%90%E9%A9%B1%E5%8A%A8%E7%89%88%EF%BC%89)
+- [CIX SoC Mainline Support](https://github.com/cixtech/linux-mainline/wiki)

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
@@ -32,7 +32,8 @@ Before you begin, make sure:
 - Your device BIOS is already updated:
   - Orion O6: see [Orion O6 BIOS Update](../../o6/low-level-dev/bios.md)
   - Orion O6N: see [BIOS Update](../low-level-dev/bios.md)
-- You have manually installed **Debian 13 (trixie)** and have working network access
+- You have prepared a USB flash drive with at least 8GB capacity
+- You have a computer available to download the image and write it to the USB drive
 - Your current user has `sudo` privileges
 
 :::warning Required BIOS Setting
@@ -43,7 +44,46 @@ After flashing the BIOS, enter BIOS Setup and enable the option below. Otherwise
 
 :::
 
-## Quick Start
+## Install Debian 13
+
+### 1. Download the Debian 13 installation image
+
+Download a **Debian 13 arm64** installation image. If you want a desktop system directly, choose an installer image with GNOME. If you use `netinst`, you can also select the GNOME desktop environment during installation.
+
+You can use one of these mirror directories:
+
+- Debian official: <https://cdimage.debian.org/debian-cd/current/arm64/>
+- Tsinghua University: <https://mirrors.tuna.tsinghua.edu.cn/debian-cd/current/arm64/>
+- USTC: <https://mirrors.ustc.edu.cn/debian-cd/current/arm64/>
+- Aliyun: <https://mirrors.aliyun.com/debian-cd/current/arm64/>
+
+### 2. Write the image to a USB drive
+
+Write the downloaded Debian 13 installation image to a USB drive. You can use any of the following tools:
+
+- Balena Etcher
+- Rufus
+- `dd`
+
+### 3. Boot from the USB drive and install the system
+
+Insert the USB drive into the device, select USB boot from the BIOS boot menu, and complete the installation by following the Debian installer.
+
+Recommended target media:
+
+- Orion O6: install to an NVMe SSD
+- Orion O6N: install to an NVMe SSD or UFS module
+
+### 4. First boot into the system
+
+After installation, boot into Debian 13 and confirm:
+
+- the system has working network access
+- the current user has `sudo` privileges
+
+Then continue with the next section to configure the CIX PPA and install the open-source drivers.
+
+## Configure the CIX PPA and Install the Open-Source Driver Stack
 
 ### 1. Enable backports and install required packages
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
@@ -90,13 +90,13 @@ Then continue with the next section to configure the CIX PPA and install the ope
 The open-source driver stack depends on newer firmware from Debian 13 backports:
 
 ```bash
-echo "deb http://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee -a /etc/apt/sources.list
+echo "deb https://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware" | sudo tee /etc/apt/sources.list.d/debian-trixie-backports.list
 sudo apt update
 sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
 ```
 
 :::tip Local mirrors
-If a regional Debian mirror works better in your network environment, you can replace `deb.debian.org` with that mirror.
+If a regional Debian mirror works better in your network environment, you can replace `deb.debian.org` with that mirror while still using a dedicated `.list` file.
 :::
 
 ### 2. Run the CIX setup script

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
@@ -106,7 +106,13 @@ curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-communi
 sudo sh ./cix-repo-community.sh
 ```
 
-When prompted, enter `2` to install the open-source driver option.
+The script prompts you to choose an action. The common options are:
+
+- `1`: install the closed-source driver stack
+- `2`: install the open-source driver stack
+- `3`: remove the installed CIX driver stack
+
+If you want to install the open-source driver stack described in this document, enter `2`.
 
 :::warning Review the script before execution
 Download the script locally and review it before running `sudo sh`, instead of piping remote content directly into a root shell.

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
@@ -50,12 +50,9 @@ After flashing the BIOS, enter BIOS Setup and enable the option below. Otherwise
 
 Download a **Debian 13 arm64** installation image. If you want a desktop system directly, choose an installer image with GNOME. If you use `netinst`, you can also select the GNOME desktop environment during installation.
 
-You can use one of these mirror directories:
+Use the official Debian image directory:
 
 - Debian official: <https://cdimage.debian.org/debian-cd/current/arm64/>
-- Tsinghua University: <https://mirrors.tuna.tsinghua.edu.cn/debian-cd/current/arm64/>
-- USTC: <https://mirrors.ustc.edu.cn/debian-cd/current/arm64/>
-- Aliyun: <https://mirrors.aliyun.com/debian-cd/current/arm64/>
 
 ### 2. Write the image to a USB drive
 
@@ -94,10 +91,6 @@ echo "deb https://deb.debian.org/debian trixie-backports main contrib non-free n
 sudo apt update
 sudo apt install firmware-misc-nonfree libgl1-mesa-dri -t trixie-backports
 ```
-
-:::tip Local mirrors
-If a regional Debian mirror works better in your network environment, you can replace `deb.debian.org` with that mirror while still using a dedicated `.list` file.
-:::
 
 ### 2. Run the CIX setup script
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
@@ -175,5 +175,5 @@ The script removes the open-source kernel packages, CIX-related configuration, a
 
 ## References
 
-- [CIX PPA User Manual (Open-Source Driver Edition)](https://github.com/cixtech/cix-developer-docs/wiki/CIX%20PPA%20%E7%94%A8%E6%88%B7%E6%89%8B%E5%86%8C%EF%BC%88%E5%BC%80%E6%BA%90%E9%A9%B1%E5%8A%A8%E7%89%88%EF%BC%89)
+- [CIX PPA User Manual (Open-Source Driver Edition)](https://github.com/cixtech/cix-developer-docs/wiki/CIX%20PPA%20User%20Manual%20%28Open%E2%80%90Source%20Driver%20Edition%29)
 - [CIX SoC Mainline Support](https://github.com/cixtech/linux-mainline/wiki)

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
@@ -103,7 +103,6 @@ If a regional Debian mirror works better in your network environment, you can re
 
 ```bash
 curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
-less cix-repo-community.sh
 sudo sh ./cix-repo-community.sh
 ```
 
@@ -176,7 +175,6 @@ Run the script again and choose option `3`:
 
 ```bash
 curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
-less cix-repo-community.sh
 sudo sh ./cix-repo-community.sh
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
@@ -102,10 +102,16 @@ If a regional Debian mirror works better in your network environment, you can re
 ### 2. Run the CIX setup script
 
 ```bash
-curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
+less cix-repo-community.sh
+sudo sh ./cix-repo-community.sh
 ```
 
 When prompted, enter `2` to install the open-source driver option.
+
+:::warning Review the script before execution
+Download the script locally and review it before running `sudo sh`, instead of piping remote content directly into a root shell.
+:::
 
 ### 3. Reboot
 
@@ -144,9 +150,10 @@ Related paths:
 
 ### Update the system
 
+Use the following command sequence as the recommended update path:
+
 ```bash
 sudo apt update
-sudo apt upgrade
 sudo apt full-upgrade
 ```
 
@@ -168,7 +175,9 @@ apt search cix-
 Run the script again and choose option `3`:
 
 ```bash
-curl -fsSL https://archive.cixtech.com/cix-repo-community.sh | sudo sh
+curl -fsSL -o cix-repo-community.sh https://archive.cixtech.com/cix-repo-community.sh
+less cix-repo-community.sh
+sudo sh ./cix-repo-community.sh
 ```
 
 The script removes the open-source kernel packages, CIX-related configuration, and attempts to restore the system to its previous state.


### PR DESCRIPTION
## Summary
- add Debian 13 CIX PPA guides for Orion O6 and O6N
- add Chinese and English other-os entries for both boards
- add download page entry and mention the required BIOS ACPI SCMI setting