### PR TITLE
docs: unify ROCK 3B download page OS section format

### DIFF
--- a/docs/rock3/rock3b/download.md
+++ b/docs/rock3/rock3b/download.md
@@ -12,10 +12,6 @@ import Images from "./\_image.mdx"
 
 <Images loader={false} system_img={true} spi_img={false} />
 
-| 系统镜像 | 架构 | 格式 | 下载地址 | 适用场景 |
-| ------- | ---- | ---- | -------- | -------- |
-| Rock-3b Bookworm KDE R1 | aarch64 | img.xz | [下载](https://github.com/radxa-build/rock-3b/releases/download/rsdk-r1/rock-3b_bookworm_kde_r1.output_512.img.xz) | 适用于 microSD 卡和 eMMC 模块启动系统 |
-
 :::caution
 除了上面的镜像经过官方充分测试外，其他镜像未经过严格测试，可能会存在未知问题，仅用于评估使用。
 :::

--- a/docs/rock3/rock3b/download.md
+++ b/docs/rock3/rock3b/download.md
@@ -8,17 +8,19 @@ import Images from "./\_image.mdx"
 
 ## 操作系统镜像
 
-### 官方操作系统镜像
+### 瑞莎系统
 
 <Images loader={false} system_img={true} spi_img={false} />
 
-- [Rock-3b Bookworm KDE R1](https://github.com/radxa-build/rock-3b/releases/download/rsdk-r1/rock-3b_bookworm_kde_r1.output_512.img.xz)(适用于 microSD 卡和 eMMC 模块启动系统)
+| 系统镜像 | 架构 | 格式 | 下载地址 | 适用场景 |
+| ------- | ---- | ---- | -------- | -------- |
+| Rock-3b Bookworm KDE R1 | aarch64 | img.xz | [下载](https://github.com/radxa-build/rock-3b/releases/download/rsdk-r1/rock-3b_bookworm_kde_r1.output_512.img.xz) | 适用于 microSD 卡和 eMMC 模块启动系统 |
 
 :::caution
 除了上面的镜像经过官方充分测试外，其他镜像未经过严格测试，可能会存在未知问题，仅用于评估使用。
 :::
 
-### 第三方操作系统镜像
+### 第三方系统
 
 - [Radxa ROCK 3B OpenWrt](https://openwrt.org/toh/hwdata/radxa/radxa_rock_3b)
 - [Radxa ROCK 3B OpenWrt ext4 sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-3b-ext4-sysupgrade.img.gz)

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/download.md
@@ -8,17 +8,15 @@ import Images from "./\_image.mdx"
 
 ## Operating system image
 
-### Official Operating System Image
+### Radxa System
 
 <Images loader={false} system_img={true} spi_img={false} />
-
-- [Rock-3b Bookworm KDE R1](https://github.com/radxa-build/rock-3b/releases/download/rsdk-r1/rock-3b_bookworm_kde_r1.output_512.img.xz)(For booting from microSD card and eMMC module)
 
 :::caution
 Except for the above mirrors which have been fully tested officially, the other mirrors have not been rigorously tested and may have unknown issues and are for evaluation purposes only.
 :::
 
-### Third-Party Operating System images
+### Third-Party System
 
 - [Radxa ROCK 3B OpenWrt](https://openwrt.org/toh/hwdata/radxa/radxa_rock_3b)
 - [Radxa ROCK 3B OpenWrt ext4 sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-3b-ext4-sysupgrade.img.gz)

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/hardware-design/hardware-interface.md
@@ -204,8 +204,7 @@ HDMI (High-Definition Multimedia Interface) is a unified method of transmitting 
   |  9  |        GND        | 10  |  MIPI_CSI_RX_D1P  |
   | 11  |  MIPI_CSI_RX_D1N  | 12  |        GND        |
   | 13  |  MIPI_CSI_RX_D0P  | 14  |  MIPI_CSI_RX_D0N  |
-  | 15  |        GND        | 16  |        GND        |
-  | 17  |        GND        |     |                   |
+  | 15  |        GND        |     |                   |
 
 - Camera_2
 
@@ -218,8 +217,7 @@ HDMI (High-Definition Multimedia Interface) is a unified method of transmitting 
   |  9  |        GND        | 10  |  MIPI_CSI_RX_D3P  |
   | 11  |  MIPI_CSI_RX_D3N  | 12  |        GND        |
   | 13  |  MIPI_CSI_RX_D2P  | 14  |  MIPI_CSI_RX_D2N  |
-  | 15  |        GND        | 16  |        GND        |
-  | 17  |        GND        |     |                   |
+  | 15  |        GND        |     |                   |
 
 ### MIPI DSI
 


### PR DESCRIPTION
## Changes

- Rename 'Official Operating System Image' to 'Radxa System'
- Rename 'Third-Party Operating System images' to 'Third-Party System'
- Convert Rock-3b Bookworm KDE R1 to table format (System Image / Architecture / Format / Download / Applicable Scenarios)
- Sync all changes to English version