### PR TITLE
docs(rock3b): unify download page OS section format

### DIFF
--- a/docs/rock3/rock3b/download.md
+++ b/docs/rock3/rock3b/download.md
@@ -2,23 +2,20 @@
 sidebar_position: 2
 ---
 
-import Images from "./\_image.mdx"
-
 # 资源下载汇总
 
 ## 操作系统镜像
 
-### 官方操作系统镜像
+### 瑞莎系统
 
-<Images loader={false} system_img={true} spi_img={false} />
-
-- [Rock-3b Bookworm KDE R1](https://github.com/radxa-build/rock-3b/releases/download/rsdk-r1/rock-3b_bookworm_kde_r1.output_512.img.xz)(适用于 microSD 卡和 eMMC 模块启动系统)
+- [Rock-3b Debian Bullseye XFCE b18](https://github.com/radxa-build/rock-3b/releases/download/b18/rock-3b_debian_bullseye_xfce_b18.img.xz)
+- [Rock-3b Bookworm KDE R1](https://github.com/radxa-build/rock-3b/releases/download/rsdk-r1/rock-3b_bookworm_kde_r1.output_512.img.xz)
 
 :::caution
 除了上面的镜像经过官方充分测试外，其他镜像未经过严格测试，可能会存在未知问题，仅用于评估使用。
 :::
 
-### 第三方操作系统镜像
+### 第三方系统
 
 - [Radxa ROCK 3B OpenWrt](https://openwrt.org/toh/hwdata/radxa/radxa_rock_3b)
 - [Radxa ROCK 3B OpenWrt ext4 sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-3b-ext4-sysupgrade.img.gz)

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/download.md
@@ -2,23 +2,20 @@
 sidebar_position: 2
 ---
 
-import Images from "./\_image.mdx"
-
 # Summary of resource downloads
 
 ## Operating system image
 
-### Official Operating System Image
+### Radxa System
 
-<Images loader={false} system_img={true} spi_img={false} />
-
-- [Rock-3b Bookworm KDE R1](https://github.com/radxa-build/rock-3b/releases/download/rsdk-r1/rock-3b_bookworm_kde_r1.output_512.img.xz)(For booting from microSD card and eMMC module)
+- [Rock-3b Debian Bullseye XFCE b18](https://github.com/radxa-build/rock-3b/releases/download/b18/rock-3b_debian_bullseye_xfce_b18.img.xz)
+- [Rock-3b Bookworm KDE R1](https://github.com/radxa-build/rock-3b/releases/download/rsdk-r1/rock-3b_bookworm_kde_r1.output_512.img.xz)
 
 :::caution
 Except for the above mirrors which have been fully tested officially, the other mirrors have not been rigorously tested and may have unknown issues and are for evaluation purposes only.
 :::
 
-### Third-Party Operating System images
+### Third-Party System
 
 - [Radxa ROCK 3B OpenWrt](https://openwrt.org/toh/hwdata/radxa/radxa_rock_3b)
 - [Radxa ROCK 3B OpenWrt ext4 sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-3b-ext4-sysupgrade.img.gz)


### PR DESCRIPTION
## Changes

- Rename section headers:
  - `官方操作系统镜像` → `瑞莎系统`
  - `第三方操作系统镜像` → `第三方系统`
  - `Official Operating System Image` → `Radxa System`
  - `Third-Party Operating System images` → `Third-Party System`
- Remove `<Images>` component and use direct markdown links instead
- Remove unused `import Images` statement

## Files modified

- docs/rock3/rock3b/download.md (Chinese)
- i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/download.md (English)