### PR TITLE
fix: resolve MDX compilation error in Debian13 docs

### DIFF
--- a/docs/orion/o6/other-os/debian13.md
+++ b/docs/orion/o6/other-os/debian13.md
@@ -52,10 +52,10 @@ CIX 的开源驱动方案基于主线开发内核，核心内容包括：
 
 可参考以下镜像目录：
 
-- Debian 官方：<https://cdimage.debian.org/debian-cd/current/arm64/>
-- 清华大学：<https://mirrors.tuna.tsinghua.edu.cn/debian-cd/current/arm64/>
-- 中国科学技术大学：<https://mirrors.ustc.edu.cn/debian-cd/current/arm64/>
-- 阿里云：<https://mirrors.aliyun.com/debian-cd/current/arm64/>
+- [Debian 官方](https://cdimage.debian.org/debian-cd/current/arm64/)
+- [清华大学](https://mirrors.tuna.tsinghua.edu.cn/debian-cd/current/arm64/)
+- [中国科学技术大学](https://mirrors.ustc.edu.cn/debian-cd/current/arm64/)
+- [阿里云](https://mirrors.aliyun.com/debian-cd/current/arm64/)
 
 ### 2. 将镜像写入 U 盘
 

--- a/docs/orion/o6n/other-os/debian13.md
+++ b/docs/orion/o6n/other-os/debian13.md
@@ -52,10 +52,10 @@ CIX 的开源驱动方案基于主线开发内核，核心内容包括：
 
 可参考以下镜像目录：
 
-- Debian 官方：<https://cdimage.debian.org/debian-cd/current/arm64/>
-- 清华大学：<https://mirrors.tuna.tsinghua.edu.cn/debian-cd/current/arm64/>
-- 中国科学技术大学：<https://mirrors.ustc.edu.cn/debian-cd/current/arm64/>
-- 阿里云：<https://mirrors.aliyun.com/debian-cd/current/arm64/>
+- [Debian 官方](https://cdimage.debian.org/debian-cd/current/arm64/)
+- [清华大学](https://mirrors.tuna.tsinghua.edu.cn/debian-cd/current/arm64/)
+- [中国科学技术大学](https://mirrors.ustc.edu.cn/debian-cd/current/arm64/)
+- [阿里云](https://mirrors.aliyun.com/debian-cd/current/arm64/)
 
 ### 2. 将镜像写入 U 盘
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/other-os/debian13.md
@@ -52,7 +52,7 @@ Download a **Debian 13 arm64** installation image. If you want a desktop system 
 
 Use the official Debian image directory:
 
-- Debian official: <https://cdimage.debian.org/debian-cd/current/arm64/>
+- [Debian official](https://cdimage.debian.org/debian-cd/current/arm64/)
 
 ### 2. Write the image to a USB drive
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6n/other-os/debian13.md
@@ -52,7 +52,7 @@ Download a **Debian 13 arm64** installation image. If you want a desktop system 
 
 Use the official Debian image directory:
 
-- Debian official: <https://cdimage.debian.org/debian-cd/current/arm64/>
+- [Debian official](https://cdimage.debian.org/debian-cd/current/arm64/)
 
 ### 2. Write the image to a USB drive
 


### PR DESCRIPTION
## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
