### PR TITLE
docs: fix X4 preparation link to Radxa Power PD30W

### DIFF
--- a/docs/x/x4/getting-started/preparation.md
+++ b/docs/x/x4/getting-started/preparation.md
@@ -11,7 +11,7 @@ sidebar_position: 1
 Radxa X4 推荐使用符合 USB Type-C PD 协议（支持12V, 12V 对应的电流 >= 2.5A）的电源适配器，但不支持 高通QC 协议。
 
 :::tip
-瑞莎推荐使用 [Radxa Power PD30W](../accessories/power/pd_30w)。
+瑞莎推荐使用 [Radxa Power PD30W](http://radxa.com/products/accessories/power-pd-30w)。
 :::
 
 ### 显示器

--- a/i18n/en/docusaurus-plugin-content-docs/current/x/x4/getting-started/preparation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/x/x4/getting-started/preparation.md
@@ -11,7 +11,7 @@ sidebar_position: 1
 Radxa X4 recommends using a power adapter that supports the USB Type-C PD protocol (supports 12V and the current >= 2.5A under 12V), but it does not support the Qualcomm QC protocol.
 
 :::tip
-Radxa recommends using [Radxa Power PD30W](../accessories/power/pd_30w).
+Radxa recommends using [Radxa Power PD30W](http://radxa.com/products/accessories/power-pd-30w).
 :::
 
 ### Monitor


### PR DESCRIPTION
## Summary
Fix broken relative link to Power PD30W accessory page in X4 preparation documentation.

## Changes
- Changed link from `../accessories/power/pd_30w` (resolves to non-existent `x/x4/accessories/` path) to absolute URL `http://radxa.com/products/accessories/power-pd-30w`

## Testing
- Verified target URL is valid and shows correct product page (Radxa Power PD 30W)
- X4 is listed in the product compatibility section