### PR TITLE
docs: update Orion O6/O6N BIOS GitHub Release links to specific version tags

### DIFF
--- a/docs/orion/download.md
+++ b/docs/orion/download.md
@@ -26,14 +26,14 @@ sidebar_position: 150
         | 下载平台                                                                            | 文件格式 | 获取方式                                                                                            |
         | :---------------------------------------------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------- |
         | [**Radxa DL**](https://dl.radxa.com/orion/o6/images/bios/orion-o6-bios-1.1.0-1.zip) | `.zip`   | 固件位于压缩包内                                                                                                  |
-        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases)                | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6` 目录下 |
+        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-1)                | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6` 目录下 |
     </TabItem>
     <TabItem value="星睿 O6N">
 #### 瑞莎星睿 O6N
         | 下载平台                                                             | 文件格式 | 获取方式                                                                                            |
         | :------------------------------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------- |
         | [**Radxa DL**](https://dl.radxa.com/orion/o6n/images/bios/orion-o6n-bios-1.1.0-2.zip)                      | `.zip`   | 固件位于压缩包内                                                                                                  |
-        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases) | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6n` 目录下 |
+        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-2) | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6n` 目录下 |
     </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## 修复内容

将 Orion O6 和 O6N 下载页面的 BIOS GitHub Release 链接从通用的 releases 页面指向具体版本标签页：

- **Orion O6**:  → 
- **Orion O6N**:  → 

## 关联 Issue

Fixes #1689