### PR TITLE
docs: clarify Rock 3A USB 3.0 OTG port and V1.3 jumper workaround

### DIFF
--- a/docs/rock3/rock3a/low-level-dev/install-os-on-emmc.md
+++ b/docs/rock3/rock3a/low-level-dev/install-os-on-emmc.md
@@ -19,10 +19,14 @@ sidebar_position: 1
 
 - 断开瑞莎 ROCK 3A电源
 - 移除 SD 卡，并插入 eMMC 模块
-- 用 USB A-A 连接 Radxa ROCK 3A 的 USB3.0 口 和 PC 端
+- 用 USB A-A 连接 Radxa ROCK 3A 的 **USB 3.0 OTG 接口**（顶部/上方的 USB 3.0 口）和 PC 端
 - 短接下面引脚
 - 给瑞莎 ROCK 3A上电
 - 摘下右边的黄色跳线帽，保留左边的黄色跳线帽
+
+:::note
+部分 V1.3 版本板卡可能没有预留跳线帽引脚，此时需要用镊子等工具直接短接下图中所示的 eMMC_CLKOUT 针脚与 GND 针脚，再接通电源即可进入 Maskrom 模式。
+:::
 
 <img src="/img/rock3/3a/rock3a-maskrom.webp" alt="rock 3a maskrom" width="500" />
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/low-level-dev/install-os-on-emmc.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/low-level-dev/install-os-on-emmc.md
@@ -19,10 +19,14 @@ Please go to [Download Summary](../getting-started/download) to download the cor
 
 - Disconnect power to the board
 - Remove the SD card and insert the eMMC module.
-- Connect the USB3.0 port of the Radxa ROCK 3A to the PC with USB A-A.
+- Connect the **USB 3.0 OTG port** (the top/upper USB 3.0 port) of the Radxa ROCK 3A to the PC with USB A-A.
 - Short the following pins
 - Power up the board.
 - Remove the right yellow jumper cap, keep the left yellow jumper cap.
+
+:::note
+On some V1.3 board revisions, the jumper pins may not be populated. In that case, use tweezers or a similar tool to directly short the eMMC_CLKOUT pin and GND pin as shown in the image below, then power on the board to enter Maskrom mode.
+:::
 
 <img src="/img/rock3/3a/rock3a-maskrom.webp" alt="rock 3a maskrom" width="500" />
 


### PR DESCRIPTION
## Fixes #96

### Changes
- **Clarify USB 3.0 OTG port**: Changed `USB3.0 port` to `USB 3.0 OTG port (the outer/top USB 3.0 port)` in both Chinese and English versions
- **Add V1.3 workaround note**: Added a `:::note` block explaining that some V1.3 board revisions may not have populated jumper pins, requiring users to short the CLK pin with GND using tweezers

### Files modified
- `docs/rock3/rock3a/low-level-dev/install-os-on-emmc.md` (Chinese)
- `i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/low-level-dev/install-os-on-emmc.md` (English)