### PR TITLE
docs(zero/zero3): adjust FAQ sidebar_position and add Android image link

### DIFF
--- a/docs/zero/zero3/download.md
+++ b/docs/zero/zero3/download.md
@@ -62,6 +62,8 @@ Armbian 的默认凭据如下：
 
 - [Radxa ZERO 3 DietPi](https://dietpi.com/downloads/images/DietPi_RadxaZERO3-ARMv8-Bookworm.img.xz)
 
+- [Radxa ZERO 3W E Android](https://github.com/radxa/manifests/releases/download/radxa-zero3-we-android11-rkr12-20240111/Radxa-Zero3WE-20231130-gpt.zip)
+
 - [Radxa Zero 3W OpenIPC](https://github.com/OpenIPC/sbc-groundstations/releases)
 
 - [OpenWRT 技术数据页面：Radxa Zero 3W](https://openwrt.org/toh/hwdata/radxa/radxa_zero_3w)

--- a/docs/zero/zero3/download.md
+++ b/docs/zero/zero3/download.md
@@ -62,7 +62,7 @@ Armbian 的默认凭据如下：
 
 - [Radxa ZERO 3 DietPi](https://dietpi.com/downloads/images/DietPi_RadxaZERO3-ARMv8-Bookworm.img.xz)
 
-- [Radxa ZERO 3W E Android](https://github.com/radxa/manifests/releases/download/radxa-zero3-we-android11-rkr12-20240111/Radxa-Zero3WE-20231130-gpt.zip)
+- [Radxa ZERO 3W/3E Android](https://github.com/radxa/manifests/releases/download/radxa-zero3-we-android11-rkr12-20240111/Radxa-Zero3WE-20231130-gpt.zip)
 
 - [Radxa Zero 3W OpenIPC](https://github.com/OpenIPC/sbc-groundstations/releases)
 

--- a/docs/zero/zero3/faq.md
+++ b/docs/zero/zero3/faq.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 60
 ---
 
 # FAQ

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/download.md
@@ -62,6 +62,8 @@ Default Armbian credentials:
 
 - [Radxa ZERO 3 DietPi](https://dietpi.com/downloads/images/DietPi_RadxaZERO3-ARMv8-Bookworm.img.xz)
 
+- [Radxa ZERO 3W E Android](https://github.com/radxa/manifests/releases/download/radxa-zero3-we-android11-rkr12-20240111/Radxa-Zero3WE-20231130-gpt.zip)
+
 - [Radxa Zero 3w OpenIPC](https://github.com/OpenIPC/sbc-groundstations/releases)
 
 - [OpenWRT Technical Data Page: Radxa Zero 3W](https://openwrt.org/toh/hwdata/radxa/radxa_zero_3w)

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/download.md
@@ -62,7 +62,7 @@ Default Armbian credentials:
 
 - [Radxa ZERO 3 DietPi](https://dietpi.com/downloads/images/DietPi_RadxaZERO3-ARMv8-Bookworm.img.xz)
 
-- [Radxa ZERO 3W E Android](https://github.com/radxa/manifests/releases/download/radxa-zero3-we-android11-rkr12-20240111/Radxa-Zero3WE-20231130-gpt.zip)
+- [Radxa ZERO 3W/3E Android](https://github.com/radxa/manifests/releases/download/radxa-zero3-we-android11-rkr12-20240111/Radxa-Zero3WE-20231130-gpt.zip)
 
 - [Radxa Zero 3w OpenIPC](https://github.com/OpenIPC/sbc-groundstations/releases)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/faq.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 60
 ---
 
 # FAQ


### PR DESCRIPTION
## Changes

1. **FAQ sidebar_position**: Changed from 10 to 60 to adjust chapter ordering

2. **Third-party images**: Added Radxa ZERO 3W E Android download link under third-party images section

3. **Synced both CN and EN versions**

## Files modified
- `docs/zero/zero3/faq.md`
- `docs/zero/zero3/download.md`
- `i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/faq.md`
- `i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/download.md`