### PR TITLE
fix(zero2pro): repair broken links in install-os.md

### DIFF
--- a/docs/zero/zero2pro/getting-started/install-os.md
+++ b/docs/zero/zero2pro/getting-started/install-os.md
@@ -13,7 +13,7 @@ import Etcher from '../../../common/general/\_etcher.mdx'
 
 ## 镜像下载
 
-请到 [资源下载汇总](./download) 下载对应的镜像文件
+请到 [资源下载汇总](../download) 下载对应的镜像文件
 
 ## 安装系统
 
@@ -25,7 +25,7 @@ import Etcher from '../../../common/general/\_etcher.mdx'
 - ZERO 2 PRO 的供电接口为 [USB OTG](../hardware-design/hardware-interface)，请使用 Type-C 线缆连接供电口和适配器。
 
 :::tip
-ZERO 2 PRO 支持 5V 电源输入，建议使用额定最大电流大于2A的电源适配器。瑞莎推荐使用 [Radxa Power PD30W](../accessories/power/pd_30w)。
+ZERO 2 PRO 支持 5V 电源输入，建议使用额定最大电流大于2A的电源适配器。瑞莎推荐使用 [Radxa Power PD30W](../accessories/pd-30w)。
 :::
 
 ## 登录系统

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero2pro/getting-started/install-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero2pro/getting-started/install-os.md
@@ -13,7 +13,7 @@ import Etcher from '../../../common/general/\_etcher.mdx'
 
 ## Image download
 
-Please go to [Download Summary](./download) to download the corresponding image file.
+Please go to [Download Summary](../download) to download the corresponding image file.
 
 ## Installation system
 
@@ -25,7 +25,7 @@ Please go to [Download Summary](./download) to download the corresponding image 
 - The power supply interface of ZERO 2 PRO is [USB OTG](../hardware-design/hardware-interface), please use a Type-C cable to connect the power port and the adapter.
 
 :::tip
-The ZERO 2 PRO power supply supports 5V, recommended to use a power adapter with a rated maximum current greater than 2A. radxa recommends using the [Radxa Power PD30W](../accessories/power/pd_30w).
+The ZERO 2 PRO power supply supports 5V, recommended to use a power adapter with a rated maximum current greater than 2A. radxa recommends using the [Radxa Power PD30W](../accessories/pd-30w).
 :::.
 
 ## Login System


### PR DESCRIPTION
修复 zero/zero2pro/getting-started/install-os.md 中的两处失效链接：

1. `./download` → `../download`
   - `download.md` 实际位于 getting-started 的上级目录，直接写 `./download` 会导致 404

2. `../accessories/power/pd_30w` → `../accessories/pd-30w`
   - `pd_30w.md` 实际位于 `accessories/pd-30w.md`，不存在 `accessories/power/pd_30w` 子目录

涉及文件：
- `docs/zero/zero2pro/getting-started/install-os.md` (CN)
- `i18n/en/docusaurus-plugin-content-docs/current/zero/zero2pro/getting-started/install-os.md` (EN)