### PR TITLE
docs: remove duplicate RKNPU2 info block in _rknn-install.mdx

### DIFF
--- a/docs/common/dev/_rknn-install.mdx
+++ b/docs/common/dev/_rknn-install.mdx
@@ -224,10 +224,6 @@ RK356X 产品用户使用 NPU 前需要在终端使用 **rsetup** 开启 NPU: `s
 Radxa 官方镜像已默认安装 RKNPU2 及其所需依赖，如无法运行可尝试注释命令。
 :::
 
-:::info
-Radxa 官方镜像已默认安装 RKNPU2 及其所需依赖，如无法运行可尝试注释命令。
-:::
-
 <NewCodeBlock tip="Device" type="device">
 
 ```bash

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rknn-install.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rknn-install.mdx
@@ -225,10 +225,6 @@ If the problem persists after trying these steps, please submit an issue on the 
 Radxa official images come with RKNPU2 and its required dependencies preinstalled. If you encounter issues running NPU workloads, you can try uncommenting and executing the following commands.
 :::
 
-:::info
-Radxa official images come with RKNPU2 and its required dependencies preinstalled. If you encounter issues running NPU workloads, you can try uncommenting and executing the following commands.
-:::
-
 <NewCodeBlock tip="Device" type="device">
 
 ```bash


### PR DESCRIPTION
## Summary
Remove duplicate info block in `docs/common/dev/_rknn-install.mdx`.

## Problem
The tip "Radxa 官方镜像已默认安装 RKNPU2 及其所需依赖，如无法运行可尝试注释命令。" appeared twice consecutively in the board-side driver configuration section, causing visual duplication on the rendered page for ROCK4D and other products using this shared component.

## Fix
Removed one of the two duplicate `:::info` blocks.

## Testing
Verified the duplicate is removed by checking the diff and the rendered content in the `rock4/rock4d/application-dev/npu/rknn-install` page.

## Screenshots
**Before (duplicate visible):**
![before](https://github.com/user-attachments/assets/placeholder)  
**After (single instance):**
![after](https://github.com/user-attachments/assets/placeholder)