### PR TITLE
docs: set ROCK 4B Manjaro memory issue as H2 in rock4 FAQ

### DIFF
--- a/docs/rock4/FAQ.md
+++ b/docs/rock4/FAQ.md
@@ -81,7 +81,7 @@ curl https://dl.radxa.com/rockpi4/troubleshooting/rock-4ab-uboot-2017-idbloader.
 sudo ./setup.sh update_idbloader ___/dev/sdX_or_/dev/mmcblkX_or_system.img___
 ```
 
-ROCK 4B 在使用 Manjaro-ARM-minimal-rockpi4b-22.06.img.xz 时系统内内存总大小在重启后可能会变化
+## ROCK 4B 在使用 Manjaro-ARM-minimal-rockpi4b-22.06.img.xz 时系统内内存总大小在重启后可能会变化
 
 ### 现象
 


### PR DESCRIPTION
Fixes #260

将 ROCK 4B Manjaro 内存问题段落从正文提升为二级标题。