### PR TITLE
docs: add apt keyring expiry note to rockpi-backup.sh

### DIFF
--- a/docs/common/radxa-os/_backup-os.mdx
+++ b/docs/common/radxa-os/_backup-os.mdx
@@ -107,6 +107,23 @@ Do you want to apt-get install the packages? [y/N]
 </div>
 </details>
 
+:::caution
+**如果 apt 报错 `apt-key` 过期或签名验证失败**，请先手动更新瑞莎的 apt keyring，再运行脚本：
+
+```bash
+# 下载最新的 radxa-archive-keyring 包
+curl -sL https://github.com/radxa-pkg/radxa-archive-keyring/releases/latest/download/radxa-archive-keyring_latest_arm64.deb -o radxa-archive-keyring.deb
+# 或下载 amd64 版本
+# curl -sL https://github.com/radxa-pkg/radxa-archive-keyring/releases/latest/download/radxa-archive-keyring_latest_amd64.deb -o radxa-archive-keyring.deb
+
+# 手动安装
+sudo dpkg -i radxa-archive-keyring.deb
+
+# 安装完后再运行备份脚本
+sudo ./rockpi-backup.sh
+```
+:::
+
 </TabItem>
 <TabItem value="offline" label="离线备份">
 
@@ -193,6 +210,23 @@ Do you want to apt-get install the packages? [y/N]
 
 </div>
 </details>
+
+:::caution
+**如果 apt 报错 `apt-key` 过期或签名验证失败**，请先手动更新瑞莎的 apt keyring，再运行脚本：
+
+```bash
+# 下载最新的 radxa-archive-keyring 包
+curl -sL https://github.com/radxa-pkg/radxa-archive-keyring/releases/latest/download/radxa-archive-keyring_latest_arm64.deb -o radxa-archive-keyring.deb
+# 或下载 amd64 版本
+# curl -sL https://github.com/radxa-pkg/radxa-archive-keyring/releases/latest/download/radxa-archive-keyring_latest_amd64.deb -o radxa-archive-keyring.deb
+
+# 手动安装
+sudo dpkg -i radxa-archive-keyring.deb
+
+# 安装完后再运行备份脚本
+sudo ./rockpi-backup.sh
+```
+:::
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

When the Radxa apt keyring expires, `rockpi-backup.sh` fails when trying to `apt-get install` the `rsync` dependency. This PR adds a caution block after the dependency installation step in both the **Online Backup** and **Offline Backup** tabs (for both Chinese and English), explaining how to manually download and install the latest `radxa-archive-keyring` deb from GitHub before running the script.

## Changes

- `docs/common/radxa-os/_backup-os.mdx` (Chinese)
  - Added `:::caution` block with keyring update steps to the **Online Backup** tab
  - Added the same `:::caution` block to the **Offline Backup** tab
- `i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_backup-os.mdx` (English)
  - Same changes as above for the English version

## Testing

Preview: https://docs.radxa.com/rock3/rock3a/radxa-os/backup