### PR TITLE
docs: add apt keyring expiry note to rockpi-backup.sh (English)

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_backup-os.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_backup-os.mdx
@@ -107,6 +107,23 @@ Do you want to apt-get install the packages? [y/N]
 </div>
 </details>
 
+:::caution
+**If apt reports an expired `apt-key` or signature verification error**, first manually update the Radxa apt keyring, then run the script again:
+
+```bash
+# Download the latest radxa-archive-keyring package
+curl -sL https://github.com/radxa-pkg/radxa-archive-keyring/releases/latest/download/radxa-archive-keyring_latest_arm64.deb -o radxa-archive-keyring.deb
+# Or for amd64:
+# curl -sL https://github.com/radxa-pkg/radxa-archive-keyring/releases/latest/download/radxa-archive-keyring_latest_amd64.deb -o radxa-archive-keyring.deb
+
+# Install manually
+sudo dpkg -i radxa-archive-keyring.deb
+
+# Run the backup script again
+sudo ./rockpi-backup.sh
+```
+:::
+
 </TabItem>
 <TabItem value="offline" label="Offline Backup">
 
@@ -193,6 +210,23 @@ Do you want to apt-get install the packages? [y/N]
 
 </div>
 </details>
+
+:::caution
+**If apt reports an expired `apt-key` or signature verification error**, first manually update the Radxa apt keyring, then run the script again:
+
+```bash
+# Download the latest radxa-archive-keyring package
+curl -sL https://github.com/radxa-pkg/radxa-archive-keyring/releases/latest/download/radxa-archive-keyring_latest_arm64.deb -o radxa-archive-keyring.deb
+# Or for amd64:
+# curl -sL https://github.com/radxa-pkg/radxa-archive-keyring/releases/latest/download/radxa-archive-keyring_latest_amd64.deb -o radxa-archive-keyring.deb
+
+# Install manually
+sudo dpkg -i radxa-archive-keyring.deb
+
+# Run the backup script again
+sudo ./rockpi-backup.sh
+```
+:::
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

English-only PR for the apt keyring expiry note added in PR #1711. Adds the same caution block to the English version of the backup script documentation.

## Changes

- English version of _backup-os.mdx (i18n)
  - Added apt keyring expiry caution to Online Backup tab
  - Added same caution to Offline Backup tab

## Related

PR #1711 (Chinese version)