### PR TITLE
docs: refine g2d guide doc

### DIFF
--- a/docs/common/ai/cubie/_g2d-usage-guide.mdx
+++ b/docs/common/ai/cubie/_g2d-usage-guide.mdx
@@ -2,6 +2,23 @@
 
 G2D 是 Allwinner SoC 集成的 2D 图形硬件加速器，负责图像旋转、缩放、格式转换、颜色填充等操作。
 
+:::info
+当前版本默认不启用 g2d ，如有需要，按照下面的命令配置。
+:::
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+wget https://github.com/cubie-image/sun60iw2p1/releases/download/linux_package4/linux-headers-5.15.147-100-a733_5.15.147-100_arm64.deb
+wget https://github.com/cubie-image/sun60iw2p1/releases/download/linux_package4/linux-image-5.15.147-100-a733_5.15.147-100_arm64.deb
+sudo dpkg -i linux-headers-5.15.147-100-a733_5.15.147-100_arm64.deb
+sudo dpkg -i linux-image-5.15.147-100-a733_5.15.147-100_arm64.deb
+# 然后重启
+sudo reboot
+```
+
+</NewCodeBlock>
+
 典型应用场景：
 
 - 视频编解码前后的图像预处理（缩放、色彩空间转换）
@@ -56,12 +73,13 @@ sudo modprobe g2d_sunxi
 /dev/dma_heap/system  (0666)
 ```
 
-如需重新配置 udev 规则：
+如遇权限不够，推荐配置 udev 规则：
 
 <NewCodeBlock tip="Device" type="device">
 
 ```bash
-sudo sh -c 'echo "KERNEL==\"system\", SUBSYSTEM==\"dma_heap\", MODE=\"0666\"" > /etc/udev/rules.d/99-dma-heap.rules'
+sudo sh -c 'echo "KERNEL==\"g2d\", MODE=\"0666\"" > /etc/udev/rules.d/99-g2d.rules'
+sudo sh -c 'echo "KERNEL==\"system\", SUBSYSTEM==\"dma_heap\", MODE=\"0666\"" >> /etc/udev/rules.d/99-g2d.rules'
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 ```
@@ -187,6 +205,10 @@ gcc -o g2d_rotation g2d_rotation.c
 </NewCodeBlock>
 
 ## 示例运行结果
+
+:::tip
+示例代码可查阅 [github](https://github.com/Ronin-1124/allwinner-g2d-usage-guide) 。
+:::
 
 | 示例              | 操作                        | 结果                       |
 | ----------------- | --------------------------- | -------------------------- |

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_g2d-usage-guide.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_g2d-usage-guide.mdx
@@ -2,6 +2,23 @@
 
 G2D is a 2D graphics hardware accelerator integrated into Allwinner SoCs, responsible for image rotation, scaling, format conversion, color filling and other operations.
 
+:::info
+G2D is not enabled by default in the current version. If needed, configure according to the commands below.
+:::
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+wget https://github.com/cubie-image/sun60iw2p1/releases/download/linux_package4/linux-headers-5.15.147-100-a733_5.15.147-100_arm64.deb
+wget https://github.com/cubie-image/sun60iw2p1/releases/download/linux_package4/linux-image-5.15.147-100-a733_5.15.147-100_arm64.deb
+sudo dpkg -i linux-headers-5.15.147-100-a733_5.15.147-100_arm64.deb
+sudo dpkg -i linux-image-5.15.147-100-a733_5.15.147-100_arm64.deb
+# Then reboot
+sudo reboot
+```
+
+</NewCodeBlock>
+
 Typical application scenarios:
 
 - Image preprocessing (scaling, color space conversion) before and after video encoding/decoding
@@ -56,12 +73,13 @@ Current system is configured to run without root:
 /dev/dma_heap/system  (0666)
 ```
 
-To reconfigure udev rules if needed:
+If you encounter permission issues, it is recommended to configure udev rules:
 
 <NewCodeBlock tip="Device" type="device">
 
 ```bash
-sudo sh -c 'echo "KERNEL==\"system\", SUBSYSTEM==\"dma_heap\", MODE=\"0666\"" > /etc/udev/rules.d/99-dma-heap.rules'
+sudo sh -c 'echo "KERNEL==\"g2d\", MODE=\"0666\"" > /etc/udev/rules.d/99-g2d.rules'
+sudo sh -c 'echo "KERNEL==\"system\", SUBSYSTEM==\"dma_heap\", MODE=\"0666\"" >> /etc/udev/rules.d/99-g2d.rules'
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 ```
@@ -187,6 +205,10 @@ gcc -o g2d_rotation g2d_rotation.c
 ```
 
 </NewCodeBlock>
+
+:::tip
+Example code is available on [github](https://github.com/Ronin-1124/allwinner-g2d-usage-guide).
+:::
 
 ## Example Results
 


### PR DESCRIPTION
## Description of changes

Refine g2d guide doc.

## Agent-doc checklist

- [x] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [x] Changed page docs are not empty, include front matter, and have an H1 heading.
- [x] Code fences in changed docs include language labels.
- [x] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [x] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [x] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [x] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
