### PR TITLE
docs(x4): remove broken schematic download link (fixes discussion #1715)

### DIFF
--- a/docs/x/x4/hardware/hardware-info.md
+++ b/docs/x/x4/hardware/hardware-info.md
@@ -8,7 +8,7 @@ sidebar_position: 10
 
 ### 原理图
 
-[Radxa X4 V1.11 原理图下载](https://dl.radxa.com/x/x4/radxa_x4_v1.11_schematic.pdf)
+原理图暂不提供公开下载，如有需要请联系 Radxa 获取。
 
 ### 位号图
 


### PR DESCRIPTION
## Summary

Remove broken schematic download link from Radxa X4 hardware-info page.

**Problem**: The schematic PDF link https://dl.radxa.com/x/x4/radxa_x4_v1.11_schematic.pdf returns HTTP 404. The file is not available on the download server.

**Fix**: Replace the broken link with a note: 原理图暂不提供公开下载，如有需要请联系 Radxa 获取。

**Source**: GitHub discussion comment - https://github.com/radxa-docs/docs/discussions/1715

**Note on English version**: The English i18n counterpart (i18n/en/docusaurus-plugin-content-docs/current/x/x4/hardware/hardware-info.md) does not currently exist in the repository — this is a pre-existing condition. The Chinese version fix is applied independently.