### PR TITLE
fix(rock5b): fix broken links in FAQ page (Q8)

### DIFF
--- a/docs/rock5/rock5b/faq.md
+++ b/docs/rock5/rock5b/faq.md
@@ -52,14 +52,14 @@ ROCK 5B 支持将 USB PD 电源协商至更高的电压，如 9V、12V、15V、2
 
 原因确认:
 
-去掉 eMMC Module, MicroSD 及 NVME 设备，然后通过 USB 线连接板子和PC，此时看设备是否进入 [Maskrom 状态](./low-level-dev/maskrom/)，
+去掉 eMMC Module, MicroSD 及 NVME 设备，然后通过 USB 线连接板子和PC，此时看设备是否进入 [Maskrom 状态](./low-level-dev/install-os/rkdevtool_maskrom)，
 如果不是MaskRom状态，则大概率是下面的原因:
 
-在 [通过 USB 烧录系统到eMMC](./low-level-dev/maskrom/) 的时候没有按照说明 按 Maskrom 按键，导致烧录系统到了 [SPI Flash](./low-level-dev/maskrom/erase)中, 而系统启动的时候，先读取SPI的信息，此时出现错误，无法正常启动。
+在 [通过 USB 烧录系统到eMMC](./low-level-dev/install-os/rkdevtool_maskrom) 的时候没有按照说明 按 Maskrom 按键，导致烧录系统到了 [SPI Flash](./low-level-dev/install-os/rkdevtool_spi)中, 而系统启动的时候，先读取SPI的信息，此时出现错误，无法正常启动。
 
 解决办法：
 
-[清空 SPI Flash](./low-level-dev/maskrom/erase), 然后重新按步骤 [通过USB烧录系统到eMMC](./low-level-dev/maskrom/)
+[清空 SPI Flash](./low-level-dev/install-os/rkdevtool_spi), 然后重新按步骤 [通过USB烧录系统到eMMC](./low-level-dev/install-os/rkdevtool_maskrom)
 
 ## Q9： Radxa APT 公钥不可用
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/faq.md
@@ -52,14 +52,14 @@ Follow the steps below to troubleshoot ROCK 5B:
 
 Confirmation: Remove eMMC Module, MicroSD and NVME devices.
 
-Remove the eMMC Module, MicroSD and NVME device, then connect the board and PC via USB cable, then see if the device enters [Maskrom state](./low-level-dev/maskrom/).
+Remove the eMMC Module, MicroSD and NVME device, then connect the board and PC via USB cable, then see if the device enters [Maskrom state](./low-level-dev/install-os/rkdevtool_maskrom).
 If it's not in MaskRom state, it's most likely due to the following reasons.
 
-In [Burning system to eMMC via USB](./low-level-dev/maskrom/), did not follow the instructions to press the Maskrom button, causing the system to reach the [SPI Flash](./low-level-dev/maskrom/erase), and when the system starts, it reads the SPI information first, and then there is an error and it cannot start normally.
+In [Burning system to eMMC via USB](./low-level-dev/install-os/rkdevtool_maskrom), did not follow the instructions to press the Maskrom button, causing the system to reach the [SPI Flash](./low-level-dev/install-os/rkdevtool_spi), and when the system starts, it reads the SPI information first, and then there is an error and it cannot start normally.
 
 Solution:
 
-[Empty SPI Flash](./low-level-dev/maskrom/erase), then follow the steps again [Burn system to eMMC via USB](./low-level-dev/maskrom/)
+[Empty SPI Flash](./low-level-dev/install-os/rkdevtool_spi), then follow the steps again [Burn system to eMMC via USB](./low-level-dev/install-os/rkdevtool_maskrom)
 
 ## Q9: Radxa APT public key not available
 


### PR DESCRIPTION
## Summary

Fix 3 broken links in `rock5/rock5b/faq` page (Q8 section):

| Broken link | Fixed link |
|---|---|
| `./low-level-dev/maskrom/` | `./low-level-dev/install-os/rkdevtool_maskrom` |
| `./low-level-dev/maskrom/erase` | `./low-level-dev/install-os/rkdevtool_spi` |

## Verification

Both target pages return HTTP 200:
- https://docs.radxa.com/rock5/rock5b/low-level-dev/install-os/rkdevtool_maskrom
- https://docs.radxa.com/rock5/rock5b/low-level-dev/install-os/rkdevtool_spi

Both Chinese and English versions are fixed.