### PR TITLE
docs(orion): add BIOS version column to download page

### DIFF
--- a/docs/orion/download.md
+++ b/docs/orion/download.md
@@ -23,17 +23,17 @@ sidebar_position: 150
 <Tabs queryString="versions">
     <TabItem value="星睿 O6">
 #### 瑞莎星睿 O6
-        | 下载平台                                                                            | 文件格式 | 获取方式                                                                                            |
-        | :---------------------------------------------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------- |
-        | [**Radxa DL**](https://dl.radxa.com/orion/o6/images/bios/orion-o6-bios-1.1.0-1.zip) | `.zip`   | 固件位于压缩包内                                                                                                  |
-        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-1)                | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6` 目录下 |
+        | 版本号      | 下载平台                                                                            | 文件格式 | 获取方式                                                                                            |
+        | :--------- | :---------------------------------------------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------- |
+        | `1.1.0-1` | [**Radxa DL**](https://dl.radxa.com/orion/o6/images/bios/orion-o6-bios-1.1.0-1.zip) | `.zip`   | 固件位于压缩包内                                                                                                  |
+        | `1.1.0-1` | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-1)                | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6` 目录下 |
     </TabItem>
     <TabItem value="星睿 O6N">
 #### 瑞莎星睿 O6N
-        | 下载平台                                                             | 文件格式 | 获取方式                                                                                            |
-        | :------------------------------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------- |
-        | [**Radxa DL**](https://dl.radxa.com/orion/o6n/images/bios/orion-o6n-bios-1.1.0-2.zip)                      | `.zip`   | 固件位于压缩包内                                                                                                  |
-        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-2) | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6n` 目录下 |
+        | 版本号      | 下载平台                                                             | 文件格式 | 获取方式                                                                                            |
+        | :--------- | :------------------------------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------- |
+        | `1.1.0-2` | [**Radxa DL**](https://dl.radxa.com/orion/o6n/images/bios/orion-o6n-bios-1.1.0-2.zip)                      | `.zip`   | 固件位于压缩包内                                                                                                  |
+        | `1.1.0-2` | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-2) | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6n` 目录下 |
     </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## 问题
BIOS 固件下载表格缺少版本号列，版本号（1.1.0-1 / 1.1.0-2）仅隐含在文件名中，用户需点开链接才能确认版本。

## 修改
在 Orion O6 和 O6N 的 BIOS 固件下载表格中新增【版本号】列：

| 版本号 | 下载平台 | 文件格式 | 获取方式 |
| :----- | :------- | :------ | :------- |
| `1.1.0-1` | Radxa DL / GitHub Release | .zip / .deb | 固件位于压缩包内 / deb 包内 |
| `1.1.0-2` | Radxa DL / GitHub Release | .zip / .deb | 同上 |

与 Android BIOS 表格的版本列格式保持一致。

## 影响范围
- \

## 测试
- [ ] 页面渲染正常，表格列对齐
- [ ] O6 / O6N 两个 Tab 均显示版本号