### PR TITLE
fix: update E20C iStoreOS download link to official site

### DIFF
--- a/docs/e/e20c/download.md
+++ b/docs/e/e20c/download.md
@@ -10,7 +10,7 @@ import Images from "./\_image.mdx"
 
 iStoreOS:
 
-[istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://dl.radxa.com/rock2/images/istoreos/istoreos-22.03.6-2024062810-e20c-squashfs.img.gz)
+[istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://site.istoreos.com/firmware/download?devicename=e20c)
 
 Radxa OS:
 

--- a/docs/orion/download.md
+++ b/docs/orion/download.md
@@ -23,17 +23,17 @@ sidebar_position: 150
 <Tabs queryString="versions">
     <TabItem value="星睿 O6">
 #### 瑞莎星睿 O6
-        | 下载平台                                                                            | 文件格式 | 获取方式                                                                                            |
-        | :---------------------------------------------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------- |
-        | [**Radxa DL**](https://dl.radxa.com/orion/o6/images/bios/orion-o6-bios-1.1.0-1.zip) | `.zip`   | 固件位于压缩包内                                                                                                  |
-        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-1)                | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6` 目录下 |
+        | 版本号      | 下载平台                                                                            | 文件格式 | 获取方式                                                                                            |
+        | :--------- | :---------------------------------------------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------- |
+        | `1.1.0-1` | [**Radxa DL**](https://dl.radxa.com/orion/o6/images/bios/orion-o6-bios-1.1.0-1.zip) | `.zip`   | 固件位于压缩包内                                                                                                  |
+        | `1.1.0-1` | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-1)                | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6` 目录下 |
     </TabItem>
     <TabItem value="星睿 O6N">
 #### 瑞莎星睿 O6N
-        | 下载平台                                                             | 文件格式 | 获取方式                                                                                            |
-        | :------------------------------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------- |
-        | [**Radxa DL**](https://dl.radxa.com/orion/o6n/images/bios/orion-o6n-bios-1.1.0-2.zip)                      | `.zip`   | 固件位于压缩包内                                                                                                  |
-        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-2) | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6n` 目录下 |
+        | 版本号      | 下载平台                                                             | 文件格式 | 获取方式                                                                                            |
+        | :--------- | :------------------------------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------- |
+        | `1.1.0-2` | [**Radxa DL**](https://dl.radxa.com/orion/o6n/images/bios/orion-o6n-bios-1.1.0-2.zip)                      | `.zip`   | 固件位于压缩包内                                                                                                  |
+        | `1.1.0-2` | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-2) | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6n` 目录下 |
     </TabItem>
 </Tabs>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
@@ -10,7 +10,7 @@ import Images from "./\_image.mdx"
 
 iStoreOS:
 
-[istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://dl.radxa.com/rock2/images/istoreos/istoreos-22.03.6-2024062810-e20c-squashfs.img.gz)
+[istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://site.istoreos.com/firmware/download?devicename=e20c)
 
 Radxa OS:
 


### PR DESCRIPTION
## Summary
Update E20C iStoreOS download link from dl.radxa.com to official iStoreOS site.

## Changes
- docs/e/e20c/download.md: Update iStoreOS link
- i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md: Update iStoreOS link (English)

## Link change
- From: https://dl.radxa.com/rock2/images/istoreos/istoreos-22.03.6-2024062810-e20c-squashfs.img.gz
- To: https://site.istoreos.com/firmware/download?devicename=e20c

cc @RadxaYuntian