### PR TITLE
fix: update E20C iStoreOS download link to official site

### DIFF
--- a/docs/e/e20c/download.md
+++ b/docs/e/e20c/download.md
@@ -10,7 +10,7 @@ import Images from "./\_image.mdx"
 
 iStoreOS:
 
-[istoreos-e20c](https://site.istoreos.com/firmware/download?devicename=e20c)
+[官方产品页面](https://site.istoreos.com/firmware/download?devicename=e20c)
 
 Radxa OS:
 

--- a/docs/e/e20c/download.md
+++ b/docs/e/e20c/download.md
@@ -10,7 +10,7 @@ import Images from "./\_image.mdx"
 
 iStoreOS:
 
-[istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://site.istoreos.com/firmware/download?devicename=e20c)
+[istoreos-e20c](https://site.istoreos.com/firmware/download?devicename=e20c)
 
 Radxa OS:
 

--- a/docs/e/e20c/download.md
+++ b/docs/e/e20c/download.md
@@ -10,7 +10,7 @@ import Images from "./\_image.mdx"
 
 iStoreOS:
 
-[istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://dl.radxa.com/rock2/images/istoreos/istoreos-22.03.6-2024062810-e20c-squashfs.img.gz)
+[istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://site.istoreos.com/firmware/download?devicename=e20c)
 
 Radxa OS:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
@@ -10,7 +10,7 @@ import Images from "./\_image.mdx"
 
 iStoreOS:
 
-[istoreos-e20c](https://site.istoreos.com/firmware/download?devicename=e20c)
+[Official Product Page](https://site.istoreos.com/firmware/download?devicename=e20c)
 
 Radxa OS:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
@@ -10,7 +10,7 @@ import Images from "./\_image.mdx"
 
 iStoreOS:
 
-[istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://site.istoreos.com/firmware/download?devicename=e20c)
+[istoreos-e20c](https://site.istoreos.com/firmware/download?devicename=e20c)
 
 Radxa OS:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md
@@ -10,7 +10,7 @@ import Images from "./\_image.mdx"
 
 iStoreOS:
 
-[istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://dl.radxa.com/rock2/images/istoreos/istoreos-22.03.6-2024062810-e20c-squashfs.img.gz)
+[istoreos-22.03.6-2024062810-e20c-squashfs.img.gz](https://site.istoreos.com/firmware/download?devicename=e20c)
 
 Radxa OS:
 


### PR DESCRIPTION
## Summary
Update E20C iStoreOS download link from dl.radxa.com to official iStoreOS site.

## Changes
- docs/e/e20c/download.md: Update iStoreOS link
- i18n/en/docusaurus-plugin-content-docs/current/e/e20c/download.md: Update iStoreOS link (English)

## Link change
- From: https://dl.radxa.com/rock2/images/istoreos/istoreos-22.03.6-2024062810-e20c-squashfs.img.gz
- To: https://site.istoreos.com/firmware/download?devicename=e20c

cc @RadxaYuntian