### PR TITLE
docs: add JMB585 kernel compatibility caution for Penta SATA HAT and Taco

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/penta-for-rpi5.md
+++ b/docs/accessories/storage/penta-sata-hat/penta-for-rpi5.md
@@ -98,6 +98,18 @@ ssh pi@raspberrypi.local
 
 编辑 `/boot/firmware/config.txt`，把 `dtparam=pciex1` 添加到文件末尾，保存后重启。
 
+:::caution JMB585 控制器内核兼容性问题
+Penta SATA HAT 使用 JMB585 PCIe SATA 控制芯片。自 Linux 内核 commit ee95f3c 起，该芯片在树莓派 5 上需要额外配置才能正常工作。如果在系统更新后发现硬盘无法识别或 AHCI 驱动加载失败，请在 `/boot/firmware/config.txt` 中添加：
+
+```bash
+dtoverlay=pcie-32bit-dma-pi5
+```
+
+添加后重启即可。该配置会影响 PCIe DMA 宽度，启用 32-bit DMA 以确保 JMB585 控制器正常工作。
+
+相关讨论：https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/615
+:::
+
 ![step1](/img/accessories/storage/penta/rpi-using-1.webp)
 
 ### 查看硬盘

--- a/docs/accessories/storage/taco/getting-started/install-system/README.md
+++ b/docs/accessories/storage/taco/getting-started/install-system/README.md
@@ -4,4 +4,14 @@ sidebar_position: 5
 
 # 安装系统
 
+:::caution SATA 存储 JMB585 控制器内核兼容性问题
+Taco 底板上的 5x SATA 接口使用 JMB585 PCIe SATA 控制芯片。自 Linux 内核 commit ee95f3c 起，该芯片在部分平台上可能需要额外配置才能正常工作。如果在系统更新后发现 SATA 硬盘无法识别或 AHCI 驱动加载失败，请尝试在启动参数或设备树配置中添加：
+
+```bash
+dtoverlay=pcie-32bit-dma-pi5   # 适用于树莓派 5 / CM5 平台
+```
+
+如遇问题，请参考硬件文档或联系支持。
+:::
+
 <DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/penta-for-rpi5.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/penta-for-rpi5.md
@@ -98,6 +98,18 @@ ssh pi@raspberrypi.local
 
 Edit `/boot/firmware/config.txt` and add `dtparam=pciex1` to the end of the file, save and reboot.
 
+:::caution JMB585 Controller Kernel Compatibility Issue
+The Penta SATA HAT uses the JMB585 PCIe SATA controller chip. Since Linux kernel commit ee95f3c, this chip requires additional configuration to work properly on Raspberry Pi 5. If hard drives are not detected or the AHCI driver fails to load after a system update, add the following to `/boot/firmware/config.txt`:
+
+```bash
+dtoverlay=pcie-32bit-dma-pi5
+```
+
+After adding, reboot. This configuration affects the PCIe DMA width, enabling 32-bit DMA to ensure the JMB585 controller works correctly.
+
+Related discussion: https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/615
+:::
+
 ![step1](/img/accessories/storage/penta/rpi-using-1.webp)
 
 ### Check disk

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/taco/getting-started/install-system/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/taco/getting-started/install-system/README.md
@@ -4,4 +4,14 @@ sidebar_position: 5
 
 # Install System
 
+:::caution SATA Storage JMB585 Controller Kernel Compatibility
+The 5x SATA interfaces on the Taco carrier board use the JMB585 PCIe SATA controller chip. Since Linux kernel commit ee95f3c, this chip may require additional configuration to work properly on certain platforms. If SATA drives are not detected or the AHCI driver fails to load after a system update, try adding to your boot configuration:
+
+```bash
+dtoverlay=pcie-32bit-dma-pi5   # For Raspberry Pi 5 / CM5 platforms
+```
+
+If you encounter issues, please refer to the hardware documentation or contact support.
+:::
+
 <DocCardList />


### PR DESCRIPTION
## Summary

Add caution note about Linux kernel commit ee95f3c affecting the JMB585 PCIe SATA controller used in Radxa Penta SATA HAT and Taco carrier board.

## Changes

- **penta-sata-hat/penta-for-rpi5.md** (CN): Added JMB585 kernel compatibility warning under "启用 PCIe" section
- **penta-sata-hat/penta-for-rpi5.md** (EN): Same warning added in English
- **taco/getting-started/install-system/README.md** (CN): Added JMB585 warning at top of install-system page
- **taco/getting-started/install-system/README.md** (EN): Same warning added in English

## Details

Since Linux kernel commit ee95f3c, the JMB585 SATA controller may fail to initialize on Raspberry Pi 5 / CM5 platforms. Users need to add the following to `/boot/firmware/config.txt`:

```bash
dtoverlay=pcie-32bit-dma-pi5
```

Ref: https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/615#issuecomment-4401932556