### PR TITLE
docs: add Cubie A7A/A7Z/A7S R6 and A5E R7 image release links

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/penta-for-rpi5.md
+++ b/docs/accessories/storage/penta-sata-hat/penta-for-rpi5.md
@@ -98,6 +98,18 @@ ssh pi@raspberrypi.local
 
 编辑 `/boot/firmware/config.txt`，把 `dtparam=pciex1` 添加到文件末尾，保存后重启。
 
+:::caution JMB585 控制器内核兼容性问题
+Penta SATA HAT 使用 JMB585 PCIe SATA 控制芯片。自 Linux 内核 commit ee95f3c 起，该芯片在树莓派 5 上需要额外配置才能正常工作。如果在系统更新后发现硬盘无法识别或 AHCI 驱动加载失败，请在 `/boot/firmware/config.txt` 中添加：
+
+```bash
+dtoverlay=pcie-32bit-dma-pi5
+```
+
+添加后重启即可。该配置会影响 PCIe DMA 宽度，启用 32-bit DMA 以确保 JMB585 控制器正常工作。
+
+相关讨论：https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/615
+:::
+
 ![step1](/img/accessories/storage/penta/rpi-using-1.webp)
 
 ### 查看硬盘

--- a/docs/accessories/storage/taco/getting-started/install-system/README.md
+++ b/docs/accessories/storage/taco/getting-started/install-system/README.md
@@ -4,4 +4,14 @@ sidebar_position: 5
 
 # 安装系统
 
+:::caution SATA 存储 JMB585 控制器内核兼容性问题
+Taco 底板上的 5x SATA 接口使用 JMB585 PCIe SATA 控制芯片。自 Linux 内核 commit ee95f3c 起，该芯片在部分平台上可能需要额外配置才能正常工作。如果在系统更新后发现 SATA 硬盘无法识别或 AHCI 驱动加载失败，请尝试在启动参数或设备树配置中添加：
+
+```bash
+dtoverlay=pcie-32bit-dma-pi5   # 适用于树莓派 5 / CM5 平台
+```
+
+如遇问题，请参考硬件文档或联系支持。
+:::
+
 <DocCardList />

--- a/docs/cubie/a5e/download.md
+++ b/docs/cubie/a5e/download.md
@@ -41,8 +41,15 @@ sidebar_position: 150
 
 #### GPT 系统镜像 (推荐)
 
+- [Radxa OS - Debian 11 Bullseye KDE R7（最新）](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz)
+- [Radxa OS - Debian 11 Bullseye CLI R7（最新）](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_cli_r7.output_512.img.xz)
+
+:::tip 旧版镜像
+
 - [Radxa OS - Debian 11 Bullseye KDE](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-b1/radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz)
 - [Tina Linux - Debian 11 Bullseye XFCE](https://mega.nz/file/g7AWVBZJ#xkDOIJYHvgUngdKUgW7D_aSaVPifyYZDOG0fUOtgAMk) ⚠️ *MEGA 链接，部分地区可能无法访问*
+
+:::
 
 #### FEL 系统镜像
 

--- a/docs/cubie/a7a/download.md
+++ b/docs/cubie/a7a/download.md
@@ -40,9 +40,21 @@ sidebar_position: 150
 
 目前支持 MicroSD 卡/ eMMC 模块 / UFS 模块启动系统，NVMe/SSD 启动需要刷写 SPI Nor Flash 固件
 
+- [Radxa Cubie A7A Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) （SD / eMMC）
+
+- [Radxa Cubie A7A Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) （SD / eMMC）
+
+- [Radxa Cubie A7A Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) （UFS）
+
+- [Radxa Cubie A7A Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) （UFS）
+
+:::tip 旧版镜像
+
 - [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) （SD / eMMC）
 
 - [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) （UFS）
+
+:::
 
 :::tip 百度网盘下载（备选）
 

--- a/docs/cubie/a7s/download.md
+++ b/docs/cubie/a7s/download.md
@@ -40,7 +40,17 @@ sidebar_position: 8
 
 - Radxa OS
 
+[radxa-a733-bullseye-kde-r6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz)：支持 MicroSD 卡和板载 eMMC 启动系统。
+
+[radxa-a733-bullseye-cli-r6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz)：支持 MicroSD 卡和板载 eMMC 启动系统。
+
+:::tip 旧版镜像
+
 [radxa-a733-bullseye-kde-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz)：支持 MicroSD 卡和板载 eMMC 启动系统。
+
+[radxa-a733-bullseye-cli-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_cli_r2.output_512.img.xz)：支持 MicroSD 卡和板载 eMMC 启动系统。
+
+:::
 
 - Radxa OS Lite
 
@@ -51,8 +61,6 @@ Radxa OS Lite 系统镜像不包含图形桌面环境。
 如果你需要显示器、窗口界面或图形应用，请选择 Radxa OS 系统镜像。
 
 :::
-
-[radxa-a733-bullseye-cli-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_cli_r2.output_512.img.xz)：支持 MicroSD 卡和板载 eMMC 启动系统。
 
 :::tip 内置 OpenClaw 环境镜像
 

--- a/docs/cubie/a7z/download.md
+++ b/docs/cubie/a7z/download.md
@@ -40,9 +40,21 @@ sidebar_position: 150
 
 目前支持 MicroSD 卡/ eMMC 模块 / UFS 模块启动系统，NVMe/SSD 启动需要刷写 SPI Nor Flash 固件
 
+- [Radxa Cubie A7Z Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) （SD / eMMC）
+
+- [Radxa Cubie A7Z Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) （SD / eMMC）
+
+- [Radxa Cubie A7Z Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) （UFS）
+
+- [Radxa Cubie A7Z Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) （UFS）
+
+:::tip 旧版镜像
+
 - [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) （SD / eMMC）
 
 - [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) （UFS）
+
+:::
 
 :::tip Cubie A7Z 旧版镜像
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/penta-for-rpi5.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/penta-for-rpi5.md
@@ -98,6 +98,18 @@ ssh pi@raspberrypi.local
 
 Edit `/boot/firmware/config.txt` and add `dtparam=pciex1` to the end of the file, save and reboot.
 
+:::caution JMB585 Controller Kernel Compatibility Issue
+The Penta SATA HAT uses the JMB585 PCIe SATA controller chip. Since Linux kernel commit ee95f3c, this chip requires additional configuration to work properly on Raspberry Pi 5. If hard drives are not detected or the AHCI driver fails to load after a system update, add the following to `/boot/firmware/config.txt`:
+
+```bash
+dtoverlay=pcie-32bit-dma-pi5
+```
+
+After adding, reboot. This configuration affects the PCIe DMA width, enabling 32-bit DMA to ensure the JMB585 controller works correctly.
+
+Related discussion: https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/615
+:::
+
 ![step1](/img/accessories/storage/penta/rpi-using-1.webp)
 
 ### Check disk

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/taco/getting-started/install-system/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/taco/getting-started/install-system/README.md
@@ -4,4 +4,14 @@ sidebar_position: 5
 
 # Install System
 
+:::caution SATA Storage JMB585 Controller Kernel Compatibility
+The 5x SATA interfaces on the Taco carrier board use the JMB585 PCIe SATA controller chip. Since Linux kernel commit ee95f3c, this chip may require additional configuration to work properly on certain platforms. If SATA drives are not detected or the AHCI driver fails to load after a system update, try adding to your boot configuration:
+
+```bash
+dtoverlay=pcie-32bit-dma-pi5   # For Raspberry Pi 5 / CM5 platforms
+```
+
+If you encounter issues, please refer to the hardware documentation or contact support.
+:::
+
 <DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/download.md
@@ -30,8 +30,15 @@ We strongly recommend that beginners download GPT format Radxa OS official image
 
 #### GPT System Images (Recommended)
 
+- [Radxa OS - Debian 11 Bullseye KDE R7 (Latest)](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz)
+- [Radxa OS - Debian 11 Bullseye CLI R7 (Latest)](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_cli_r7.output_512.img.xz)
+
+:::tip Legacy Images
+
 - [Radxa OS - Debian 11 Bullseye KDE](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-b1/radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz)
 - [Tina Linux - Debian 11 Bullseye XFCE](https://mega.nz/file/g7AWVBZJ#xkDOIJYHvgUngdKUgW7D_aSaVPifyYZDOG0fUOtgAMk)
+
+:::
 
 #### FEL System Images
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/download.md
@@ -40,9 +40,21 @@ Suitable for all A733 SoC products, such as Cubie A7Z, Cubie A7A, etc. Beta vers
 
 Currently supports booting from MicroSD cards, eMMC modules, and UFS modules. NVMe/SSD boot requires flashing the SPI Nor Flash firmware.
 
+- [Radxa Cubie A7A Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) (SD / eMMC)
+
+- [Radxa Cubie A7A Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) (SD / eMMC)
+
+- [Radxa Cubie A7A Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) (UFS)
+
+- [Radxa Cubie A7A Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) (UFS)
+
+:::tip Legacy Images
+
 - [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) (SD / eMMC)
 
 - [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) (UFS)
+
+:::
 
 :::tip Baidu Netdisk Download (Alternative)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/download.md
@@ -40,7 +40,17 @@ This page publishes the latest stable and test images. Test versions start with 
 
 - Radxa OS
 
+[radxa-a733-bullseye-kde-r6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz): supports booting from microSD and onboard eMMC.
+
+[radxa-a733-bullseye-cli-r6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz): supports booting from microSD and onboard eMMC.
+
+:::tip Legacy Images
+
 [radxa-a733-bullseye-kde-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz): supports booting from microSD and onboard eMMC.
+
+[radxa-a733-bullseye-cli-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_cli_r2.output_512.img.xz): supports booting from microSD and onboard eMMC.
+
+:::
 
 - Radxa OS Lite
 
@@ -51,8 +61,6 @@ Radxa OS Lite does not include a graphical desktop environment.
 If you need a monitor UI or graphical applications, use the full Radxa OS image.
 
 :::
-
-[radxa-a733-bullseye-cli-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_cli_r2.output_512.img.xz): supports booting from microSD and onboard eMMC.
 
 :::tip Built-in OpenClaw environment image
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/download.md
@@ -40,9 +40,21 @@ Suitable for all A733 SoC products, such as Cubie A7Z, Cubie A7A, etc. Beta vers
 
 Currently supports booting from MicroSD cards, eMMC modules, and UFS modules. NVMe/SSD boot requires flashing the SPI Nor Flash firmware.
 
+- [Radxa Cubie A7Z Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) (SD / eMMC)
+
+- [Radxa Cubie A7Z Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) (SD / eMMC)
+
+- [Radxa Cubie A7Z Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) (UFS)
+
+- [Radxa Cubie A7Z Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) (UFS)
+
+:::tip Legacy Images
+
 - [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) (SD / eMMC)
 
 - [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) (UFS)
+
+:::
 
 :::tip Cubie A7Z Legacy Images
 


### PR DESCRIPTION
## Changes

- Add Radxa Cubie A7A/A7Z/A7S Debian R6 (SD/eMMC and UFS, KDE and CLI) as latest
- Add Radxa Cubie A5E Debian R7 (SD/eMMC, KDE and CLI) as latest  
- Mark R2 (A7A/A7Z/A7S) and B1 (A5E) as legacy/旧版镜像
- Update both Chinese and English documentation

## Files Changed

- `docs/cubie/a7a/download.md` (Chinese)
- `docs/cubie/a7z/download.md` (Chinese)
- `docs/cubie/a7s/download.md` (Chinese)
- `docs/cubie/a5e/download.md` (Chinese)
- `i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/download.md` (English)
- `i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/download.md` (English)
- `i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/download.md` (English)
- `i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/download.md` (English)