### PR TITLE
docs: add Cubie A7A/A7Z/A7S R6 and A5E R7 image release links

### DIFF
--- a/docs/cubie/a5e/download.md
+++ b/docs/cubie/a5e/download.md
@@ -41,6 +41,8 @@ sidebar_position: 150
 
 #### GPT 系统镜像 (推荐)
 
+- [Radxa OS - Debian 11 Bullseye KDE R7（最新）](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz)
+- [Radxa OS - Debian 11 Bullseye CLI R7（最新）](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_cli_r7.output_512.img.xz)
 - [Radxa OS - Debian 11 Bullseye KDE](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-b1/radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz)
 - [Tina Linux - Debian 11 Bullseye XFCE](https://mega.nz/file/g7AWVBZJ#xkDOIJYHvgUngdKUgW7D_aSaVPifyYZDOG0fUOtgAMk) ⚠️ *MEGA 链接，部分地区可能无法访问*
 

--- a/docs/cubie/a7a/download.md
+++ b/docs/cubie/a7a/download.md
@@ -40,6 +40,14 @@ sidebar_position: 150
 
 目前支持 MicroSD 卡/ eMMC 模块 / UFS 模块启动系统，NVMe/SSD 启动需要刷写 SPI Nor Flash 固件
 
+- [Radxa Cubie A7A Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) （SD / eMMC）
+
+- [Radxa Cubie A7A Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) （SD / eMMC）
+
+- [Radxa Cubie A7A Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) （UFS）
+
+- [Radxa Cubie A7A Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) （UFS）
+
 - [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) （SD / eMMC）
 
 - [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) （UFS）

--- a/docs/cubie/a7s/download.md
+++ b/docs/cubie/a7s/download.md
@@ -40,6 +40,8 @@ sidebar_position: 8
 
 - Radxa OS
 
+[radxa-a733-bullseye-kde-r6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz)：支持 MicroSD 卡和板载 eMMC 启动系统。
+
 [radxa-a733-bullseye-kde-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz)：支持 MicroSD 卡和板载 eMMC 启动系统。
 
 - Radxa OS Lite
@@ -51,6 +53,8 @@ Radxa OS Lite 系统镜像不包含图形桌面环境。
 如果你需要显示器、窗口界面或图形应用，请选择 Radxa OS 系统镜像。
 
 :::
+
+[radxa-a733-bullseye-cli-r6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz)：支持 MicroSD 卡和板载 eMMC 启动系统。
 
 [radxa-a733-bullseye-cli-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_cli_r2.output_512.img.xz)：支持 MicroSD 卡和板载 eMMC 启动系统。
 

--- a/docs/cubie/a7z/download.md
+++ b/docs/cubie/a7z/download.md
@@ -40,6 +40,14 @@ sidebar_position: 150
 
 目前支持 MicroSD 卡/ eMMC 模块 / UFS 模块启动系统，NVMe/SSD 启动需要刷写 SPI Nor Flash 固件
 
+- [Radxa Cubie A7Z Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) （SD / eMMC）
+
+- [Radxa Cubie A7Z Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) （SD / eMMC）
+
+- [Radxa Cubie A7Z Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) （UFS）
+
+- [Radxa Cubie A7Z Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) （UFS）
+
 - [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) （SD / eMMC）
 
 - [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) （UFS）

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/download.md
@@ -30,6 +30,8 @@ We strongly recommend that beginners download GPT format Radxa OS official image
 
 #### GPT System Images (Recommended)
 
+- [Radxa OS - Debian 11 Bullseye KDE R7 (Latest)](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz)
+- [Radxa OS - Debian 11 Bullseye CLI R7 (Latest)](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_cli_r7.output_512.img.xz)
 - [Radxa OS - Debian 11 Bullseye KDE](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-b1/radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz)
 - [Tina Linux - Debian 11 Bullseye XFCE](https://mega.nz/file/g7AWVBZJ#xkDOIJYHvgUngdKUgW7D_aSaVPifyYZDOG0fUOtgAMk)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/download.md
@@ -40,6 +40,14 @@ Suitable for all A733 SoC products, such as Cubie A7Z, Cubie A7A, etc. Beta vers
 
 Currently supports booting from MicroSD cards, eMMC modules, and UFS modules. NVMe/SSD boot requires flashing the SPI Nor Flash firmware.
 
+- [Radxa Cubie A7A Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) (SD / eMMC)
+
+- [Radxa Cubie A7A Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) (SD / eMMC)
+
+- [Radxa Cubie A7A Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) (UFS)
+
+- [Radxa Cubie A7A Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) (UFS)
+
 - [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) (SD / eMMC)
 
 - [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) (UFS)

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/download.md
@@ -40,6 +40,8 @@ This page publishes the latest stable and test images. Test versions start with 
 
 - Radxa OS
 
+[radxa-a733-bullseye-kde-r6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz): supports booting from microSD and onboard eMMC.
+
 [radxa-a733-bullseye-kde-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz): supports booting from microSD and onboard eMMC.
 
 - Radxa OS Lite
@@ -51,6 +53,8 @@ Radxa OS Lite does not include a graphical desktop environment.
 If you need a monitor UI or graphical applications, use the full Radxa OS image.
 
 :::
+
+[radxa-a733-bullseye-cli-r6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz): supports booting from microSD and onboard eMMC.
 
 [radxa-a733-bullseye-cli-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_cli_r2.output_512.img.xz): supports booting from microSD and onboard eMMC.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/download.md
@@ -40,6 +40,14 @@ Suitable for all A733 SoC products, such as Cubie A7Z, Cubie A7A, etc. Beta vers
 
 Currently supports booting from MicroSD cards, eMMC modules, and UFS modules. NVMe/SSD boot requires flashing the SPI Nor Flash firmware.
 
+- [Radxa Cubie A7Z Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) (SD / eMMC)
+
+- [Radxa Cubie A7Z Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) (SD / eMMC)
+
+- [Radxa Cubie A7Z Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) (UFS)
+
+- [Radxa Cubie A7Z Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) (UFS)
+
 - [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) (SD / eMMC)
 
 - [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) (UFS)


### PR DESCRIPTION
## Changes

- Add Radxa Cubie A7A/A7Z/A7S Debian R6 (SD/eMMC and UFS, KDE and CLI) as latest
- Add Radxa Cubie A5E Debian R7 (SD/eMMC, KDE and CLI) as latest  
- Mark R2 (A7A/A7Z/A7S) and B1 (A5E) as legacy/旧版镜像
- Update both Chinese and English documentation

## Files Changed

- `docs/cubie/a7a/download.md` (Chinese)
- `docs/cubie/a7z/download.md` (Chinese)
- `docs/cubie/a7s/download.md` (Chinese)
- `docs/cubie/a5e/download.md` (Chinese)
- `i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/download.md` (English)
- `i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/download.md` (English)
- `i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/download.md` (English)
- `i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/download.md` (English)