### PR TITLE
docs: cubie: add R6/R7 camera gstreamer commands for a7a/a7z/a7s/a5e

### DIFF
--- a/docs/cubie/a5e/accessories/camera-13m-214.md
+++ b/docs/cubie/a5e/accessories/camera-13m-214.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/accessories/_camera-13m-214.mdx
+---
+
+import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
+
+# 瑞莎 13M 214 摄像头
+
+<Camera13M214 product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a5e'/>
+
+## 预览摄像头
+
+使用 GStreamer 预览摄像头画面。
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160 (4K)
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-4k.md
+++ b/docs/cubie/a5e/accessories/camera-4k.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/accessories/_camera-4k.mdx
+---
+
+import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
+
+# 瑞莎 4K 摄像头
+
+<Camera4K product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a5e' enable_camera='Enable Radxa Camera 4K'/>
+
+## 预览摄像头
+
+使用 GStreamer 预览摄像头画面。
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120 (4K+)
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-8m-219.md
+++ b/docs/cubie/a5e/accessories/camera-8m-219.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/accessories/_camera-8m-219.mdx
+---
+
+import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
+
+# 瑞莎 8M 219 摄像头
+
+<Camera8M219 product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='同面' board='cubie-a5e' />
+
+## 预览摄像头
+
+使用 GStreamer 预览摄像头画面。
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-13m-214.md
+++ b/docs/cubie/a7a/accessories/camera-13m-214.md
@@ -20,7 +20,27 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160 (4K)
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-4k.md
+++ b/docs/cubie/a7a/accessories/camera-4k.md
@@ -20,7 +20,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120 (4K+)
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-8m-219.md
+++ b/docs/cubie/a7a/accessories/camera-8m-219.md
@@ -20,7 +20,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-13m-214.md
+++ b/docs/cubie/a7s/accessories-use/camera-13m-214.md
@@ -36,7 +36,27 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160 (4K)
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-4k.md
+++ b/docs/cubie/a7s/accessories-use/camera-4k.md
@@ -36,7 +36,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120 (4K+)
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-8m-219.md
+++ b/docs/cubie/a7s/accessories-use/camera-8m-219.md
@@ -36,7 +36,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7z/accessories/camera-13m-214.md
+++ b/docs/cubie/a7z/accessories/camera-13m-214.md
@@ -20,21 +20,12 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-## 已验证环境与常用管线
-
-以下说明基于 issue #1360 中确认过的 Cubie A7Z 实测结果整理，适合先做快速自检。
-
-- 已验证镜像：`radxa-a733_bullseye_kde_r2.output_512.img.xz`
-- 全分辨率预览：使用 `/dev/video1`，分辨率 `4208x3120`，并保持 `en-largemode=1`
-- 1080p 预览：使用 `/dev/video0`，分辨率 `1920x1080`，并使用 `en-largemode=0`
-- 当前软件流中，更低分辨率未在该 issue 对应环境下完成验证；如果直接切到更低分辨率，可能出现画面异常
-
-### 1080p 预览
+### 1920x1080 (1080p)
 
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
@@ -44,8 +35,17 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 !
 
 </NewCodeBlock>
 
+### 3840x2160 (4K)
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
 ## 排障
 
 - 如果系统中没有出现 `/dev/video*` 节点，请先确认使用的是最新可用官方镜像，再重新插拔并检查 FPC 排线是否压紧、方向是否正确
 - 如果需要先确认摄像头是否已经被内核识别，可运行 `v4l2-ctl --list-devices`
-- 如需复现本文档中的已验证结果，建议优先使用上方两条已验证管线，不要一开始就切换到未验证的低分辨率参数

--- a/docs/cubie/a7z/accessories/camera-4k.md
+++ b/docs/cubie/a7z/accessories/camera-4k.md
@@ -20,7 +20,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120 (4K+)
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7z/accessories/camera-8m-219.md
+++ b/docs/cubie/a7z/accessories/camera-8m-219.md
@@ -20,7 +20,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-13m-214.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_camera-13m-214.mdx
+---
+
+import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
+
+# Radxa Camera 13M 214
+
+<Camera13M214 product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a5e' />
+
+## Preview the camera
+
+Use GStreamer to preview the camera image.
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160 (4K)
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_camera-4k.mdx
+---
+
+import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
+
+# Radxa Camera 4K
+
+<Camera4K product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a5e' enable_camera='Enable Radxa Camera 4K' />
+
+## Preview the camera
+
+Use GStreamer to preview the camera image.
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120 (4K+)
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-8m-219.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_camera-8m-219.mdx
+---
+
+import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
+
+# Radxa Camera 8M 219
+
+<Camera8M219 product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='same side' board='cubie-a5e' />
+
+## Preview the camera
+
+Use GStreamer to preview the camera image.
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-13m-214.md
@@ -20,7 +20,27 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160 (4K)
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
@@ -20,7 +20,17 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120 (4K+)
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-8m-219.md
@@ -20,7 +20,17 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-13m-214.md
@@ -36,7 +36,27 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160 (4K)
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
@@ -36,7 +36,17 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120 (4K+)
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-8m-219.md
@@ -36,7 +36,17 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
@@ -20,21 +20,12 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-## Verified setup and common pipelines
-
-The notes below summarize the Cubie A7Z results confirmed in issue #1360 and are intended as a quick validation baseline.
-
-- Verified image: `radxa-a733_bullseye_kde_r2.output_512.img.xz`
-- Full-resolution preview: use `/dev/video1` at `4208x3120` with `en-largemode=1`
-- 1080p preview: use `/dev/video0` at `1920x1080` with `en-largemode=0`
-- Lower resolutions were not fully validated in that software flow; switching directly to smaller resolutions may still produce abnormal output
-
-### 1080p preview
+### 1920x1080 (1080p)
 
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
@@ -44,8 +35,17 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 !
 
 </NewCodeBlock>
 
+### 3840x2160 (4K)
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
 ## Troubleshooting
 
 - If no `/dev/video*` nodes appear, first confirm that you are using a recent official image, then reseat the FPC cable and verify its orientation and latch state
 - To quickly confirm whether the camera has been detected by the kernel, run `v4l2-ctl --list-devices`
-- To reproduce the validated behavior documented here, start with the two verified pipelines above before trying unvalidated lower-resolution settings

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-4k.md
@@ -20,7 +20,17 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120 (4K+)
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-8m-219.md
@@ -20,7 +20,17 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080 (1080p)
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>


### PR DESCRIPTION
## Summary

Add R6 firmware gstreamer preview commands for Cubie A7A/A7Z/A7S and R7 firmware gstreamer preview commands for Cubie A5E.

## Changes

New commands added for multiple resolutions:
- 1920x1080 (1080p) for IMX214/IMX219/IMX415
- 3280x2464 for IMX219
- 3840x2160 (4K) for IMX214/IMX415
- 4208x3120 (4K+) for IMX214

For A5E (R7), format=I420 is used instead of NV12.

## Files changed

### Modified (existing docs)
- `docs/cubie/a7a/accessories/camera-8m-219.md`
- `docs/cubie/a7a/accessories/camera-4k.md`
- `docs/cubie/a7a/accessories/camera-13m-214.md`
- `docs/cubie/a7s/accessories-use/camera-8m-219.md`
- `docs/cubie/a7s/accessories-use/camera-4k.md`
- `docs/cubie/a7s/accessories-use/camera-13m-214.md`
- `docs/cubie/a7z/accessories/camera-8m-219.md`
- `docs/cubie/a7z/accessories/camera-4k.md`
- `docs/cubie/a7z/accessories/camera-13m-214.md` (added 3840x2160 subsection)
- English counterparts in `i18n/en/`

### New (Cubie A5E camera pages - previously had no dedicated camera pages)
- `docs/cubie/a5e/accessories/camera-8m-219.md`
- `docs/cubie/a5e/accessories/camera-4k.md`
- `docs/cubie/a5e/accessories/camera-13m-214.md`
- English counterparts in `i18n/en/`