### PR TITLE
docs: cubie: update camera gstreamer commands to 30fps

### DIFF
--- a/docs/cubie/a5e/accessories/camera-13m-214.md
+++ b/docs/cubie/a5e/accessories/camera-13m-214.md
@@ -20,27 +20,23 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
-```
-
-</NewCodeBlock>
-
-### 1920x1080
-
-<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
-
-```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 3840x2160
-
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-13m-214.md
+++ b/docs/cubie/a5e/accessories/camera-13m-214.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/accessories/_camera-13m-214.mdx
+---
+
+import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
+
+# 瑞莎 13M 214 摄像头
+
+<Camera13M214 product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a5e'/>
+
+## 预览摄像头
+
+使用 GStreamer 预览摄像头画面。
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-4k.md
+++ b/docs/cubie/a5e/accessories/camera-4k.md
@@ -20,17 +20,15 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-4k.md
+++ b/docs/cubie/a5e/accessories/camera-4k.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/accessories/_camera-4k.mdx
+---
+
+import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
+
+# 瑞莎 4K 摄像头
+
+<Camera4K product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a5e' enable_camera='Enable Radxa Camera 4K'/>
+
+## 预览摄像头
+
+使用 GStreamer 预览摄像头画面。
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-4k.md
+++ b/docs/cubie/a5e/accessories/camera-4k.md
@@ -25,12 +25,12 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 
 </NewCodeBlock>
 
-### 4208x3120
+### 1920x1080
 
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-8m-219.md
+++ b/docs/cubie/a5e/accessories/camera-8m-219.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/accessories/_camera-8m-219.mdx
+---
+
+import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
+
+# 瑞莎 8M 219 摄像头
+
+<Camera8M219 product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='同面' board='cubie-a5e' />
+
+## 预览摄像头
+
+使用 GStreamer 预览摄像头画面。
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-8m-219.md
+++ b/docs/cubie/a5e/accessories/camera-8m-219.md
@@ -20,17 +20,15 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=3280,height=2464,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=3280,height=2464,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-13m-214.md
+++ b/docs/cubie/a7a/accessories/camera-13m-214.md
@@ -20,27 +20,23 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1  ! xvimagesink
-```
-
-</NewCodeBlock>
-
-### 1920x1080
-
-<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
-
-```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 3840x2160
-
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-13m-214.md
+++ b/docs/cubie/a7a/accessories/camera-13m-214.md
@@ -20,7 +20,27 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-4k.md
+++ b/docs/cubie/a7a/accessories/camera-4k.md
@@ -20,17 +20,15 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-4k.md
+++ b/docs/cubie/a7a/accessories/camera-4k.md
@@ -25,12 +25,12 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 
 </NewCodeBlock>
 
-### 4208x3120
+### 1920x1080
 
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-4k.md
+++ b/docs/cubie/a7a/accessories/camera-4k.md
@@ -20,7 +20,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-8m-219.md
+++ b/docs/cubie/a7a/accessories/camera-8m-219.md
@@ -20,7 +20,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-8m-219.md
+++ b/docs/cubie/a7a/accessories/camera-8m-219.md
@@ -20,17 +20,15 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-13m-214.md
+++ b/docs/cubie/a7s/accessories-use/camera-13m-214.md
@@ -36,7 +36,27 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-13m-214.md
+++ b/docs/cubie/a7s/accessories-use/camera-13m-214.md
@@ -36,27 +36,23 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
-```
-
-</NewCodeBlock>
-
-### 1920x1080
-
-<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
-
-```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 3840x2160
-
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-4k.md
+++ b/docs/cubie/a7s/accessories-use/camera-4k.md
@@ -41,12 +41,12 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 
 </NewCodeBlock>
 
-### 4208x3120
+### 1920x1080
 
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-4k.md
+++ b/docs/cubie/a7s/accessories-use/camera-4k.md
@@ -36,7 +36,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-4k.md
+++ b/docs/cubie/a7s/accessories-use/camera-4k.md
@@ -36,17 +36,15 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-8m-219.md
+++ b/docs/cubie/a7s/accessories-use/camera-8m-219.md
@@ -36,17 +36,15 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-8m-219.md
+++ b/docs/cubie/a7s/accessories-use/camera-8m-219.md
@@ -36,7 +36,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7z/accessories/camera-13m-214.md
+++ b/docs/cubie/a7z/accessories/camera-13m-214.md
@@ -20,7 +20,17 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7z/accessories/camera-13m-214.md
+++ b/docs/cubie/a7z/accessories/camera-13m-214.md
@@ -20,17 +20,23 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
-
-### 3840x2160
 
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
@@ -43,8 +49,6 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 - 全分辨率预览：使用 `/dev/video1`，分辨率 `4208x3120`，并保持 `en-largemode=1`
 - 1080p 预览：使用 `/dev/video0`，分辨率 `1920x1080`，并使用 `en-largemode=0`
 - 当前软件流中，更低分辨率未在该 issue 对应环境下完成验证；如果直接切到更低分辨率，可能出现画面异常
-
-### 1920x1080
 
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 

--- a/docs/cubie/a7z/accessories/camera-13m-214.md
+++ b/docs/cubie/a7z/accessories/camera-13m-214.md
@@ -44,7 +44,7 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 - 1080p 预览：使用 `/dev/video0`，分辨率 `1920x1080`，并使用 `en-largemode=0`
 - 当前软件流中，更低分辨率未在该 issue 对应环境下完成验证；如果直接切到更低分辨率，可能出现画面异常
 
-### 1080p 预览
+### 1920x1080
 
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 

--- a/docs/cubie/a7z/accessories/camera-4k.md
+++ b/docs/cubie/a7z/accessories/camera-4k.md
@@ -25,12 +25,12 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 
 </NewCodeBlock>
 
-### 4208x3120
+### 1920x1080
 
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7z/accessories/camera-4k.md
+++ b/docs/cubie/a7z/accessories/camera-4k.md
@@ -20,17 +20,15 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7z/accessories/camera-4k.md
+++ b/docs/cubie/a7z/accessories/camera-4k.md
@@ -20,7 +20,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7z/accessories/camera-8m-219.md
+++ b/docs/cubie/a7z/accessories/camera-8m-219.md
@@ -20,17 +20,15 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7z/accessories/camera-8m-219.md
+++ b/docs/cubie/a7z/accessories/camera-8m-219.md
@@ -20,7 +20,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-13m-214.md
@@ -20,27 +20,23 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
-```
-
-</NewCodeBlock>
-
-### 1920x1080
-
-<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
-
-```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 3840x2160
-
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-13m-214.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_camera-13m-214.mdx
+---
+
+import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
+
+# Radxa Camera 13M 214
+
+<Camera13M214 product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a5e' />
+
+## Preview the camera
+
+Use GStreamer to preview the camera image.
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
@@ -20,17 +20,15 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
@@ -25,12 +25,12 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 
 </NewCodeBlock>
 
-### 4208x3120
+### 1920x1080
 
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_camera-4k.mdx
+---
+
+import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
+
+# Radxa Camera 4K
+
+<Camera4K product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a5e' enable_camera='Enable Radxa Camera 4K' />
+
+## Preview the camera
+
+Use GStreamer to preview the camera image.
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-8m-219.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_camera-8m-219.mdx
+---
+
+import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
+
+# Radxa Camera 8M 219
+
+<Camera8M219 product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='same side' board='cubie-a5e' />
+
+## Preview the camera
+
+Use GStreamer to preview the camera image.
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-8m-219.md
@@ -20,17 +20,15 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=3280,height=2464,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip='radxa@cubie-a5e$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=3280,height=2464,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-13m-214.md
@@ -20,27 +20,23 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1  ! xvimagesink
-```
-
-</NewCodeBlock>
-
-### 1920x1080
-
-<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
-
-```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 3840x2160
-
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-13m-214.md
@@ -20,7 +20,27 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
@@ -20,17 +20,15 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
@@ -25,12 +25,12 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 
 </NewCodeBlock>
 
-### 4208x3120
+### 1920x1080
 
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
@@ -20,7 +20,17 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-8m-219.md
@@ -20,7 +20,17 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-8m-219.md
@@ -20,17 +20,15 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-13m-214.md
@@ -36,27 +36,23 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
-```
-
-</NewCodeBlock>
-
-### 1920x1080
-
-<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
-
-```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 3840x2160
-
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-13m-214.md
@@ -36,7 +36,27 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
@@ -36,17 +36,15 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
@@ -41,12 +41,12 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 
 </NewCodeBlock>
 
-### 4208x3120
+### 1920x1080
 
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
@@ -36,7 +36,17 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-8m-219.md
@@ -36,17 +36,15 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
 
-### 1920x1080
-
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-8m-219.md
@@ -36,7 +36,17 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
@@ -44,7 +44,7 @@ The notes below summarize the Cubie A7Z results confirmed in issue #1360 and are
 - 1080p preview: use `/dev/video0` at `1920x1080` with `en-largemode=0`
 - Lower resolutions were not fully validated in that software flow; switching directly to smaller resolutions may still produce abnormal output
 
-### 1080p preview
+### 1920x1080
 
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
@@ -20,17 +20,23 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
-
-### 3840x2160
 
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>
@@ -43,8 +49,6 @@ The notes below summarize the Cubie A7Z results confirmed in issue #1360 and are
 - Full-resolution preview: use `/dev/video1` at `4208x3120` with `en-largemode=1`
 - 1080p preview: use `/dev/video0` at `1920x1080` with `en-largemode=0`
 - Lower resolutions were not fully validated in that software flow; switching directly to smaller resolutions may still produce abnormal output
-
-### 1920x1080
 
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
@@ -20,7 +20,17 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 3840x2160
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-4k.md
@@ -25,12 +25,12 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 
 </NewCodeBlock>
 
-### 4208x3120
+### 1920x1080
 
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-4k.md
@@ -20,7 +20,17 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 4208x3120
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-8m-219.md
@@ -20,7 +20,17 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1  ! xvimagesink
+```
+
+</NewCodeBlock>
+
+### 1920x1080
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>


### PR DESCRIPTION
## Summary

Update camera preview commands for Cubie A7A/A7Z/A7S (R6) and Cubie A5E (R7).

## Changes

- Replace main preview commands framerate=24/1 with 30/1
- Add missing resolution options as subsections (no 4K+/4K- labels)
- A5E uses format=I420; others use format=NV12
- **a7z camera-13m-214.md: `## 已验证环境与常用管线` section left untouched (R2 verified commands preserved)**

## Files

### a7a / a7z / a7s (R6, format=NV12)
- `camera-8m-219.md`: main 3280x2464@30fps, added 1920x1080 subsection
- `camera-4k.md`: main 3840x2160@30fps, added 4208x3120 subsection
- `camera-13m-214.md`: main 4208x3120@30fps, added 3840x2160 subsection (a7z: verified section untouched)

### a5e (R7, format=I420) - new pages
- `camera-8m-219.md`: 3280x2464@30fps main, 1920x1080 subsection
- `camera-4k.md`: 3840x2160@30fps main, 4208x3120 subsection
- `camera-13m-214.md`: 4208x3120@30fps main, 1920x1080 + 3840x2160 subsections

Both zh and en versions updated.