### PR TITLE
docs: add binfmt section to environment setup

### DIFF
--- a/docs/common/radxa-os/build-system/_install_env.mdx
+++ b/docs/common/radxa-os/build-system/_install_env.mdx
@@ -12,6 +12,19 @@
 
 我们需要在 PC 上安装 Visual Studio Code、Dev Container 拓展插件和 Docker，方便快速构建 {props?.items ?? 'U-Boot、Kernel and Radxa OS'} 的编译和开发环境。
 
+### 启用 binfmt {#binfmt}
+
+支持以运行跨架构二进制文件。
+
+<NewCodeBlock tip="Linux@host$" type="host">
+
+```bash
+sudo apt-get update
+sudo apt-get install git qemu-user-static binfmt-support
+```
+
+</NewCodeBlock>
+
 ### Docker
 
 可以根据自己使用需求选择 Docker 引擎或 Docker 桌面版本进行安装。

--- a/docs/cubie/a5e/accessories/camera-13m-214.md
+++ b/docs/cubie/a5e/accessories/camera-13m-214.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/accessories/_camera-13m-214.mdx
+---
+
+import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
+
+# 瑞莎 13M 214 摄像头
+
+<Camera13M214 product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a5e' />
+
+## 预览摄像头
+
+使用 GStreamer 预览摄像头画面。
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-4k.md
+++ b/docs/cubie/a5e/accessories/camera-4k.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/accessories/_camera-4k.mdx
+---
+
+import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
+
+# 瑞莎 4K 摄像头
+
+<Camera4K product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a5e' enable_camera='Enable Radxa Camera 4K' />
+
+## 预览摄像头
+
+使用 GStreamer 预览摄像头画面。
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-8m-219.md
+++ b/docs/cubie/a5e/accessories/camera-8m-219.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/accessories/_camera-8m-219.mdx
+---
+
+import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
+
+# 瑞莎 8M 219 摄像头
+
+<Camera8M219 product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='同面' board='cubie-a5e' />
+
+## 预览摄像头
+
+使用 GStreamer 预览摄像头画面。
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3280,height=2464,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-13m-214.md
+++ b/docs/cubie/a7a/accessories/camera-13m-214.md
@@ -20,7 +20,19 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-4k.md
+++ b/docs/cubie/a7a/accessories/camera-4k.md
@@ -20,7 +20,13 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7a/accessories/camera-8m-219.md
+++ b/docs/cubie/a7a/accessories/camera-8m-219.md
@@ -20,7 +20,13 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-13m-214.md
+++ b/docs/cubie/a7s/accessories-use/camera-13m-214.md
@@ -23,6 +23,12 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 
 使用 GStreamer 工具预览摄像头画面。
 
+:::tip 使用提示
+
+该教程适用于 Radxa OS 系统镜像。
+
+:::
+
 :::tip 摄像头设备路径
 
 - 请使用 `ls /dev/video*` 命令查看摄像头设备路径和更换命令中的设备路径。
@@ -36,7 +42,19 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-4k.md
+++ b/docs/cubie/a7s/accessories-use/camera-4k.md
@@ -23,6 +23,12 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 
 使用 GStreamer 工具预览摄像头画面。
 
+:::tip 使用提示
+
+该教程适用于 Radxa OS 系统镜像。
+
+:::
+
 :::tip 摄像头设备路径
 
 - 请使用 `ls /dev/video*` 命令查看摄像头设备路径和更换命令中的设备路径。
@@ -36,7 +42,13 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7s/accessories-use/camera-8m-219.md
+++ b/docs/cubie/a7s/accessories-use/camera-8m-219.md
@@ -23,6 +23,12 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 
 使用 GStreamer 工具预览摄像头画面。
 
+:::tip 使用提示
+
+该教程适用于 Radxa OS 系统镜像。
+
+:::
+
 :::tip 摄像头设备路径
 
 - 请使用 `ls /dev/video*` 命令查看摄像头设备路径和更换命令中的设备路径。
@@ -36,7 +42,13 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7z/accessories/camera-13m-214.md
+++ b/docs/cubie/a7z/accessories/camera-13m-214.md
@@ -20,12 +20,22 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
-</NewCodeBlock>
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
-## 已验证环境与常用管线
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>## 已验证环境与常用管线
 
 以下说明基于 issue #1360 中确认过的 Cubie A7Z 实测结果整理，适合先做快速自检。
 
@@ -34,17 +44,13 @@ DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 !
 - 1080p 预览：使用 `/dev/video0`，分辨率 `1920x1080`，并使用 `en-largemode=0`
 - 当前软件流中，更低分辨率未在该 issue 对应环境下完成验证；如果直接切到更低分辨率，可能出现画面异常
 
-### 1080p 预览
-
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
-</NewCodeBlock>
-
-## 排障
+</NewCodeBlock>## 排障
 
 - 如果系统中没有出现 `/dev/video*` 节点，请先确认使用的是最新可用官方镜像，再重新插拔并检查 FPC 排线是否压紧、方向是否正确
 - 如果需要先确认摄像头是否已经被内核识别，可运行 `v4l2-ctl --list-devices`

--- a/docs/cubie/a7z/accessories/camera-4k.md
+++ b/docs/cubie/a7z/accessories/camera-4k.md
@@ -20,7 +20,13 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a7z/accessories/camera-8m-219.md
+++ b/docs/cubie/a7z/accessories/camera-8m-219.md
@@ -20,7 +20,13 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_install_env.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_install_env.mdx
@@ -12,6 +12,19 @@ This guide covers setting up the development environment for {props?.items ?? 'U
 
 To quickly set up a compilation and development environment for {props?.items ?? 'U-Boot, Kernel, Radxa OS'}, we need to install Visual Studio Code, the Dev Container extension, and Docker on your PC.
 
+### Enable binfmt {#binfmt}
+
+Enables running cross-architecture binaries.
+
+<NewCodeBlock tip="Linux@host$" type="host">
+
+```bash
+sudo apt-get update
+sudo apt-get install git qemu-user-static binfmt-support
+```
+
+</NewCodeBlock>
+
 ### Docker
 
 You can choose to install either Docker Engine or Docker Desktop based on your needs.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-13m-214.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_camera-13m-214.mdx
+---
+
+import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
+
+# Radxa Camera 8M 219
+
+<Camera13M214 product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a5e' />
+
+## Preview the camera
+
+Use GStreamer to preview the camera image.
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_camera-4k.mdx
+---
+
+import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
+
+# Radxa Camera 8M 219
+
+<Camera4K product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a5e' enable_camera='Enable Radxa Camera 4K' />
+
+## Preview the camera
+
+Use GStreamer to preview the camera image.
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-8m-219.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_camera-8m-219.mdx
+---
+
+import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
+
+# Radxa Camera 8M 219
+
+<Camera8M219 product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='same side' board='cubie-a5e' />
+
+## Preview the camera
+
+Use GStreamer to preview the camera image.
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=I420,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=1 ! video/x-raw,format=I420,width=3280,height=2464,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-13m-214.md
@@ -20,7 +20,19 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
@@ -20,7 +20,13 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-8m-219.md
@@ -20,7 +20,13 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7a$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-13m-214.md
@@ -23,6 +23,12 @@ This tutorial applies to the Radxa OS system image.
 
 Use GStreamer to preview the camera stream.
 
+:::tip Usage notes
+
+This tutorial applies to the Radxa OS system image.
+
+:::
+
 :::tip Camera device node
 
 - Use `ls /dev/video*` to find the camera device node, and update the `device=` argument accordingly.
@@ -36,7 +42,19 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
@@ -23,6 +23,12 @@ This tutorial applies to the Radxa OS system image.
 
 Use GStreamer to preview the camera stream.
 
+:::tip Usage notes
+
+This tutorial applies to the Radxa OS system image.
+
+:::
+
 :::tip Camera device node
 
 - Use `ls /dev/video*` to find the camera device node, and update the `device=` argument accordingly.
@@ -36,7 +42,13 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-8m-219.md
@@ -23,6 +23,12 @@ This tutorial applies to the Radxa OS system image.
 
 Use GStreamer to preview the camera stream.
 
+:::tip Usage notes
+
+This tutorial applies to the Radxa OS system image.
+
+:::
+
 :::tip Camera device node
 
 - Use `ls /dev/video*` to find the camera device node, and update the `device=` argument accordingly.
@@ -36,7 +42,13 @@ Run the following command on the board to preview the camera stream.
 <NewCodeBlock tip="radxa@cubie-a7s$" type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip="radxa@cubie-a7s$" type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
@@ -20,12 +20,22 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=24/1 ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
-</NewCodeBlock>
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
-## Verified setup and common pipelines
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=4208,height=3120,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock>## Verified setup and common pipelines
 
 The notes below summarize the Cubie A7Z results confirmed in issue #1360 and are intended as a quick validation baseline.
 
@@ -34,17 +44,13 @@ The notes below summarize the Cubie A7Z results confirmed in issue #1360 and are
 - 1080p preview: use `/dev/video0` at `1920x1080` with `en-largemode=0`
 - Lower resolutions were not fully validated in that software flow; switching directly to smaller resolutions may still produce abnormal output
 
-### 1080p preview
-
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
 DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
 ```
 
-</NewCodeBlock>
-
-## Troubleshooting
+</NewCodeBlock>## Troubleshooting
 
 - If no `/dev/video*` nodes appear, first confirm that you are using a recent official image, then reseat the FPC cable and verify its orientation and latch state
 - To quickly confirm whether the camera has been detected by the kernel, run `v4l2-ctl --list-devices`

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-4k.md
@@ -20,7 +20,13 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video1 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3840,height=2160,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-8m-219.md
@@ -20,7 +20,13 @@ Use GStreamer to preview the camera image.
 <NewCodeBlock tip='radxa@cubie-a7z$' type="device">
 
 ```bash
-DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=24/1  ! xvimagesink
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! xvimagesink
+```
+
+</NewCodeBlock><NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+DISPLAY=:0 gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=1 ! video/x-raw,format=NV12,width=3280,height=2464,framerate=30/1 ! xvimagesink
 ```
 
 </NewCodeBlock>


### PR DESCRIPTION
## Summary

Add binfmt section (### 启用 binfmt / ### Enable binfmt) before the Docker section in environment setup for U-Boot/Kernel/Radxa OS build environment documentation.

## Changes

- **docs/common/radxa-os/build-system/_install_env.mdx**: Added  section with description and install commands
- **i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_install_env.mdx**: Added  section (English equivalent)

## Content

Enables running cross-architecture binaries via qemu-user-static and binfmt-support.

