### PR TITLE
docs: dragon/q6a: update Camera8M219 pins/pitch/orientation params

### DIFF
--- a/docs/dragon/q6a/accessories/camera-8m-219.md
+++ b/docs/dragon/q6a/accessories/camera-8m-219.md
@@ -6,7 +6,7 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 
 # 瑞莎 8M 219 摄像头
 
-<Camera8M219 product='瑞莎 Dragon Q6A' interface='15-Pin 1.0 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='同面' board='dragon-q6a' />
+<Camera8M219 product='瑞莎 Dragon Q6A' interface='15-Pin 1.0 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='15-Pin' pitch='1.0mm 间距' orientation='异面' board='dragon-q6a' />
 
 ## 预览摄像头
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/accessories/camera-8m-219.md
@@ -6,7 +6,7 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 
 # Radxa Camera 8M 219
 
-<Camera8M219 product='Radxa Dragon Q6A' interface='15-pin 1.0 mm pitch SMD Horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='same side' board='dragon-q6a' />
+<Camera8M219 product='Radxa Dragon Q6A' interface='15-pin 1.0 mm pitch SMD Horizontal FPC connector' connect='Flip type, bottom contact' pins='15-Pin' pitch='1.0mm pitch' orientation='opposite sides' board='dragon-q6a' />
 
 ## Preview the camera
 


### PR DESCRIPTION
Change FPC cable spec from 31-Pin/0.3mm/same-side to 15-Pin/1.0mm/opposite-sides to match actual camera-8m-219 board hardware interface.

## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
