### PR TITLE
docs(rock3/rock5b): update ROCK 3A image and ROCK 5B LPDDR4 spec

### DIFF
--- a/docs/rock3/images.md
+++ b/docs/rock3/images.md
@@ -25,7 +25,7 @@ sidebar_position: 7
 
 以下系统已由瑞莎官方测试验证：
 
-ROCK 3A: [Build 25](https://github.com/radxa-build/rock-3a/releases/download/b25/rock-3a_debian_bullseye_xfce_b25.img.xz)
+ROCK 3A: [Bookworm KDE R2](https://github.com/radxa-build/rock-3a/releases/download/rsdk-r2/rock-3a_bookworm_kde_r2.output_512.img.xz)
 
 更多镜像请查看： [ROCK 3A radxa-build](https://github.com/radxa-build/rock-3a/releases/latest)
 

--- a/docs/rock5/rock5b/getting-started/introduction.md
+++ b/docs/rock5/rock5b/getting-started/introduction.md
@@ -80,7 +80,7 @@ ROCK 5B 提供了完整的硬件设计原理图和软件源代码，这一特性
     </tr>
     <tr>
         <td align="center">内存</td>
-        <td align="center">4/8/16 64 位 LPDDR4</td>
+        <td align="center">4/8/16 64 位 LPDDR4X</td>
         <td align="center">4/8/16/32 64 位 LPDDR5</td>
     </tr>
     <tr>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/images.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/images.md
@@ -27,7 +27,7 @@ Tip: We will publish relevant information about each version release in [Raxa Fo
 
 The following systems have been officially tested and verified by Radxa:
 
-ROCK 3A: [Build 25](https://github.com/radxa-build/rock-3a/releases/download/b25/rock-3a_debian_bullseye_xfce_b25.img.xz)
+ROCK 3A: [Bookworm KDE R2](https://github.com/radxa-build/rock-3a/releases/download/rsdk-r2/rock-3a_bookworm_kde_r2.output_512.img.xz)
 
 For more images, please check: [ROCK 3A radxa-build](https://github.com/radxa-build/rock-3a/releases/latest)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/getting-started/introduction.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/getting-started/introduction.md
@@ -80,7 +80,7 @@ ROCK 5B provides complete hardware design schematics and software source code, a
     </tr>
     <tr>
         <td align="center">RAM</td>
-        <td align="center">4/8/16 64 bit LPDDR4</td>
+        <td align="center">4/8/16 64 bit LPDDR4X</td>
         <td align="center">4/8/16/32 64 bit LPDDR5</td>
     </tr>
     <tr>


### PR DESCRIPTION
## Changes

### 1. ROCK 3A Image Update
Update ROCK 3A official image download link from Debian 11 Bullseye (Build 25) to Debian 12 Bookworm KDE R2.

Files:
- docs/rock3/images.md (Chinese)
- i18n/en/docusaurus-plugin-content-docs/current/rock3/images.md (English)

Link change:
- Replace: https://github.com/radxa-build/rock-3a/releases/download/b25/rock-3a_debian_bullseye_xfce_b25.img.xz
- With: https://github.com/radxa-build/rock-3a/releases/download/rsdk-r2/rock-3a_bookworm_kde_r2.output_512.img.xz

### 2. ROCK 5B Spec Correction
Correct LPDDR4 to LPDDR4X in ROCK 5B introduction spec table.

Files:
- docs/rock5/rock5b/getting-started/introduction.md (Chinese)
- i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/getting-started/introduction.md (English)

## Testing
- Verified the new release link is accessible on GitHub releases page