### PR TITLE
docs(cm3): remove U31 description from DIP_2.54MM_3PIN_180

### DIFF
--- a/docs/som/cm/cm3/hardware-design/hardware-interface.md
+++ b/docs/som/cm/cm3/hardware-design/hardware-interface.md
@@ -37,13 +37,6 @@ description: "详细介绍 CM3/CM3 IO 硬件信息"
 
 ### DIP_2.54MM_3PIN_180
 
-- U31
-
-  | Pin |  Name   | Pin | Name |
-  | :-: | :-----: | :-: | :--: |
-  |  1  | WL_nDis |  2  | GND  |
-  |  3  | BT_nDis |     |      |
-
 - U32
 
   | Pin |   Name    | Pin | Name |

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/hardware-design/hardware-interface.md
@@ -37,13 +37,6 @@ The following outlines the comprehensive interface details for the Radxa CM3 IO 
 
 ### DIP_2.54MM_3PIN_180
 
-- U31
-
-  | Pin |  Name   | Pin | Name |
-  | :-: | :-----: | :-: | :--: |
-  |  1  | WL_nDis |  2  | GND  |
-  |  3  | BT_nDis |     |      |
-
 - U32
 
   | Pin |   Name    | Pin | Name |


### PR DESCRIPTION
## Description
Remove the U31 (WL_nDis/BT_nDis) section from the CM3 IO hardware interface documentation as requested. The U32 section is kept.

## Changes
- docs/som/cm/cm3/hardware-design/hardware-interface.md (Chinese)
- i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/hardware-design/hardware-interface.md (English)