### PR TITLE
docs: update rsetup Common Tasks TUI screenshot — Baota only

### DIFF
--- a/docs/common/config/_rsetup.mdx
+++ b/docs/common/config/_rsetup.mdx
@@ -717,8 +717,6 @@ radxa-ncm@*.*   # 配置为 NCM 设备（推荐）
 ┌──────────────────────────────────┤ RSETUP ├──────────────────────────────────┐
 │ Please select all tasks you want to perform:                                │
 │                                                                              │
-│    [ ] Install Docker                                                        │
-│    [ ] Configure SSH                                                         │
 │    [ ] Install Baota Panel                                                   │
 │                                                                              │
 │                      <Ok>                      <Cancel>                      │
@@ -728,14 +726,6 @@ radxa-ncm@*.*   # 配置为 NCM 设备（推荐）
 ### 可用任务（正常模式）
 
 在正常模式下，Common Tasks 以多选列表形式显示，可以一次选择多个任务批量执行。
-
-#### Install Docker
-
-自动安装 Docker 容器引擎及相关工具。
-
-#### Configure SSH
-
-配置 SSH 服务器设置。
 
 #### Install Baota Panel
 
@@ -749,8 +739,7 @@ radxa-ncm@*.*   # 配置为 NCM 设备（推荐）
 ┌──────────────────────────────────┤ RSETUP ├──────────────────────────────────┐
 │ Please select an option below:                                              │
 │                                                                              │
-│                         Docker                                               │
-│                         SSH                                                  │
+│                         Baota Panel                                          │
 │                                                                              │
 │                      <Ok>                      <Cancel>                      │
 └──────────────────────────────────────────────────────────────────────────────┘

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/config/_rsetup.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/config/_rsetup.mdx
@@ -495,8 +495,6 @@ Quick shortcuts to perform common setup tasks.
 ┌──────────────────────────────────┤ RSETUP ├──────────────────────────────────┐
 │ Please select all tasks you want to perform:                                │
 │                                                                              │
-│    [ ] Install Docker                                                        │
-│    [ ] Configure SSH                                                         │
 │    [ ] Install Baota Panel                                                   │
 │                                                                              │
 │                      <Ok>                      <Cancel>                      │
@@ -506,14 +504,6 @@ Quick shortcuts to perform common setup tasks.
 ### Tasks (normal mode)
 
 In normal mode, Common Tasks is a multi-select list.
-
-#### Install Docker
-
-Installs Docker engine and related tools.
-
-#### Configure SSH
-
-Configures SSH server settings.
 
 #### Install Baota Panel
 
@@ -527,8 +517,7 @@ In DEBUG mode, Common Tasks may show a dedicated menu:
 ┌──────────────────────────────────┤ RSETUP ├──────────────────────────────────┐
 │ Please select an option below:                                              │
 │                                                                              │
-│                         Docker                                               │
-│                         SSH                                                  │
+│                         Baota Panel                                          │
 │                                                                              │
 │                      <Ok>                      <Cancel>                      │
 └──────────────────────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
## What

Update the Common Tasks section in `common/config/_rsetup.mdx` (both zh-CN source and en i18n) to match the actual current rsetup TUI output.

## Why

Reported in radxa-docs/docs#1766: the docs screenshot still shows three options (Install Docker, Configure SSH, Install Baota Panel), but the actual rsetup TUI now only shows Install Baota Panel. This misleads users who follow the docs and expect to see Docker/SSH options.

## Changes

- Removed `Install Docker` and `Configure SSH` from the Common Tasks TUI screenshot
- Removed the corresponding subsection descriptions (Install Docker / Configure SSH)
- Updated DEBUG-mode screenshot to show only Baota Panel

Both zh-CN and en versions updated in the same commit.