### PR TITLE
docs(cm3i): update Debian b4 image link to Bookworm KDE r2

### DIFF
--- a/docs/som/cm/cm3i/download.md
+++ b/docs/som/cm/cm3i/download.md
@@ -16,7 +16,7 @@ sidebar_position: 99
 
 ### 系统镜像
 
-- [Radxa CM3I IO Board Debian b4](https://github.com/radxa-build/radxa-cm3i-io/releases/download/b4/radxa-cm3i-io_debian_bullseye_xfce_b4.img.xz)
+- [Radxa CM3I IO Board Bookworm KDE](https://github.com/radxa-build/radxa-cm3i-io/releases/download/rsdk-r2/radxa-cm3i-io_bookworm_kde_r2.output_512.img.xz)
 
 - [Android11 Image](https://github.com/radxa/manifests/releases/download/android11-radxa-20240724/Radxa_CM3I_Android11_r12-20240724-gpt.zip)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3i/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3i/download.md
@@ -16,7 +16,7 @@ sidebar_position: 99
 
 ### System Images
 
-- [Radxa CM3I IO Board Debian b4](https://github.com/radxa-build/radxa-cm3i-io/releases/download/b4/radxa-cm3i-io_debian_bullseye_xfce_b4.img.xz)
+- [Radxa CM3I IO Board Bookworm KDE](https://github.com/radxa-build/radxa-cm3i-io/releases/download/rsdk-r2/radxa-cm3i-io_bookworm_kde_r2.output_512.img.xz)
 
 - [Android11 Image](https://github.com/radxa/manifests/releases/download/android11-radxa-20240724/Radxa_CM3I_Android11_r12-20240724-gpt.zip)
 


### PR DESCRIPTION
Replace the deprecated Debian Bullseye XFCE b4 image link with the new Bookworm KDE r2 image for Radxa CM3I IO Board.

## Changes
- Update download link in `docs/som/cm/cm3i/download.md`
- Update English translation in `i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3i/download.md`

## Link change
- Old: `releases/download/b4/radxa-cm3i-io_debian_bullseye_xfce_b4.img.xz`
- New: `releases/download/rsdk-r2/radxa-cm3i-io_bookworm_kde_r2.output_512.img.xz`