### PR TITLE
docs(cm3i): align NVME install guide release_num with download page (b4 → rsdk-r2)

### DIFF
--- a/docs/som/cm/cm3i/getting-started/install-os/nvme.md
+++ b/docs/som/cm/cm3i/getting-started/install-os/nvme.md
@@ -12,7 +12,7 @@ imports_resolve_to:
 
 import NVME from '../../../../../common/dev/\_nvme.mdx';
 
-<NVME model="radxa-cm3i-io" release_num="b4" desktop="xfce" rsetup_path="../../radxa-os/rsetup" etcher_path="./boot-from-sd-card" download_path="../../download" />
+<NVME model="radxa-cm3i-io" release_num="rsdk-r2" desktop="xfce" rsetup_path="../../radxa-os/rsetup" etcher_path="./boot-from-sd-card" download_path="../../download" />
 
 :::tip
 系统从上电到开机启动，整个过程持续约53秒，然后进入系统桌面。

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3i/getting-started/install-os/nvme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3i/getting-started/install-os/nvme.md
@@ -12,7 +12,7 @@ imports_resolve_to:
 
 import NVME from '../../../../../common/dev/\_nvme.mdx';
 
-<NVME model="radxa-cm3i-io" release_num="b4" desktop="xfce" rsetup_path="../../radxa-os/rsetup" etcher_path="./boot-from-sd-card" download_path="../../download" />
+<NVME model="radxa-cm3i-io" release_num="rsdk-r2" desktop="xfce" rsetup_path="../../radxa-os/rsetup" etcher_path="./boot-from-sd-card" download_path="../../download" />
 
 :::tip
 The entire process of powering up the system and booting it up lasts about 53 seconds before it enters the system desktop.


### PR DESCRIPTION
## Summary

PR #1770 updated the CM3I IO Board download page to point to the new `rsdk-r2` (Bookworm KDE R2) image, replacing the deprecated `b4` (Bullseye XFCE) image.

However, the NVME installation guide (both Chinese and English versions) was not updated and still uses `release_num="b4"", which would direct users to the deprecated image when following the NVME install steps.

This PR aligns the NVME installation guide with the updated download page.

## Changes

- `docs/som/cm/cm3i/getting-started/install-os/nvme.md`: `release_num="b4"` → `release_num="rsdk-r2"` (Chinese)
- `i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3i/getting-started/install-os/nvme.md`: `release_num="b4"` → `release_num="rsdk-r2"` (English)

## Source

Triggered by internal Feishu discussion (售后技术支持群, 2026-05-22) where 吴闽龙 reported the CM3i download page still showed the old b4 link. PR #1770 addressed the download page, but the NVME guide inconsistency was missed.

## Testing

- [x] Both zh and en files updated together (bilingual sync)
- [x] Only the 2 NVME guide files changed (docs-only, minimal scope)
- [x] No functional changes beyond the release_num parameter