### PR TITLE
docs(cubie/a5e): add audio interface clarification note

### DIFF
--- a/docs/cubie/a5e/system-config/audio-usage.md
+++ b/docs/cubie/a5e/system-config/audio-usage.md
@@ -12,3 +12,9 @@ import AUDIO from '../../../common/radxa-os/system-config/\_audio_usage.mdx';
 # 音频管理
 
 <AUDIO debian_version="debian11" board="cubie-a5e" />
+
+:::note Cubie A5E 音频接口说明
+Cubie A5E 主板**未配备 3.5mm 耳机接口**。系统默认音频输出优先级为「蓝牙音频 > 耳机 > HDMI 音频」，其中「耳机」选项将在连接 USB 耳机或通过 40 Pin GPIO 接口连接外部 USB 声卡时生效。
+
+如需通过 40 Pin GPIO 接口使用数字音频，可使用 I2S2 接口（需外接 DAC 芯片转换为模拟音频）。
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/system-config/audio-usage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/system-config/audio-usage.md
@@ -12,3 +12,9 @@ import AUDIO from '../../../common/radxa-os/system-config/\_audio_usage.mdx';
 # Audio Management
 
 <AUDIO debian_version="debian11" board="cubie-a5e" />
+
+:::note Cubie A5E Audio Interface Note
+The Cubie A5E board **does not have a 3.5mm headphone jack**. The default audio output priority listed as "Bluetooth Audio > Headphones > HDMI Audio" means the "Headphones" entry will appear when a USB headphone or external USB audio card connected via the 40 Pin GPIO is detected.
+
+To use digital audio via the 40 Pin GPIO interface, you can use the I2S2 interface (requires an external DAC chip to convert to analog audio).
+:::


### PR DESCRIPTION
## 来源

GitHub Discussion #1776 - 用户在音频使用页面提问：Cubie A5E 没有标注耳机接口，询问是否可以通过 40 Pin GPIO 接模拟音频。

## 改动说明

共享音频模板列出「蓝牙音频 > 耳机 > HDMI 音频」作为默认优先级，但 Cubie A5E 主板**没有物理 3.5mm 耳机接口**。此次添加说明注释：

- 板载无耳机插孔
- alsamixer 中「耳机」选项仅在检测到 USB 音频设备时出现
- 40 Pin GPIO 提供 I2S2 数字音频接口（需外接 DAC 芯片转模拟）

中英文版本同步更新。

## 关联 Discussion

https://github.com/radxa-docs/docs/discussions/1776