### PR TITLE
docs(cm3j): add Debian 12 Bookworm KDE R3 system image

### DIFF
--- a/docs/som/cm/cm3j/download.md
+++ b/docs/som/cm/cm3j/download.md
@@ -20,6 +20,8 @@ sidebar_position: 99
 
 Debian OS:
 
+- 系统镜像： [Debian 12 (Bookworm) KDE](https://github.com/radxa-build/radxa-cm3j-rpi-cm4-io/releases/download/rsdk-r3/radxa-cm3j-rpi-cm4-io_bookworm_kde_r3.output_512.img.xz)
+
 - 系统镜像： [Debian b2](https://github.com/radxa-build/radxa-cm3j-rpi-cm4-io/releases/download/rsdk-b2/radxa-cm3j-rpi-cm4-io_bullseye_xfce_b2.output.img.xz)
 
 ## 硬件设计

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3j/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3j/download.md
@@ -20,6 +20,8 @@ sidebar_position: 99
 
 Debian OS:
 
+- System Image: [Debian 12 (Bookworm) KDE](https://github.com/radxa-build/radxa-cm3j-rpi-cm4-io/releases/download/rsdk-r3/radxa-cm3j-rpi-cm4-io_bookworm_kde_r3.output_512.img.xz)
+
 - System Image: [Debian b2](https://github.com/radxa-build/radxa-cm3j-rpi-cm4-io/releases/download/rsdk-b2/radxa-cm3j-rpi-cm4-io_bullseye_xfce_b2.output.img.xz)
 
 ## Hardware Design


### PR DESCRIPTION
## Description

Add the new Radxa CM3J Debian 12 (Bookworm) KDE R3 system image to the download page, while preserving the older Debian b2 (Bullseye XFCE) image.

## Image Link

- https://github.com/radxa-build/radxa-cm3j-rpi-cm4-io/releases/download/rsdk-r3/radxa-cm3j-rpi-cm4-io_bookworm_kde_r3.output_512.img.xz

## Changes

- Add Debian 12 (Bookworm) KDE image link to Chinese download page (`docs/som/cm/cm3j/download.md`)
- Add corresponding English translation in i18n (`docs/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3j/download.md`)
