### PR TITLE
docs(penta-sata-hat): add Debian trixie fresh install note for top board package

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -39,12 +39,12 @@ sudo apt install -y ./rockpi-penta-0.2.2.deb
 :::note
 **最新 Raspberry Pi OS (Debian trixie) 用户注意**
 
-如果您在最新的 Raspberry Pi OS (Debian trixie) 上遇到以下问题：
+`rockpi-penta` 软件包在全新安装的 Raspberry Pi OS (Debian trixie / Debian 13) 上可能无法正常安装；从 Debian 12 升级到 trixie 的系统通常可以正常安装，但 trixie 全新安装可能会失败。在 trixie 上安装或运行后，您还可能遇到以下问题：
 - OLED 显示屏只显示静态消息 "RADXA SATA HAT Loading..."
 - 风扇固定在 100% 功率
 - 服务启动报错 `FileNotFoundError: No such file or directory`
 
-可能需要应用额外的修复。请参考 [GitHub issue #1540](https://github.com/radxa-docs/docs/issues/1540) 中用户报告的解决方案：https://github.com/HabiRabbu/rockpi-penta-pi5-fix
+可能需要应用额外的修复。请参考 [GitHub issue #1792](https://github.com/radxa-docs/docs/issues/1792) 和 [#1540](https://github.com/radxa-docs/docs/issues/1540) 中用户报告的解决方案：https://github.com/HabiRabbu/rockpi-penta-pi5-fix
 :::
 
 安装软件包后，如果需要修改配置，可以编辑配置文件 `/etc/rockpi-penta.conf`，下面是配置文件的默认值。

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -37,14 +37,14 @@ sudo apt install -y ./rockpi-penta-0.2.2.deb
 ### Software configuration
 
 :::note
-**Note for latest Raspberry Pi OS (Debian trixie) users**
+**Notes for latest Raspberry Pi OS (Debian trixie) users**
 
-If you encounter the following issues on the latest Raspberry Pi OS (Debian trixie):
+The `rockpi-penta` package may not install cleanly on a fresh Raspberry Pi OS (Debian trixie / Debian 13) system. Systems that upgrade from Debian 12 to trixie usually install the package without issues, but a fresh trixie install may fail. After installing or running on trixie, you may also encounter the following issues:
 - OLED display only shows static message "RADXA SATA HAT Loading..."
 - Fan stuck at 100% power
 - Service startup error `FileNotFoundError: No such file or directory`
 
-Additional fixes may be required. Please refer to the solution reported by users in [GitHub issue #1540](https://github.com/radxa-docs/docs/issues/1540): https://github.com/HabiRabbu/rockpi-penta-pi5-fix
+Additional fixes may be required. Please refer to the solutions reported by users in [GitHub issue #1792](https://github.com/radxa-docs/docs/issues/1792) and [#1540](https://github.com/radxa-docs/docs/issues/1540): https://github.com/HabiRabbu/rockpi-penta-pi5-fix
 :::
 
 After installing the package, if you need to modify the configuration, you can edit the configuration file `/etc/rockpi-penta.conf`, the following is the default value of the configuration file.


### PR DESCRIPTION
## Summary

- Extend the existing Raspberry Pi OS (Debian trixie) note on the Penta SATA HAT top board page to also call out the fresh-install failure of `rockpi-penta` on a clean Trixie / Debian 13 system.
- Reference both #1792 (fresh install) and #1540 (post-install runtime) for known workarounds.

## Context / Source

This docs-only change is triggered by GitHub issue #1792, opened on 2026-06-02 by a user on the sata-hat-top-board docs page.

User report (verbatim):

> This package does not install natively on Trixie/debian 13. It is incompatible. The documentation works when migrating from 12 but a fresh install of the top board package fails on 13.

The existing docs note (added for the post-install symptoms covered by #1540) was positioned **after** the `apt install` command, which implicitly assumed the install step succeeded. Issue #1792 makes it clear the install step itself can fail on a clean Trixie system, so the note now:

1. Mentions the fresh-install failure on a clean Raspberry Pi OS (Debian trixie / Debian 13) base.
2. Distinguishes the fresh-install case from the Debian 12 → trixie upgrade case (where the package usually installs fine).
3. Keeps the post-install symptom list (OLED static / fan 100% / `FileNotFoundError`) for users who did manage to install.
4. References both #1792 and #1540 alongside the community workaround repo.

## Change

- `docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md` (中文)
- `i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md` (English)
- 2 files changed, 5 insertions(+), 5 deletions(-)
- Single scope (`docs/accessories/storage`).
- Bilingual sync verified (CN + EN updated together).

## What this is NOT

- Not a code change. The `rockpi-penta` package itself is a third-party / community-maintained tool; the docs only describe the known install/runtime behavior.
- Not a scope expansion. No new pages, no other products touched.

## Validation

- `python3 scripts/github_pr_guard.py check --repo-path ~/radxa-docs/docs --fetch` → `ok: true` (1 commit, 2 files, bilingual OK, single scope)
- `python3 scripts/github_issue_guard.py check --repo radxa-docs/docs --issue 1792` → `skip: false` (no prior watcher / PR)

Fixes #1792
