### PR TITLE
docs(dragon/q8b): add Debian to supported operating systems

### DIFF
--- a/docs/dragon/q8b/README.md
+++ b/docs/dragon/q8b/README.md
@@ -40,7 +40,7 @@ sidebar_position: 2
 | 音频           | 1x 3.5mm 耳机接口<br/>1x 麦克风接口                                                                                                                                                                                                             |
 | 供电           | 1x USB Type-C 供电口<br/>1x 电源输入排针<br/>- 12-20V 电源输入<br/>- 支持外接电源按键                                                                                                                                                           |
 | 其他           | 1x 电源按键<br/>1x EDL 按键<br/>1x RTC 接口<br/>1x 风扇接口<br/>1x FPC 接口 (PCIe 3.0 x1)<br/>1x 40-Pin GPIO 排针<br/>- 支持 UART / I2C / SPI / GPIO                                                                                            |
-| 操作系统       | Radxa OS<br/>Windows<br/>Ubuntu<br/>Armbian<br/>Arch Linux<br/>Nix OS                                                                                                                                                                           |
+| 操作系统       | Radxa OS<br/>Windows<br/>Ubuntu<br/>Armbian<br/>Arch Linux<br/>Nix OS<br/>Debian<br/>······                                                                                                                                                                  |
 | 尺寸           | 100 mm x 75 mm                                                                                                                                                                                                                                  |
 
 ## 接口说明
@@ -87,3 +87,5 @@ sidebar_position: 2
 - Armbian
 - Arch Linux
 - Nix OS
+- Debian
+- ······

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/README.md
@@ -40,7 +40,7 @@ Designed for edge computing, intelligent terminals, and similar applications, Dr
 | Audio                    | 1x 3.5 mm headphone jack<br/>1x microphone connector                                                                                                                                                                                                                            |
 | Power                    | 1x USB Type-C power port<br/>1x power input header<br/>- 12-20V power input<br/>- Supports external power button                                                                                                                                                                |
 | Other                    | 1x power button<br/>1x EDL button<br/>1x RTC connector<br/>1x fan connector<br/>1x FPC connector (PCIe 3.0 x1)<br/>1x 40-pin GPIO header<br/>- Supports UART / I2C / SPI / GPIO                                                                                                 |
-| Operating System         | Radxa OS<br/>Windows<br/>Ubuntu<br/>Armbian<br/>Arch Linux<br/>Nix OS                                                                                                                                                                                                           |
+| Operating System         | Radxa OS<br/>Windows<br/>Ubuntu<br/>Armbian<br/>Arch Linux<br/>Nix OS<br/>Debian<br/>······                                                                                                                                                                                     |
 | Dimensions               | 100 mm x 75 mm                                                                                                                                                                                                                                                                  |
 
 ## Interface Description
@@ -87,3 +87,5 @@ Based on the Qualcomm Snapdragon® 8cx Gen 3 SoC, Dragon Q8B supports multiple o
 - Armbian
 - Arch Linux
 - Nix OS
+- Debian
+- ······


### PR DESCRIPTION
## Summary

- 在 Dragon Q8B README 的"操作系统"行和"系统平台"列表里加入 Debian,与已有 Radxa OS / Windows / Ubuntu / Armbian / Arch Linux / Nix OS 并列
- 中英文同步修改(`docs/dragon/q8b/README.md` + `i18n/en/.../dragon/q8b/README.md`)

## 背景

Dragon Q8B 的官方镜像仓库 [radxa-dragon-midstream](https://github.com/radxa-build/radxa-dragon-midstream/releases) 已经发布 `radxa-dragon-midstream_trixie_gnome_t2` (Debian 13 Trixie + GNOME) 镜像,因此 q8b 实际已经具备 Debian 13 桌面系统能力。本次仅同步产品 README 中"操作系统"字段,把 Debian 列入官方支持列表。

## 改动范围

- 仅 docs-only,只动两处:
  - `docs/dragon/q8b/README.md`: 规格表 操作系统行 + 系统平台列表
  - `i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/README.md`: 同样两处英文版

## 证据

- 镜像发布: https://github.com/radxa-build/radxa-dragon-midstream/releases (`radxa-dragon-midstream_trixie_gnome_t2`)
- 已在 download.md 里指向该仓库: https://docs.radxa.com/dragon/q8b

## 检查

- 中英文同步: 改了两个文件
- 本地 lint / translation guard 已通过
