### PR TITLE
docs(q6a/rsdk-image): drop redundant in-container git clone

### DIFF
--- a/docs/common/radxa-os/build-system/_radxa_os.mdx
+++ b/docs/common/radxa-os/build-system/_radxa_os.mdx
@@ -123,17 +123,7 @@ Radxa OS 的开发环境提供两种搭建方式：**方式一**基于 Dev Conta
   - 如果容器已经存在，会直接进入容器；如果需要重建容器，请先执行 `docker rm -f rsdk` 删除旧容器。
   - 也可以传入需要执行的命令：`rsdk-image --name rsdk -- <command>`。
 
-  进入容器后，使用方式一中克隆的 rsdk 源码，或在容器内重新克隆：
-
-  <NewCodeBlock tip="Linux@host$" type="host">
-
-  ```bash
-  git clone --recurse-submodules <git_repo_url>
-  ```
-
-  </NewCodeBlock>
-
-  其中 `<git_repo_url>` 需要替换成：{props.git_url}
+  进入容器后无需再克隆仓库源码，容器内已自带 `rsdk` 工具与 SDK 工作目录，可以直接使用 `rsdk` 命令编译系统镜像。
 
 </TabItem>
 </Tabs>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_radxa_os.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_radxa_os.mdx
@@ -122,17 +122,7 @@ You can follow the tutorial below to install Docker / Visual Studio Code / Dev C
   - If the container already exists, you will enter it directly. To rebuild the container, first run `docker rm -f rsdk` to remove the existing one.
   - You can also pass a command to execute inside the container: `rsdk-image --name rsdk -- <command>`.
 
-  After entering the container, use the rsdk source cloned in Method 1, or clone it again inside the container:
-
-  <NewCodeBlock tip="Linux@host$" type="host">
-
-  ```bash
-  git clone --recurse-submodules <git_repo_url>
-  ```
-
-  </NewCodeBlock>
-
-  Replace `<git_repo_url>` with: {props.git_url}
+  Once inside the container there is no need to clone the repository again. The container already ships with the `rsdk` tool and the SDK working directory, so you can run `rsdk` directly to build the system image.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

Drop the redundant `git clone --recurse-submodules` block from the
**Method 2 (rsdk-image container)** section of the Q6A low-level dev
build system tutorial.

Reason: the `rsdk-image` prebuilt container already ships with the
`rsdk` tool and the SDK working directory, so once a user enters the
container they do not need to clone the repository again. The old
"After entering the container, use the rsdk source cloned in Method 1,
or clone it again inside the container" block is therefore misleading
and is removed.

Replace it with a one-line note explaining that the container already
provides `rsdk` and the SDK working directory.

## Affected pages

- https://docs.radxa.com/dragon/q6a/low-level-dev/build-system/radxa-os?setup-method=rsdk-image
- English mirror: .../dragon/q6a/low-level-dev/build-system/radxa-os?setup-method=rsdk-image (i18n)

## Source / Trigger

Follow-up to PR #1795 (docs(dragon/q6a): add rsdk-image container as
second environment setup method). The previously added Method 2 section
inadvertently asked users to re-clone the rsdk source after entering
the container, which is not necessary because the container already
ships with `rsdk` and the SDK working directory.

## Files changed

- `docs/common/radxa-os/build-system/_radxa_os.mdx` (zh)
- `i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_radxa_os.mdx` (en)

Both languages updated in lock-step; `agent-doc-translation-guard` and
`agent-doc-lint` pass on the changed files.

## Diff stat

```
 2 files changed, 2 insertions(+), 22 deletions(-)
```

The change is docs-only, scoped to a single tutorial, and contains no
product / hardware claims that need R&D confirmation.
