### PR TITLE
docs(cm3): update image links to Bookworm KDE r2 (Debian 12 R2)

### DIFF
--- a/docs/som/cm/cm3/download.md
+++ b/docs/som/cm/cm3/download.md
@@ -18,9 +18,9 @@ sidebar_position: 99
 
 Debian:
 
-- Radxa CM3 IO Board 系统镜像： [Radxa CM3 IO Debian b27](https://github.com/radxa-build/radxa-cm3-io/releases/download/b27/radxa-cm3-io_debian_bullseye_kde_b27.img.xz)
+- Radxa CM3 IO Board 系统镜像： [Radxa CM3 IO Debian 12 R2 (Bookworm KDE)](https://github.com/radxa-build/radxa-cm3-io/releases/download/rsdk-r2/radxa-cm3-io_bookworm_kde_r2.output_512.img.xz)
 
-- Radxa CM3 + RPI CM4 IO Board 系统镜像： [Radxa CM3 With Raspberry CM4 IO Debian b15](https://github.com/radxa-build/radxa-cm3-rpi-cm4-io/releases/download/b15/radxa-cm3-rpi-cm4-io_debian_bullseye_kde_b15.img.xz)
+- Radxa CM3 + RPI CM4 IO Board 系统镜像： [Radxa CM3 With Raspberry CM4 IO Debian 12 R2 (Bookworm KDE)](https://github.com/radxa-build/radxa-cm3-rpi-cm4-io/releases/download/rsdk-r2/radxa-cm3-rpi-cm4-io_bookworm_kde_r2.output_512.img.xz)
 
 Android:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/download.md
@@ -18,9 +18,9 @@ sidebar_position: 99
 
 Debian:
 
-- Radxa CM3 IO Board System Image: [Radxa CM3 IO Debian b27](https://github.com/radxa-build/radxa-cm3-io/releases/download/b27/radxa-cm3-io_debian_bullseye_kde_b27.img.xz)
+- Radxa CM3 IO Board System Image: [Radxa CM3 IO Debian 12 R2 (Bookworm KDE)](https://github.com/radxa-build/radxa-cm3-io/releases/download/rsdk-r2/radxa-cm3-io_bookworm_kde_r2.output_512.img.xz)
 
-- Radxa CM3 + RPI CM4 IO Board System Image: [Radxa CM3 With Raspberry CM4 IO Debian b15](https://github.com/radxa-build/radxa-cm3-rpi-cm4-io/releases/download/b15/radxa-cm3-rpi-cm4-io_debian_bullseye_kde_b15.img.xz)
+- Radxa CM3 + RPI CM4 IO Board System Image: [Radxa CM3 With Raspberry CM4 IO Debian 12 R2 (Bookworm KDE)](https://github.com/radxa-build/radxa-cm3-rpi-cm4-io/releases/download/rsdk-r2/radxa-cm3-rpi-cm4-io_bookworm_kde_r2.output_512.img.xz)
 
 Android:
 


### PR DESCRIPTION
## Summary

Replace the deprecated Debian Bullseye image links on the Radxa CM3 download page with the new Debian 12 (Bookworm) KDE r2 system images for:

- **Radxa CM3 IO Board** (formerly b27 Debian Bullseye KDE)
- **Radxa CM3 + RPI CM4 IO Board** (formerly b15 Debian Bullseye KDE)

Image label format updated to `Debian 12 R2 (Bookworm KDE)` to match the existing cm3j/rock3a convention for Bookworm KDE R2 releases.

## Link Changes

| Board | Old | New |
| :--- | :--- | :--- |
| CM3 IO | `b27/radxa-cm3-io_debian_bullseye_kde_b27.img.xz` | `rsdk-r2/radxa-cm3-io_bookworm_kde_r2.output_512.img.xz` |
| CM3 + RPI CM4 IO | `b15/radxa-cm3-rpi-cm4-io_debian_bullseye_kde_b15.img.xz` | `rsdk-r2/radxa-cm3-rpi-cm4-io_bookworm_kde_r2.output_512.img.xz` |

Both releases are confirmed available on the upstream `radxa-build/radxa-cm3-io` and `radxa-build/radxa-cm3-rpi-cm4-io` repositories as the current official Bookworm KDE R2 release (2026-06-03).

## Changelog

- [x] Update Chinese download page (`docs/som/cm/cm3/download.md`) - replace b27/b15 with rsdk-r2
- [x] Update English translation (`i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/download.md`) - replace b27/b15 with rsdk-r2
- [x] Rename image label to `Debian 12 R2 (Bookworm KDE)` format

## Note

This PR supersedes #1800 which was created from the wrong working directory (docs-template) and had incorrect file paths with an extra `docs/` prefix.
