### PR TITLE
docs(e/e20c,e/e52c): point factory-installed system callout to download page

### DIFF
--- a/docs/e/e20c/getting-started/quick-start.md
+++ b/docs/e/e20c/getting-started/quick-start.md
@@ -24,7 +24,7 @@ import { Section, Image } from "@site/src/utils/docs";
 
 <TabItem value="withemmc" label="带板载EMMC" default>
 
-出厂自带 [istoreos](../istoreos) 系统，上电自启动，不需要烧录。
+出厂自带 [iStoreOS](../download) 系统，上电自启动，不需要烧录。
 
 </TabItem>
 

--- a/docs/e/e52c/getting-started/quick-start.md
+++ b/docs/e/e52c/getting-started/quick-start.md
@@ -26,7 +26,7 @@ import { Section, Image } from "@site/src/utils/docs";
 
 <TabItem value="withemmc" label="带板载EMMC" default>
 
-出厂自带 [iStoreOS](../istoreos) 系统，上电自启动，不需要烧录。
+出厂自带 [iStoreOS](../download) 系统，上电自启动，不需要烧录。
 
 </TabItem>
 


### PR DESCRIPTION
## Summary

Replace the standalone `../istoreos` subpage link in the factory-installed
system callout of the E20C and E52C quick-start pages with a link to the
resource download page (`../download`).

The iStoreOS subpage is a short blurb that mostly duplicates the
introduction already present on the download page. The download page is
the actionable page that lists every supported system image (iStoreOS,
Radxa OS, OpenWrt, etc.) and is what users actually need when they want
to switch away from the factory-installed system or check what is
available.

## Issue

Fixes #1799 (E52C quick-start: "istoreos expansion: images missing /
not showing"). The same callout pattern existed in E20C and is fixed
in the same PR for consistency.

## Changes

- `docs/e/e20c/getting-started/quick-start.md`: factory-installed system
  callout now points to `../download` instead of `../istoreos`.
- `docs/e/e52c/getting-started/quick-start.md`: same change.

## Notes

- English counterparts in `i18n/en/...` for E20C and E52C do not exist
  upstream yet; both products are still Chinese-only. No English file
  was added in this PR — bilingual sync can be handled in a follow-up
  once the English docs are introduced.
- The `../istoreos` subpage itself is intentionally left in place. It
  is no longer linked from the quick-start page but can still be
  reached by direct URL, and may be picked up by search engines /
  external links for a while.

## Verification

- `git diff fc6557490..HEAD` is exactly two single-line changes.
- No image, navigation, or component changes — only the markdown link
  text and target.
