### PR TITLE
docs(e/e52c): close unclosed 4-backtick code block hiding iStoreOS expansion images

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/getting-started/quick-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/getting-started/quick-start.md
@@ -238,11 +238,9 @@ Picocom is a serial port utility that can be used on a Mac and supports multiple
 
 5. Connecting to Radxa E52C via SSH
 
-````
-
+```bash
 ssh [username]@[IP address] # or ssh [username]@[hostname]
-
-```text
+```
 
 ## System login
 
@@ -273,4 +271,3 @@ Because the default file system size of iStoreOS is only 2GB, if you need to exp
 <img src="/img/e/e52c/radxa-e52c-istoreos-expansion-6.webp" width="700" alt="e52c-istoreos" />
 
 <img src="/img/e/e52c/radxa-e52c-istoreos-expansion-7.webp" width="700" alt="e52c-istoreos" />
-````


### PR DESCRIPTION
## Summary

In the English E52C quick-start, the "Connecting to Radxa E52C via SSH"
section is wrapped in a malformed 4-backtick code block. The opening
fence is a 4-backtick line, the inner content (including a `\`\`\`text`
fence) is treated as literal text, and the closing fence is again 4
backticks. The result: the SSH command, "## System login", the Debian
/ iStoreOS default-account block, and the entire "## istoreos expansion"
section (with its seven `<img>` tags) are all rendered as raw text
inside one big code block, which is why the expansion images never
show up in the docs.

Replace the broken 4-backtick fences with a normal `\`\`\`bash` /
`\`\`\`` pair so the SSH command is the only thing inside the code
block. Everything from "## System login" through the 7 expansion images
now renders as Markdown again.

## Issue

Fixes #1799 (E52C quick-start: "istoreos expansion: images missing /
not showing").

## Diff

```diff
 5. Connecting to Radxa E52C via SSH

-````
-
+```bash
 ssh [username]@[IP address] # or ssh [username]@[hostname]
-
-```text
+```

 ## System login
 ...
 <img src="/img/e/e52c/radxa-e52c-istoreos-expansion-7.webp" width="700" alt="e52c-istoreos" />
-````
```

## Notes

- Chinese source is unaffected — the Chinese version uses a normal
  ` ```bash ` / ` ``` ` pair around the SSH command and never had this
  bug. The local PR guard flags "missing Chinese counterpart" because
  it assumes English and Chinese are always changed in lockstep, but
  in this case only the English translation is broken and there is
  nothing to sync on the Chinese side.
- E20C English quick-start uses the correct fence pattern and renders
  fine; no change needed there.
- The downstream 7 expansion images themselves (`radxa-e52c-istoreos-
  expansion-*.webp`) already exist in `static/img/e/e52c/` and are
  intact — the bug was purely that they were inside a code block.

## Verification

- `git diff fc6557490..HEAD` is one file, 2 insertions / 5 deletions.
- Manual render check on the patched section confirms the SSH command
  is the only thing inside the `bash` code block, "## System login"
  and "## istoreos expansion" are now headings, and the seven `<img>`
  tags are now treated as images.
