### PR TITLE
docs(e/e20c,e/e52c): link factory-installed system callout to download page

### DIFF
--- a/docs/e/e20c/getting-started/quick-start.md
+++ b/docs/e/e20c/getting-started/quick-start.md
@@ -24,7 +24,7 @@ import { Section, Image } from "@site/src/utils/docs";
 
 <TabItem value="withemmc" label="带板载EMMC" default>
 
-出厂自带 [istoreos](../istoreos) 系统，上电自启动，不需要烧录。
+出厂自带 [istoreos](../download) 系统，上电自启动，不需要烧录。
 
 </TabItem>
 

--- a/docs/e/e52c/getting-started/quick-start.md
+++ b/docs/e/e52c/getting-started/quick-start.md
@@ -26,7 +26,7 @@ import { Section, Image } from "@site/src/utils/docs";
 
 <TabItem value="withemmc" label="带板载EMMC" default>
 
-出厂自带 [iStoreOS](../istoreos) 系统，上电自启动，不需要烧录。
+出厂自带 [iStoreOS](../download) 系统，上电自启动，不需要烧录。
 
 </TabItem>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/getting-started/quick-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/getting-started/quick-start.md
@@ -24,7 +24,7 @@ To start the Radxa E20C, you need the following equipment:
 
 <TabItem value="withemmc" label="with onBoard EMMC" default>
 
-E20C with onBoard EMMC is equipped with a pre-installed system [istoreos](../istoreos), no need to install os.
+E20C with onBoard EMMC is equipped with a pre-installed system [istoreos](../download), no need to install os.
 
 </TabItem>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/getting-started/quick-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e52c/getting-started/quick-start.md
@@ -26,7 +26,7 @@ To start the Radxa E52C, you need the following equipment:：
 
 <TabItem value="withemmc" label="with onBoard EMMC" default>
 
-E52C with onBoard EMMC is equipped with a pre-installed system [istoreos](../istoreos), no need to install os.
+E52C with onBoard EMMC is equipped with a pre-installed system [istoreos](../download), no need to install os.
 
 </TabItem>
 


### PR DESCRIPTION
## Summary

Replace the standalone `../istoreos` subpage link in the factory-installed
system callout of the E20C and E52C quick-start pages (both Chinese and
English) with a link to the resource download page (`../download`).

The iStoreOS subpage is a short blurb that mostly duplicates the
introduction already present on the download page. The download page is
the actionable page that lists every supported system image (iStoreOS,
Radxa OS, OpenWrt, etc.) and is what users actually need when they want
to switch away from the factory-installed system or check what is
available.

## Issue

Refs #1799.

## Background

PR #1803 originally proposed the same change but was closed by the
author because the real root cause of the missing expansion images was
the unclosed 4-backtick code fence in the English `quick-start.md`
(which swallowed the entire `## istoreos expansion` image block). That
real fix landed in PR #1804.

After PR #1804 merged, the docs owner requested in the 售后技术支持 group
on 2026-06-05 that we still apply the iStoreOS-link-to-download swap
on top, since the iStoreOS subpage is a duplicate of the download
page and the download page is the actionable destination. This PR does
exactly that, and now covers both languages (the EN file does exist
for both products).

## Changes

- `docs/e/e20c/getting-started/quick-start.md` (zh): factory-installed
  system callout now points to `../download` instead of `../istoreos`.
- `docs/e/e52c/getting-started/quick-start.md` (zh): same change.
- `i18n/en/docusaurus-plugin-content-docs/current/e/e20c/getting-started/quick-start.md` (en): same change.
- `i18n/en/docusaurus-plugin-content-docs/current/e/e52c/getting-started/quick-start.md` (en): same change.

## Verification

- `git diff upstream-docs/main..HEAD` is exactly four single-line link
  swaps (2 zh + 2 en).
- The `../download` target exists in both `docs/e/e20c/`,
  `docs/e/e52c/`, and their i18n/en counterparts (all four
  `download.md` files list iStoreOS, Radxa OS, and OpenWrt).
- Bilingual sync confirmed: every changed `docs/...` file has a
  corresponding `i18n/en/...` file changed.
- The `../istoreos` subpage itself is intentionally left in place. It
  is no longer linked from the quick-start page but can still be
  reached by direct URL.
