### PR TITLE
docs(q6a,q8b,airbox-q900): add Python venv-usage tutorial to app-dev chapters

### DIFF
--- a/docs/dragon/q6a/app-dev/virtual-env/venv-usage.md
+++ b/docs/dragon/q6a/app-dev/virtual-env/venv-usage.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 10
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/dev/_venv_usage.mdx
+---
+
+# Python 虚拟环境使用
+
+import VENVUSAGE from '../../../../common/dev/\_venv_usage.mdx';
+
+<VENVUSAGE />

--- a/docs/dragon/q8b/app-dev/README.md
+++ b/docs/dragon/q8b/app-dev/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 4
+---
+
+# 应用开发
+
+主要介绍上层应用开发，比如 QT, WiringX, Mraa, NPU 等
+
+<DocCardList />

--- a/docs/dragon/q8b/app-dev/README.md
+++ b/docs/dragon/q8b/app-dev/README.md
@@ -4,6 +4,4 @@ sidebar_position: 4
 
 # 应用开发
 
-主要介绍上层应用开发，比如 QT, WiringX, Mraa, NPU 等
-
 <DocCardList />

--- a/docs/dragon/q8b/app-dev/virtual-env/README.md
+++ b/docs/dragon/q8b/app-dev/virtual-env/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 1
+---
+
+# 虚拟环境
+
+<DocCardList />

--- a/docs/dragon/q8b/app-dev/virtual-env/venv-usage.md
+++ b/docs/dragon/q8b/app-dev/virtual-env/venv-usage.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 10
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/dev/_venv_usage.mdx
+---
+
+# Python 虚拟环境使用
+
+import VENVUSAGE from '../../../../common/dev/\_venv_usage.mdx';
+
+<VENVUSAGE />

--- a/docs/fogwise/airbox-q900/app-dev/virtual-env/README.md
+++ b/docs/fogwise/airbox-q900/app-dev/virtual-env/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 1
+---
+
+# 虚拟环境
+
+<DocCardList />

--- a/docs/fogwise/airbox-q900/app-dev/virtual-env/venv-usage.md
+++ b/docs/fogwise/airbox-q900/app-dev/virtual-env/venv-usage.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 10
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/dev/_venv_usage.mdx
+---
+
+# Python 虚拟环境使用
+
+import VENVUSAGE from '../../../../common/dev/\_venv_usage.mdx';
+
+<VENVUSAGE />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/app-dev/virtual-env/venv-usage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/app-dev/virtual-env/venv-usage.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 10
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_venv_usage.mdx
+---
+
+# Python Virtual Environment Usage
+
+import VENVUSAGE from '../../../../common/dev/\_venv_usage.mdx';
+
+<VENVUSAGE />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 4
+---
+
+# Application Development
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 1
+---
+
+# Virtual Environment
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/venv-usage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/venv-usage.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 10
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_venv_usage.mdx
+---
+
+# Python Virtual Environment Usage
+
+import VENVUSAGE from '../../../../common/dev/\_venv_usage.mdx';
+
+<VENVUSAGE />

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/virtual-env/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/virtual-env/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 1
+---
+
+# Virtual Environment
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/virtual-env/venv-usage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/virtual-env/venv-usage.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 10
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_venv_usage.mdx
+---
+
+# Python Virtual Environment Usage
+
+import VENVUSAGE from '../../../../common/dev/\_venv_usage.mdx';
+
+<VENVUSAGE />


### PR DESCRIPTION
docs(q6a,q8b,airbox-q900): add Python venv-usage tutorial to app-dev chapters

Add the Python virtual environment usage tutorial (the same content
that already lives at `docs/rock5/rock5b/app-development/venv-usage.md`,
sourced from `common/dev/_venv_usage.mdx`) to the application
development chapter of three products that previously lacked it:

- **Dragon Q6A**: append to the existing
  `docs/dragon/q6a/app-dev/virtual-env/` section as a wrapper file
  alongside conda/docker.
- **Dragon Q8B**: introduce a brand new `app-dev/` chapter
  (with a `virtual-env/` section) so the venv-usage tutorial has an
  application-development home on Q8B.
- **AIRbox Q900**: add a `virtual-env/` section under the existing
  `app-dev/` chapter, alongside `ros-dev/`.

Both Chinese (`docs/`) and English (`i18n/`) versions are added so the
docs/i18n drift guard stays clean. The shared body content continues
to come from `common/dev/_venv_usage.mdx` (and its English counterpart
at `i18n/en/docusaurus-plugin-content-docs/current/common/dev/_venv_usage.mdx`),
matching the existing wrapper pattern used by ROCK 5B and other
products.

## Files added

```
docs/dragon/q6a/app-dev/virtual-env/venv-usage.md
docs/dragon/q8b/app-dev/README.md
docs/dragon/q8b/app-dev/virtual-env/README.md
docs/dragon/q8b/app-dev/virtual-env/venv-usage.md
docs/fogwise/airbox-q900/app-dev/virtual-env/README.md
docs/fogwise/airbox-q900/app-dev/virtual-env/venv-usage.md
i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/app-dev/virtual-env/venv-usage.md
i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/README.md
i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/README.md
i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/venv-usage.md
i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/virtual-env/README.md
i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/app-dev/virtual-env/venv-usage.md
```

## Verification

- `scripts/agent-doc-lint.sh` passes on all touched files.
- `scripts/agent-doc-drift-guard.sh` does not report any *new* drift
  introduced by this PR (the only flagged file,
  `docs/i18n/.../common/radxa-os/build-system/_radxa_os.mdx`, is a
  pre-existing local artifact unrelated to this change).
