### PR TITLE
docs(dragon/q6a,q8b): expand build-system info block and add Q8B build-system chapter

### DIFF
--- a/docs/common/radxa-os/build-system/_radxa_os.mdx
+++ b/docs/common/radxa-os/build-system/_radxa_os.mdx
@@ -181,8 +181,9 @@ rsdk
 
 编译完成后，会在 `out` 目录下生成主板型号与系统版本对应的文件夹，该文件夹下会生成名称为 `output.img` 的 Radxa OS 镜像。
 
-:::info 瑞莎 Cubie A7A / A7Z / A7S 构建系统选项
-选择 `Build system image` 后，在主板型号列表中选择 `radxa-a733` 选项。
+:::info 构建系统选项
+- 瑞莎 Cubie A7A / A7Z / A7S 对应的主板型号是 `radxa-a733` 选项。
+- 瑞莎 Dragon Q6A / Q8B 对应的主板型号是  `radxa-dragon-midstream` 选项。
 :::
 
 ## 常见问题

--- a/docs/dragon/q8b/low-level-dev/build-system/README.md
+++ b/docs/dragon/q8b/low-level-dev/build-system/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 1
+---
+
+# 构建系统
+
+<DocCardList />

--- a/docs/dragon/q8b/low-level-dev/build-system/install-env.md
+++ b/docs/dragon/q8b/low-level-dev/build-system/install-env.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/build-system/_install_env.mdx
+---
+
+import InstallEnv from '../../../../common/radxa-os/build-system/_install_env.mdx';
+
+# 环境搭建
+
+<InstallEnv items="Kernel 和 Radxa OS" />

--- a/docs/dragon/q8b/low-level-dev/build-system/kernel.md
+++ b/docs/dragon/q8b/low-level-dev/build-system/kernel.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 3
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/build-system/_kernel.mdx
+---
+
+import Kernel from '../../../../common/radxa-os/build-system/_kernel.mdx';
+
+# Kernel 开发
+
+<Kernel  git_url="https://github.com/radxa-pkg/linux-qcom.git" />

--- a/docs/dragon/q8b/low-level-dev/build-system/radxa-os.md
+++ b/docs/dragon/q8b/low-level-dev/build-system/radxa-os.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 4
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/build-system/_radxa_os.mdx
+---
+
+import RadxaOS from '../../../../common/radxa-os/build-system/_radxa_os.mdx';
+
+# Radxa OS 开发
+
+<RadxaOS  git_url="https://github.com/RadxaOS-SDK/rsdk.git" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_radxa_os.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_radxa_os.mdx
@@ -180,8 +180,9 @@ After selecting `yes`, the Radxa OS build process will start, and rsdk will auto
 
 After compilation is complete, a folder corresponding to the board model and system version will be generated in the `out` directory, containing the Radxa OS image named `output.img`.
 
-:::info Radxa Cubie A7A / A7Z / A7S Build System Options
-After selecting `Build system image`, choose the `radxa-a733` option from the board model list.
+:::info Build System Options
+- For Radxa Cubie A7A / A7Z / A7S, the corresponding board model is `radxa-a733`.
+- For Radxa Dragon Q6A / Q8B, the corresponding board model is `radxa-dragon-midstream`.
 :::
 
 ## FAQ

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/build-system/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/build-system/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 1
+---
+
+# Build System
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/build-system/install-env.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/build-system/install-env.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_install_env.mdx
+---
+
+import InstallEnv from '../../../../common/radxa-os/build-system/_install_env.mdx';
+
+# Environment Setup
+
+<InstallEnv items="Kernel and Radxa OS" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/build-system/kernel.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/build-system/kernel.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 3
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_kernel.mdx
+---
+
+import Kernel from '../../../../common/radxa-os/build-system/_kernel.mdx';
+
+# Kernel Development
+
+<Kernel  git_url="https://github.com/radxa-pkg/linux-qcom.git" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/build-system/radxa-os.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/build-system/radxa-os.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 4
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_radxa_os.mdx
+---
+
+import RadxaOS from '../../../../common/radxa-os/build-system/_radxa_os.mdx';
+
+# Radxa OS Development
+
+<RadxaOS  git_url="https://github.com/RadxaOS-SDK/rsdk.git" />


### PR DESCRIPTION
## 背景

`docs/dragon/q6a/low-level-dev/build-system/radxa-os` 教程里的 info 提示一直只提到 Cubie A7A / A7Z / A7S（`radxa-a733`），对 Dragon Q6A / Q8B 用户来说在 `rsdk` TUI 里看不到对应 `radxa-dragon-midstream` 选项的提示。

同时 Dragon Q6A 有完整的 底层开发 → 构建系统 章节（环境搭建 / Kernel 开发 / Radxa OS 开发），Dragon Q8B 这一侧还没有对应章节。

## 改动

两个 commit，分别处理共享内容与 Q8B 章节本身：

1. `docs(common): expand build-system info block to cover Dragon Q6A/Q8B`
   - 把 `common/radxa-os/build-system/_radxa_os.mdx` 末尾的 Cubie 专属 info 块改成通用的 info 块，同时列 Cubie 主板型号（`radxa-a733`）和 Dragon Q6A / Q8B 主板型号（`radxa-dragon-midstream`）
   - 同步中英文版（`docs/` 与 `i18n/en/`）

2. `docs(dragon/q8b): add low-level-dev build-system chapter`
   - 新增 `docs/dragon/q8b/low-level-dev/build-system/` 目录（与 `dragon/q6a/low-level-dev/build-system/` 框架一致）
   - 内容通过 `doc_kind: wrapper` 复用 `common/radxa-os/build-system/_*.mdx`，与 Q6A 完全同源
   - 同步中英文版

## 影响范围

- `docs/common/radxa-os/build-system/_radxa_os.mdx`（中/英）
- `docs/dragon/q8b/low-level-dev/build-system/` 新增 4 个 wrapper 文件（中/英）

## 验证

- `python3 ~/.openclaw/workspaces/support/scripts/github_pr_guard.py check --repo-path ~/radxa-docs --fetch --max-scopes 2`：bilingual 检查通过，scopes 检查在 `--max-scopes 2` 下通过
- 改动只在 `docs/common/radxa-os/build-system/` 与 `docs/dragon/q8b/low-level-dev/build-system/`，与其它产品线无交叉
