### PR TITLE
docs(rkdeveloptool): add macOS Apple Silicon VLA build note

### DIFF
--- a/docs/common/dev/_rkdeveloptool.mdx
+++ b/docs/common/dev/_rkdeveloptool.mdx
@@ -50,6 +50,23 @@ make -j $(nproc)
 cp rkdeveloptool /opt/homebrew/bin/
 ```
 
+:::warning[macOS 编译报错]
+在 Apple Silicon（M1 / M2 / M3 等）上使用 Apple Clang 编译时，`main.cpp` 中的 `BYTE pBuf[nSectorSize * DEFAULT_RW_LBA]` 会被 Clang 视为 C++ VLA 扩展并因 `-Werror` 直接编译失败，报错形如：
+
+```text
+error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
+```
+
+请在 `configure` 阶段追加 `CXXFLAGS` 关闭该警告：
+
+```bash
+./configure CXXFLAGS="-Wno-vla-cxx-extension"
+make -j $(nproc)
+```
+
+或直接修改 `main.cpp`，将两处 `int nSectorSize = 512;` 改为 `constexpr int nSectorSize = 512;` 后重新编译。详见 [Issue #1813](https://github.com/radxa-docs/docs/issues/1813)。
+:::
+
 </TabItem>
 </Tabs>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptool.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptool.mdx
@@ -52,6 +52,23 @@ make -j $(nproc)
 cp rkdeveloptool /opt/homebrew/bin/
 ```
 
+:::warning[macOS build error]
+On Apple Silicon (M1 / M2 / M3, etc.) with Apple Clang, the `BYTE pBuf[nSectorSize * DEFAULT_RW_LBA]` arrays in `main.cpp` are treated as a C++ VLA extension and the build fails under `-Werror`, with errors like:
+
+```text
+error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
+```
+
+Pass `CXXFLAGS` to `configure` to silence the warning:
+
+```bash
+./configure CXXFLAGS="-Wno-vla-cxx-extension"
+make -j $(nproc)
+```
+
+Alternatively, edit `main.cpp` and change the two `int nSectorSize = 512;` lines to `constexpr int nSectorSize = 512;`, then rebuild. See [Issue #1813](https://github.com/radxa-docs/docs/issues/1813).
+:::
+
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Fixes #1813

## Summary
The macOS build instructions for rkdeveloptool (the common MDX file imported by CM3, CM5, Rock 3A/3C, Rock 4C+, Rock Pi S0, Zero 3, NX5, etc.) did not mention the Apple Clang `-Werror,-Wvla-cxx-extension` build failure that hits users on Apple Silicon (M1 / M2 / M3).

In `main.cpp` the two `BYTE pBuf[nSectorSize * DEFAULT_RW_LBA]` arrays use a non-`constexpr` `nSectorSize`, which Apple Clang rejects as a C++ VLA extension. Because the Makefile builds with `-Werror`, the whole `make -j $(nproc)` aborts and the user is left with no documented workaround.

## Change
Add a `:::warning[macOS 编译报错]` / `:::warning[macOS build error]` callout inside the macOS tab, in both zh and en, with two workable workarounds:

1. Pass `CXXFLAGS="-Wno-vla-cxx-extension"` to `./configure` (no source patch required).
2. Edit `main.cpp` and change the two `int nSectorSize = 512;` lines to `constexpr int nSectorSize = 512;`, then rebuild.

Both zh (`docs/common/dev/_rkdeveloptool.mdx`) and en (`i18n/en/.../_rkdeveloptool.mdx`) are updated in sync.

## Source
- User feedback issue: #1813 (docs feedback form, 2026-06-09, Mac M2 编译错误)
- Reported error: `main.cpp:2563:12: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]`

## Risk
docs-only, single scope (`docs/common/dev`). Touches the shared `_rkdeveloptool.mdx` MDX file, which is imported by ~9 product pages, so all of them will pick up the new note uniformly.