### PR TITLE
docs(q6a): rename qualcomm.md to yocto-guide.md and add meta-radxa-dragon link

### DIFF
--- a/docs/dragon/q6a/other-system/yocto-guide.md
+++ b/docs/dragon/q6a/other-system/yocto-guide.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Qualcomm Linux Guide
+# Yocto Guide
 
 ## Qualcomm Linux 编译指南
 
@@ -11,3 +11,7 @@ sidebar_position: 1
 ## Qualcomm Linux Yocto 指南
 
 请参考 [Qualcomm Linux Yocto 指南](https://docs.qualcomm.com/bundle/publicresource/topics/80-70020-27/yocto_landing_page.html)
+
+## Radxa Dragon Q6A Yocto 编译指南
+
+请参考 [Radxa Dragon Q6A Yocto 编译指南](https://github.com/radxa/meta-radxa-dragon/wiki/dragon-q6a)

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/other-system/yocto-guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/other-system/yocto-guide.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Qualcomm Linux Guide
+# Yocto Guide
 
 ## Qualcomm Linux Compilation Guide
 
@@ -11,3 +11,7 @@ Please refer [Qualcomm Linux Compilation Guide](https://docs.qualcomm.com/bundle
 ## Qualcomm Linux Yocto Guide
 
 Please refer [Qualcomm Linux Yocto Guide](https://docs.qualcomm.com/bundle/publicresource/topics/80-70020-27/yocto_landing_page.html)
+
+## Radxa Dragon Q6A Yocto Guide
+
+Please refer [Radxa Dragon Q6A Yocto Guide](https://github.com/radxa/meta-radxa-dragon/wiki/dragon-q6a)


### PR DESCRIPTION
## Summary

- Rename `docs/dragon/q6a/other-system/qualcomm.md` to `yocto-guide.md`
- Update H1 title to `Yocto Guide` (capital Y)
- Add a third section `Radxa Dragon Q6A Yocto 编译指南` linking to the Radxa-maintained meta-radxa-dragon Yocto layer wiki:
  https://github.com/radxa/meta-radxa-dragon/wiki/dragon-q6a
- Mirror the same change in the i18n/en counterpart

## Background

Originated from an internal support topic discussion on Q6A Linux SDK source. The previous page only pointed users to Qualcomm's official docs, with no reference to the Radxa-maintained Yocto layer that actually builds Q6A images. The page title and filename also still used the generic "Qualcomm Linux Guide" name, which no longer matches the main content focus.

## Changes

| File | Change |
| --- | --- |
| `docs/dragon/q6a/other-system/qualcomm.md` → `yocto-guide.md` | Renamed; H1 → `Yocto Guide`; new third section |
| `i18n/en/.../dragon/q6a/other-system/qualcomm.md` → `yocto-guide.md` | Same change in English |

## Impact

- Affects: https://docs.radxa.com/dragon/q6a/other-system/qualcomm (will redirect to .../other-system/yocto-guide)
- Sidebar position kept at 1 → no sidebar reshuffle
- No other docs reference the old file name (`qualcomm.md` is only used as the renamed file; the Casaos `qualcomm` mdx is unrelated)
- Bilingual check: ZH and EN both updated
