### PR TITLE
docs(rock5t): move SIM7600G-H LTE guide to accessories and clean up headings

### DIFF
--- a/docs/rock5/rock5t/accessories/m2-b-key-sim7600g-h.md
+++ b/docs/rock5/rock5t/accessories/m2-b-key-sim7600g-h.md
@@ -1,8 +1,8 @@
 ---
-sidebar_position: 10
+sidebar_position: 20
 ---
 
-# M.2 B Key - SIM7600G-H LTE 配置指南
+# SIM7600G-H 4G 模组使用指南
 
 **System:** Radxa Rock 5T · Ubuntu 24.04 · Kernel 6.1.115-3-rockchip  
 **模组:** SimCom SIM7600G-H 安装在 M.2 B-Key插槽  
@@ -10,7 +10,7 @@ sidebar_position: 10
 
 ---
 
-##1.确认 GPIO 引脚
+## 确认 GPIO 引脚
 
 SIM7600G-H 通过 RK3588 的 4 个 GPIO 引脚进行控制。  
 Linux GPIO编号的计算公式为: `Bank × 32 + Group × 8 + Bit`
@@ -28,7 +28,7 @@ Linux GPIO编号的计算公式为: `Bank × 32 + Group × 8 + Bit`
 
 ---
 
-##2.导出 GPIO 并启动模组（手动测试）
+## 导出 GPIO 并启动模组（手动测试）
 
 ```bash
 # Export GPIOs and set as output
@@ -60,7 +60,7 @@ lsusb | grep -i sim
 
 ---
 
-##3.验证模组
+## 验证模组
 
 ```bash
 mmcli -L
@@ -75,7 +75,7 @@ mmcli -m 0
 
 ---
 
-##4. 解锁 SIM PIN 并关闭 PIN校验
+## 解锁 SIM PIN 并关闭 PIN 校验
 
 ```bash
 # Install minicom
@@ -103,7 +103,7 @@ AT+COPS?           # Show network operator
 
 ---
 
-##5.解决 APN 问题（Telekom运营商配置）
+## 解决 APN 问题（Telekom 运营商配置）
 
 模组出厂默认携带 `carrier config: Commercial-DT`。Deutsche Telekom 网络强制要求使用 `INTERNET.TELEKOM` 作为唯一允许的 APN。依托 Telekom 网络的虚拟运营商（例如 Congstar、Aldi Talk）也必须使用该 APN。
 
@@ -136,7 +136,7 @@ sudo qmicli -d /dev/cdc-wdm0 --wds-get-current-settings
 
 ---
 
-##6.开机自动连接脚本
+## 开机自动连接脚本
 
 创建连接脚本:
 
@@ -210,7 +210,7 @@ sudo chmod +x /usr/local/bin/sim7600-connect.sh
 
 ---
 
-##7. 创建 Systemd 服务
+## 创建 Systemd 服务
 
 ```bash
 sudo nano /etc/systemd/system/sim7600-init.service
@@ -240,7 +240,7 @@ sudo systemctl disable ModemManager
 
 ---
 
-##8.手动切换 LTE
+## 手动切换 LTE
 
 创建一个在切换到 WiFi 时关闭 LTE 的脚本:
 
@@ -268,7 +268,7 @@ sudo sim7600-connect.sh      # Turn LTE back on
 
 ---
 
-##9. 测试连接
+## 测试连接
 
 ```bash
 # After reboot or manual start:
@@ -283,7 +283,7 @@ nmcli radio wifi on         # Re-enable WiFi
 
 ---
 
-##排障
+## 排障
 
 | 问题                          | 原因                                | 解决方案                                            |
 | ----------------------------- | ----------------------------------- | --------------------------------------------------- |

--- a/docs/rock5/rock5t/accessories/m2-b-key-sim7600g-h.md
+++ b/docs/rock5/rock5t/accessories/m2-b-key-sim7600g-h.md
@@ -6,7 +6,7 @@ sidebar_position: 20
 
 **System:** Radxa Rock 5T · Ubuntu 24.04 · Kernel 6.1.115-3-rockchip  
 **模组:** SimCom SIM7600G-H 安装在 M.2 B-Key插槽  
-**目标:**每次开机自动建立 LTE 连接
+**目标:** 每次开机自动建立 LTE 连接
 
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/accessories/m2-b-key-sim7600g-h.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/accessories/m2-b-key-sim7600g-h.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 10
+sidebar_position: 20
 description: "Setup guide for the SimCom SIM7600G-H LTE modem in the Rock5T M.2 B-Key slot, covering GPIO control, QMI connection, and automatic boot."
 ---
 
-# M.2 B Key - SIM7600G-H LTE Setup
+# SIM7600G-H 4G Modem User Guide
 
 **System:** Radxa Rock 5T · Ubuntu 24.04 · Kernel 6.1.115-3-rockchip  
 **Modem:** SimCom SIM7600G-H in M.2 B-Key slot  
@@ -11,7 +11,7 @@ description: "Setup guide for the SimCom SIM7600G-H LTE modem in the Rock5T M.2 
 
 ---
 
-## 1. Identify GPIO Pins
+## Identify GPIO Pins
 
 The SIM7600G-H is controlled via 4 GPIO pins of the RK3588.  
 The Linux GPIO number is calculated as: `Bank × 32 + Group × 8 + Bit`
@@ -29,7 +29,7 @@ The Linux GPIO number is calculated as: `Bank × 32 + Group × 8 + Bit`
 
 ---
 
-## 2. Export GPIOs and Start Modem (Manual Test)
+## Export GPIOs and Start Modem (Manual Test)
 
 ```bash
 # Export GPIOs and set as output
@@ -61,7 +61,7 @@ lsusb | grep -i sim
 
 ---
 
-## 3. Verify Modem
+## Verify Modem
 
 ```bash
 mmcli -L
@@ -76,7 +76,7 @@ Expected output shows:
 
 ---
 
-## 4. Unlock SIM PIN and Disable PIN Lock
+## Unlock SIM PIN and Disable PIN Lock
 
 ```bash
 # Install minicom
@@ -104,7 +104,7 @@ AT+COPS?           # Show network operator
 
 ---
 
-## 5. Solve APN Issue (Telekom Carrier Config)
+## Solve APN Issue (Telekom Carrier Config)
 
 The modem ships with `carrier config: Commercial-DT`. The Deutsche Telekom network enforces `INTERNET.TELEKOM` as the only allowed APN. MVNOs running on the Telekom network (e.g. Congstar, Aldi Talk) must also use this APN.
 
@@ -137,7 +137,7 @@ sudo qmicli -d /dev/cdc-wdm0 --wds-get-current-settings
 
 ---
 
-## 6. Automatic Boot Script
+## Automatic Boot Script
 
 Create the connection script:
 
@@ -211,7 +211,7 @@ sudo chmod +x /usr/local/bin/sim7600-connect.sh
 
 ---
 
-## 7. Create Systemd Service
+## Create Systemd Service
 
 ```bash
 sudo nano /etc/systemd/system/sim7600-init.service
@@ -241,7 +241,7 @@ sudo systemctl disable ModemManager
 
 ---
 
-## 8. Toggle LTE Manually
+## Toggle LTE Manually
 
 Create a script to turn LTE off when using WiFi:
 
@@ -269,7 +269,7 @@ sudo sim7600-connect.sh      # Turn LTE back on
 
 ---
 
-## 9. Test Connection
+## Test Connection
 
 ```bash
 # After reboot or manual start:


### PR DESCRIPTION
## Summary

Move the `SIM7600G-H` 4G modem guide for ROCK 5T from `hardware-design/`
to `accessories/`, where it belongs as an accessory tutorial rather
than a board-level hardware design, and clean up the section headings.

## Changes

- **Move**: `docs/rock5/rock5t/hardware-design/m2-b-key-sim7600g-h.md`
  → `docs/rock5/rock5t/accessories/m2-b-key-sim7600g-h.md`
  (and the matching English page under `i18n/en/...`).
- **Rename title**:
  - zh: `M.2 B Key - SIM7600G-H LTE 配置指南` → `SIM7600G-H 4G 模组使用指南`
  - en: `M.2 B Key - SIM7600G-H LTE Setup` → `SIM7600G-H 4G Modem User Guide`
- **Drop manual section numbering** on both zh and en pages. The site
  auto-numbers headings, so the hand-written `1.`, `2.`, … only
  produced duplicated numbers in the rendered output.
- **Bump `sidebar_position`** from `10` to `20` so the page slots in
  between the existing 3D case guide (`3`) and the accessories README
  (`99`) without colliding with anything else.

## Why

The SIM7600G-H is an M.2 B-Key accessory modem, not a board-level
hardware design reference, so the tutorial belongs in the
`accessories/` sidebar. The duplicated numbering was a long-standing
cosmetic issue on this page.

## Verification

- `bash scripts/agent-doc-drift-guard.sh` — passed
- `bash scripts/agent-doc-translation-guard.sh` — passed
- zh / en pages updated together so the translation stays in sync.
