### PR TITLE
docs(rock3b): drop redundant V1.5/V1.6 sub-headers in hardware design tabs

### DIFF
--- a/docs/rock3/rock3b/download.md
+++ b/docs/rock3/rock3b/download.md
@@ -25,8 +25,6 @@ sidebar_position: 2
 <Tabs queryString="HardwareDesign">
     <TabItem value="ROCK 3B">
 
-### V1.5
-
 - 原理图
 
 [Radxa_ROCK_3B_V1.51_SCH](https://dl.radxa.com/rock3/docs/hw/3b/Radxa_ROCK_3B_V1.51_SCH.pdf)
@@ -51,8 +49,6 @@ sidebar_position: 2
 
     </TabItem>
     <TabItem value="ROCK 3B+">
-
-### V1.6
 
 - 原理图
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/download.md
@@ -25,8 +25,6 @@ Except for the above mirrors which have been fully tested officially, the other 
 <Tabs queryString="HardwareDesign">
     <TabItem value="ROCK 3B">
 
-### V1.5
-
 - Schematic
 
 [Radxa_ROCK_3B_V1.51_SCH](https://dl.radxa.com/rock3/docs/hw/3b/Radxa_ROCK_3B_V1.51_SCH.pdf)
@@ -51,8 +49,6 @@ Except for the above mirrors which have been fully tested officially, the other 
 
     </TabItem>
     <TabItem value="ROCK 3B+">
-
-### V1.6
 
 - Schematic
 


### PR DESCRIPTION
## Summary

- Drop the redundant `### V1.5` and `### V1.6` H3 sub-headers in the
  ROCK 3B download page's Hardware Design section.
- The section is already a `<Tabs queryString="HardwareDesign">` block
  with the two boards identified by tab label (`ROCK 3B` / `ROCK 3B+`),
  so the H3 sub-headers only added duplicate entries to the right-hand
  table of contents without giving the page more structure.
- Sync the Chinese and English translations.

## Why

Internal feedback: when a single Hardware Design section contains two
`<TabItem>` panels that each start with an H3 for the same board
revision, both H3s show up at once in the page outline. The tab label
is already enough to tell the two panels apart.

## Files

- `docs/rock3/rock3b/download.md`
- `i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/download.md`

Refs: 售后技术支持 group, 2026-06-12.
