### PR TITLE
docs(dragon-q8b): add system usage tutorials (RDP / NoMachine / fcitx / video / OpenCL)

### DIFF
--- a/docs/dragon/q8b/system-config/fcitx-usage.md
+++ b/docs/dragon/q8b/system-config/fcitx-usage.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 4
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/system-config/_fcitx_usage.mdx
+---
+
+import FCITX from '../../../common/radxa-os/system-config/_fcitx_usage.mdx';
+
+# 输入法使用
+
+<FCITX debian_version="debian11" board="dragon-q8b" />

--- a/docs/dragon/q8b/system-config/nomachine.md
+++ b/docs/dragon/q8b/system-config/nomachine.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 3
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/system-config/_nomachine.mdx
+---
+
+import NO_MACHINE from '../../../common/radxa-os/system-config/_nomachine.mdx';
+
+# NoMachine 登录
+
+<NO_MACHINE board="dragon-q8b" />

--- a/docs/dragon/q8b/system-config/opencl.md
+++ b/docs/dragon/q8b/system-config/opencl.md
@@ -1,0 +1,311 @@
+---
+sidebar_position: 5
+---
+
+# OpenCL 使用指南
+
+在 Dragon Q8B 上安装并验证 OpenCL（基于 Mesa RustiCL + Freedreno GPU）。
+
+## 安装 OpenCL
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+
+sudo apt update
+sudo apt install mesa-opencl-icd -y
+
+```
+
+</NewCodeBlock>
+
+## 验证 OpenCL
+
+启用 Freedreno 后端并查看 OpenCL 信息：
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+
+RUSTICL_ENABLE=freedreno clinfo
+
+```
+
+</NewCodeBlock>
+
+终端输出示例：
+
+```bash
+
+radxa@radxa-dragon-q8b:~$ RUSTICL_ENABLE=freedreno clinfo
+Number of platforms                               1
+  Platform Name                                   rusticl
+  Platform Vendor                                 Mesa/X.org
+  Platform Version                                OpenCL 3.0
+  Platform Profile                                FULL_PROFILE
+  Platform Extensions                             cl_khr_icd cl_khr_byte_addressable_store cl_khr_create_command_queue cl_khr_expect_assume cl_khr_extended_bit_ops cl_khr_extended_versioning cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_il_program cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_integer_dot_product cl_khr_spirv_no_integer_wrap_decoration cl_khr_spirv_queries cl_khr_suggested_local_work_size cl_ext_immutable_memory_objects cl_khr_spirv_linkonce_odr cl_khr_fp16 cles_khr_int64 cl_khr_kernel_clock cl_khr_image2d_from_buffer cl_khr_3d_image_writes cl_khr_depth_images cl_ext_image_unorm_int_2_101010 cl_khr_priority_hints cl_khr_device_uuid
+  Platform Extensions with Version                cl_khr_icd                                                       0x800000 (2.0.0)
+                                                  cl_khr_byte_addressable_store                                    0x400000 (1.0.0)
+                                                  cl_khr_create_command_queue                                      0x400000 (1.0.0)
+                                                  cl_khr_expect_assume                                             0x400000 (1.0.0)
+                                                  cl_khr_extended_bit_ops                                          0x400000 (1.0.0)
+                                                  cl_khr_extended_versioning                                       0x400000 (1.0.0)
+                                                  cl_khr_global_int32_base_atomics                                 0x400000 (1.0.0)
+                                                  cl_khr_global_int32_extended_atomics                             0x400000 (1.0.0)
+                                                  cl_khr_il_program                                                0x400000 (1.0.0)
+                                                  cl_khr_local_int32_base_atomics                                  0x400000 (1.0.0)
+                                                  cl_khr_local_int32_extended_atomics                              0x400000 (1.0.0)
+                                                  cl_khr_integer_dot_product                                       0x800000 (2.0.0)
+                                                  cl_khr_spirv_no_integer_wrap_decoration                          0x400000 (1.0.0)
+                                                  cl_khr_spirv_queries                                             0x400000 (1.0.0)
+                                                  cl_khr_suggested_local_work_size                                 0x400000 (1.0.0)
+                                                  cl_ext_immutable_memory_objects                                  0x400000 (1.0.0)
+                                                  cl_khr_spirv_linkonce_odr                                        0x400000 (1.0.0)
+                                                  cl_khr_fp16                                                      0x400000 (1.0.0)
+                                                  cles_khr_int64                                                   0x400000 (1.0.0)
+                                                  cl_khr_kernel_clock                                              0x400000 (1.0.0)
+                                                  cl_khr_image2d_from_buffer                                       0x400000 (1.0.0)
+                                                  cl_khr_3d_image_writes                                           0x400000 (1.0.0)
+                                                  cl_khr_depth_images                                              0x400000 (1.0.0)
+                                                  cl_ext_image_unorm_int_2_101010                                  0x400000 (1.0.0)
+                                                  cl_khr_priority_hints                                            0x400000 (1.0.0)
+                                                  cl_khr_device_uuid                                               0x400000 (1.0.0)
+  Platform Numeric Version                        0xc00000 (3.0.0)
+  Platform Extensions function suffix             MESA
+  Platform Host timer resolution                  1ns
+
+  Platform Name                                   rusticl
+Number of devices                                 1
+  Device Name                                     FD690
+  Device Vendor                                   Qualcomm
+  Device Vendor ID                                0x5143
+  Device Version                                  OpenCL 3.0
+  Device UUID                                     463bc9b2-20ab-14eb-a880-fe78d7aeeb54
+  Driver UUID                                     b251c0ed-95c4-4ac2-0c0b-6df49772396f
+  Valid Device LUID                               No
+  Device LUID                                     0000-000000000000
+  Device Node Mask                                0
+  Device Numeric Version                          0xc00000 (3.0.0)
+  Driver Version                                  26.0.3-1ubuntu1
+  Device OpenCL C Version                         OpenCL C 1.2
+  Device OpenCL C Numeric Version                 0x402000 (1.2.0)
+  Device OpenCL C all versions                    OpenCL C                                                         0xc00000 (3.0.0)
+                                                  OpenCL C                                                         0x402000 (1.2.0)
+                                                  OpenCL C                                                         0x401000 (1.1.0)
+                                                  OpenCL C                                                         0x400000 (1.0.0)
+  Device OpenCL C features                        __opencl_c_integer_dot_product_input_4x8bit                      0x800000 (2.0.0)
+                                                  __opencl_c_integer_dot_product_input_4x8bit_packed               0x800000 (2.0.0)
+                                                  __opencl_c_int64                                                 0x400000 (1.0.0)
+                                                  __opencl_c_kernel_clock_scope_device                             0x400000 (1.0.0)
+                                                  __opencl_c_kernel_clock_scope_sub_group                          0x400000 (1.0.0)
+                                                  __opencl_c_images                                                0x400000 (1.0.0)
+                                                  __opencl_c_read_write_images                                     0x400000 (1.0.0)
+                                                  __opencl_c_3d_image_writes                                       0x400000 (1.0.0)
+                                                  __opencl_c_ext_image_unorm_int_2_101010                          0x400000 (1.0.0)
+  Latest conformance test passed                  v0000-01-01-00
+  Device Type                                     GPU
+  Device Profile                                  EMBEDDED_PROFILE
+  Device Available                                Yes
+  Compiler Available                              Yes
+  Linker Available                                Yes
+  Max compute units                               8
+  Max clock frequency                             690MHz
+  Device Partition                                (core)
+    Max number of sub-devices                     0
+    Supported partition types                     None
+    Supported affinity domains                    (n/a)
+  Max work item dimensions                        3
+  Max work item sizes                             1024x1024x64
+  Max work group size                             2048
+  Preferred work group size multiple (device)     16
+  Preferred work group size multiple (kernel)     128
+  Max sub-groups per work group                   0
+  Preferred / native vector sizes
+    char                                                 1 / 1
+    short                                                1 / 1
+    int                                                  1 / 1
+    long                                                 1 / 1
+    half                                                 1 / 1        (cl_khr_fp16)
+    float                                                1 / 1
+    double                                               0 / 0        (n/a)
+  Half-precision Floating-point support           (cl_khr_fp16)
+    Denormals                                     No
+    Infinity and NANs                             Yes
+    Round to nearest                              Yes
+    Round to zero                                 No
+    Round to infinity                             No
+    IEEE754-2008 fused multiply-add               No
+    Support is emulated in software               No
+  Single-precision Floating-point support         (core)
+    Denormals                                     No
+    Infinity and NANs                             Yes
+    Round to nearest                              Yes
+    Round to zero                                 No
+    Round to infinity                             No
+    IEEE754-2008 fused multiply-add               No
+    Support is emulated in software               No
+    Correctly-rounded divide and sqrt operations  No
+  Double-precision Floating-point support         (n/a)
+  Address bits                                    64, Little-Endian
+  Global memory size                              16071417856 (14.97GiB)
+  Error Correction support                        No
+  Max memory allocation                           2147483647 (2GiB)
+  Unified memory for Host and Device              Yes
+  Shared Virtual Memory (SVM) capabilities        (core)
+    Coarse-grained buffer sharing                 No
+    Fine-grained buffer sharing                   No
+    Fine-grained system sharing                   No
+    Atomics                                       No
+  Minimum alignment for any data type             128 bytes
+  Alignment of base address                       4096 bits (512 bytes)
+  Preferred alignment for atomics
+    SVM                                           0 bytes
+    Global                                        0 bytes
+    Local                                         0 bytes
+  Atomic memory capabilities                      relaxed, work-group scope
+  Atomic fence capabilities                       relaxed, acquire/release, work-group scope
+  Max size for global variable                    0
+  Preferred total size of global vars             0
+  Global Memory cache type                        None
+  Image support                                   Yes
+    Max number of samplers per kernel             16
+    Max size for 1D images from buffer            134217727 pixels
+    Max 1D or 2D image array size                 2048 images
+    Base address alignment for 2D image buffers   64 bytes
+    Pitch alignment for 2D image buffers          64 pixels
+    Max 2D image size                             16384x16384 pixels
+    Max 3D image size                             2048x2048x2048 pixels
+    Max number of read image args                 16
+    Max number of write image args                32
+    Max number of read/write image args           32
+  Pipe support                                    No
+  Max number of pipe args                         0
+  Max active pipe reservations                    0
+  Max pipe packet size                            0
+  Local memory type                               Global
+  Local memory size                               32768 (32KiB)
+  Max number of constant args                     16
+  Max constant buffer size                        67108864 (64MiB)
+  Generic address space support                   No
+  Max size of kernel argument                     4096 (4KiB)
+  Queue properties (on host)
+    Out-of-order execution                        Yes
+    Profiling                                     Yes
+  Device enqueue capabilities                     (n/a)
+  Queue properties (on device)
+    Out-of-order execution                        No
+    Profiling                                     No
+    Preferred size                                0
+    Max size                                      0
+  Max queues on device                            0
+  Max events on device                            0
+  Prefer user sync for interop                    Yes
+  Profiling timer resolution                      52ns
+  Execution capabilities
+    Run OpenCL kernels                            Yes
+    Run native kernels                            No
+    Non-uniform work-groups                       No
+    Work-group collective functions               No
+    Sub-group independent forward progress        No
+    IL version                                    SPIR-V_1.0 SPIR-V_1.1 SPIR-V_1.2 SPIR-V_1.3 SPIR-V_1.4 SPIR-V_1.5 SPIR-V_1.6
+    ILs with version                              SPIR-V                                                           0x400000 (1.0.0)
+                                                  SPIR-V                                                           0x401000 (1.1.0)
+                                                  SPIR-V                                                           0x402000 (1.2.0)
+                                                  SPIR-V                                                           0x403000 (1.3.0)
+                                                  SPIR-V                                                           0x404000 (1.4.0)
+                                                  SPIR-V                                                           0x405000 (1.5.0)
+                                                  SPIR-V                                                           0x406000 (1.6.0)
+  printf() buffer size                            1048576 (1024KiB)
+  Built-in kernels                                (n/a)
+  Built-in kernels with version                   (n/a)
+  Device Extensions                               cl_khr_byte_addressable_store cl_khr_create_command_queue cl_khr_expect_assume cl_khr_extended_bit_ops cl_khr_extended_versioning cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_il_program cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_integer_dot_product cl_khr_spirv_no_integer_wrap_decoration cl_khr_spirv_queries cl_khr_suggested_local_work_size cl_ext_immutable_memory_objects cl_khr_spirv_linkonce_odr cl_khr_fp16 cles_khr_int64 cl_khr_kernel_clock cl_khr_image2d_from_buffer cl_khr_3d_image_writes cl_khr_depth_images cl_ext_image_unorm_int_2_101010 cl_khr_priority_hints cl_khr_device_uuid
+  Device Extensions with Version                  cl_khr_byte_addressable_store                                    0x400000 (1.0.0)
+                                                  cl_khr_create_command_queue                                      0x400000 (1.0.0)
+                                                  cl_khr_expect_assume                                             0x400000 (1.0.0)
+                                                  cl_khr_extended_bit_ops                                          0x400000 (1.0.0)
+                                                  cl_khr_extended_versioning                                       0x400000 (1.0.0)
+                                                  cl_khr_global_int32_base_atomics                                 0x400000 (1.0.0)
+                                                  cl_khr_global_int32_extended_atomics                             0x400000 (1.0.0)
+                                                  cl_khr_il_program                                                0x400000 (1.0.0)
+                                                  cl_khr_local_int32_base_atomics                                  0x400000 (1.0.0)
+                                                  cl_khr_local_int32_extended_atomics                              0x400000 (1.0.0)
+                                                  cl_khr_integer_dot_product                                       0x800000 (2.0.0)
+                                                  cl_khr_spirv_no_integer_wrap_decoration                          0x400000 (1.0.0)
+                                                  cl_khr_spirv_queries                                             0x400000 (1.0.0)
+                                                  cl_khr_suggested_local_work_size                                 0x400000 (1.0.0)
+                                                  cl_ext_immutable_memory_objects                                  0x400000 (1.0.0)
+                                                  cl_khr_spirv_linkonce_odr                                        0x400000 (1.0.0)
+                                                  cl_khr_fp16                                                      0x400000 (1.0.0)
+                                                  cles_khr_int64                                                   0x400000 (1.0.0)
+                                                  cl_khr_kernel_clock                                              0x400000 (1.0.0)
+                                                  cl_khr_image2d_from_buffer                                       0x400000 (1.0.0)
+                                                  cl_khr_3d_image_writes                                           0x400000 (1.0.0)
+                                                  cl_khr_depth_images                                              0x400000 (1.0.0)
+                                                  cl_ext_image_unorm_int_2_101010                                  0x400000 (1.0.0)
+                                                  cl_khr_priority_hints                                            0x400000 (1.0.0)
+                                                  cl_khr_device_uuid                                               0x400000 (1.0.0)
+
+NULL platform behavior
+  clGetPlatformInfo(NULL, CL_PLATFORM_NAME, ...)  rusticl
+  clGetDeviceIDs(NULL, CL_DEVICE_TYPE_ALL, ...)   Success [MESA]
+  clCreateContext(NULL, ...) [default]            Success [MESA]
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_DEFAULT)  Success (1)
+    Platform Name                                 rusticl
+    Device Name                                   FD690
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_CPU)  No devices found in platform
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_GPU)  Success (1)
+    Platform Name                                 rusticl
+    Device Name                                   FD690
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_ACCELERATOR)  No devices found in platform
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_CUSTOM)  No devices found in platform
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_ALL)  Success (1)
+    Platform Name                                 rusticl
+    Device Name                                   FD690
+
+ICD loader properties
+  ICD loader Name                                 OpenCL ICD Loader
+  ICD loader Vendor                               OCL Icd free software
+  ICD loader Version                              2.3.4
+  ICD loader Profile                              OpenCL 3.0
+
+```
+
+## OpenCL 信息
+
+### OpenCL 平台信息
+
+```text
+Platform Name        rusticl
+Platform Vendor      Mesa/X.org
+Platform Version     OpenCL 3.0
+Platform Profile     FULL_PROFILE
+```
+
+说明当前系统已启用 Mesa RustiCL OpenCL 平台，并支持 OpenCL 3.0 运行时。
+
+### GPU 设备信息
+
+```text
+Device Name          FD690
+Device Vendor        Qualcomm
+Device Type          GPU
+Device Available     Yes
+Driver Version       26.0.3-1ubuntu1
+```
+
+### OpenCL C 支持情况
+
+```text
+Device OpenCL C Version    OpenCL C 1.2
+```
+
+说明当前系统支持 OpenCL C 1.2。
+
+### ICD Loader 信息
+
+```text
+ICD loader Name      OpenCL ICD Loader
+ICD loader Vendor    OCL Icd free software
+ICD loader Version   2.3.4
+ICD loader Profile   OpenCL 3.0
+```

--- a/docs/dragon/q8b/system-config/rdp-login.md
+++ b/docs/dragon/q8b/system-config/rdp-login.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 2
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/system-config/_rdp_remote.mdx
+---
+
+import RDP_LOGIN from '../../../common/radxa-os/system-config/_rdp-remote-gnome.mdx';
+
+# RDP 登录
+
+<RDP_LOGIN desktop="gnome" board="dragon-q8b" />

--- a/docs/dragon/q8b/system-config/video.md
+++ b/docs/dragon/q8b/system-config/video.md
@@ -10,20 +10,17 @@ sidebar_position: 4
 
 - 系统镜像：[radxa-dragon-midstream rsdk-t2](https://github.com/radxa-build/radxa-dragon-midstream/releases/tag/rsdk-t2)
 - 内核版本：[linux-6.18.2](https://github.com/radxa/kernel/tree/linux-6.18.2)
-- SPI 固件：参考 [Dragon Q8B 资源汇总下载](../download) 中的 SPI 启动固件
   :::
 
 :::tip
 测试资源中的部分视频文件无法通过 GStreamer 正常播放。为保证测试条件一致，建议统一使用 FFmpeg 生成测试视频，再使用 GStreamer 调用硬件解码器进行验证。
 :::
 
+:::tip
+建议使用最新 BIOS 固件和系统进行测试！
+:::
+
 ## 前置准备
-
-### 硬件编码器 BIOS 配置
-
-在使用硬件编码器前，需要先在 BIOS 中启用以下选项：
-
-`Radxa Platform Configuration -> Hypervisor Settings -> Hypervisor Override in UEFI Setup`
 
 ### 安装 GStreamer
 

--- a/docs/dragon/q8b/system-config/video.md
+++ b/docs/dragon/q8b/system-config/video.md
@@ -4,20 +4,10 @@ sidebar_position: 4
 
 # 视频编解码测试指南
 
-本文档用于记录 Radxa Dragon Q8B 在指定镜像与内核版本下的视频编解码测试方法和结果。
-
-:::info 测试环境
-
-- 系统镜像：[radxa-dragon-midstream rsdk-t2](https://github.com/radxa-build/radxa-dragon-midstream/releases/tag/rsdk-t2)
-- 内核版本：[linux-6.18.2](https://github.com/radxa/kernel/tree/linux-6.18.2)
-  :::
+本文介绍如何在 Radxa Dragon Q8B 上使用 FFmpeg 生成测试视频，并通过 GStreamer 验证硬件编解码能力。
 
 :::tip
-测试资源中的部分视频文件无法通过 GStreamer 正常播放。为保证测试条件一致，建议统一使用 FFmpeg 生成测试视频，再使用 GStreamer 调用硬件解码器进行验证。
-:::
-
-:::tip
-建议使用最新 BIOS 固件和系统进行测试！
+建议使用最新 BIOS 固件和系统进行测试。测试资源中的部分视频文件无法通过 GStreamer 正常播放，为保证测试条件一致，建议统一使用 FFmpeg 生成测试视频，再使用 GStreamer 调用硬件解码器进行验证。
 :::
 
 ## 前置准备

--- a/docs/dragon/q8b/system-config/video.md
+++ b/docs/dragon/q8b/system-config/video.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 4
+---
+
+# 视频编解码测试指南
+
+本文档用于记录 Radxa Dragon Q8B 在指定镜像与内核版本下的视频编解码测试方法和结果。
+
+:::info 测试环境
+
+- 系统镜像：[radxa-dragon-midstream rsdk-t2](https://github.com/radxa-build/radxa-dragon-midstream/releases/tag/rsdk-t2)
+- 内核版本：[linux-6.18.2](https://github.com/radxa/kernel/tree/linux-6.18.2)
+- SPI 固件：参考 [Dragon Q8B 资源汇总下载](../download) 中的 SPI 启动固件
+  :::
+
+:::tip
+测试资源中的部分视频文件无法通过 GStreamer 正常播放。为保证测试条件一致，建议统一使用 FFmpeg 生成测试视频，再使用 GStreamer 调用硬件解码器进行验证。
+:::
+
+## 前置准备
+
+### 硬件编码器 BIOS 配置
+
+在使用硬件编码器前，需要先在 BIOS 中启用以下选项：
+
+`Radxa Platform Configuration -> Hypervisor Settings -> Hypervisor Override in UEFI Setup`
+
+### 安装 GStreamer
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+sudo apt update
+sudo apt install gstreamer1.0-tools
+```
+
+</NewCodeBlock>
+
+### 安装 FFmpeg
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+sudo apt install ffmpeg
+```
+
+</NewCodeBlock>
+
+## 解码示例
+
+以下示例统一使用 FFmpeg 生成 10 秒 1080p 30FPS 测试视频，再用 GStreamer 调用硬件解码器验证。
+
+### AVC / H.264 解码
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+ffmpeg -f lavfi -i testsrc=duration=10:size=1920x1080:rate=30 -c:v libx264 -pix_fmt yuv420p -preset fast -crf 18 1080p-AVC-8bit-30FPS.mp4
+gst-launch-1.0 filesrc location=./1080p-AVC-8bit-30FPS.mp4 ! qtdemux ! h264parse ! v4l2h264dec capture-io-mode=4 output-io-mode=4 ! video/x-raw,format=NV12 ! waylandsink fullscreen=true
+```
+
+</NewCodeBlock>
+
+### HEVC / H.265 解码
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+ffmpeg -f lavfi -i testsrc=duration=10:size=1920x1080:rate=30 -c:v libx265 -preset fast -pix_fmt yuv420p -crf 14 1080p-HEVC-8bit-30FPS.mp4
+gst-launch-1.0 filesrc location=./1080p-HEVC-8bit-30FPS.mp4 ! qtdemux ! h265parse ! v4l2h265dec capture-io-mode=4 output-io-mode=4 ! video/x-raw,format=NV12 ! waylandsink fullscreen=true
+```
+
+</NewCodeBlock>
+
+### VP9 解码
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+ffmpeg -f lavfi -i testsrc=duration=10:size=1920x1080:rate=30 -c:v libvpx-vp9 -pix_fmt yuv420p -b:v 0 -crf 30 -row-mt 1 -threads 8 1080p-VP9-8bit-30FPS.webm
+gst-launch-1.0 -e filesrc location=./1080p-VP9-8bit-30FPS.webm ! matroskademux ! v4l2vp9dec capture-io-mode=4 output-io-mode=4 ! video/x-raw,format=NV12 ! waylandsink fullscreen=true
+```
+
+</NewCodeBlock>
+
+## GStreamer 硬件编码验证
+
+当前仅保留 HEVC / H.265 1080p 30FPS 编码验证示例：
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+gst-launch-1.0 -e videotestsrc num-buffers=150 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! v4l2h265enc ! h265parse ! mp4mux ! filesink location=1080p-HEVC-8bit-30FPS.mp4
+gst-launch-1.0 filesrc location=./1080p-HEVC-8bit-30FPS.mp4 ! qtdemux ! h265parse ! v4l2h265dec capture-io-mode=4 output-io-mode=4 ! video/x-raw,format=NV12 ! waylandsink fullscreen=true
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/fcitx-usage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/fcitx-usage.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 4
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_fcitx_usage.mdx
+---
+
+import FCITX from '../../../common/radxa-os/system-config/_fcitx_usage.mdx';
+
+# Input Method Usage
+
+<FCITX debian_version="debian11" board="dragon-q8b" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/nomachine.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/nomachine.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 3
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_nomachine.mdx
+---
+
+import NO_MACHINE from '../../../common/radxa-os/system-config/_nomachine.mdx';
+
+# NoMachine Login
+
+<NO_MACHINE board="dragon-q8b" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/opencl.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/opencl.md
@@ -1,0 +1,311 @@
+---
+sidebar_position: 5
+---
+
+# OpenCL Usage Guide
+
+Install and verify OpenCL on the Dragon Q8B (based on Mesa RustiCL + Freedreno GPU).
+
+## Install OpenCL
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+
+sudo apt update
+sudo apt install mesa-opencl-icd -y
+
+```
+
+</NewCodeBlock>
+
+## Verify OpenCL
+
+Enable the Freedreno backend and view OpenCL info:
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+
+RUSTICL_ENABLE=freedreno clinfo
+
+```
+
+</NewCodeBlock>
+
+Example terminal output:
+
+```bash
+
+radxa@radxa-dragon-q8b:~$ RUSTICL_ENABLE=freedreno clinfo
+Number of platforms                               1
+  Platform Name                                   rusticl
+  Platform Vendor                                 Mesa/X.org
+  Platform Version                                OpenCL 3.0
+  Platform Profile                                FULL_PROFILE
+  Platform Extensions                             cl_khr_icd cl_khr_byte_addressable_store cl_khr_create_command_queue cl_khr_expect_assume cl_khr_extended_bit_ops cl_khr_extended_versioning cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_il_program cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_integer_dot_product cl_khr_spirv_no_integer_wrap_decoration cl_khr_spirv_queries cl_khr_suggested_local_work_size cl_ext_immutable_memory_objects cl_khr_spirv_linkonce_odr cl_khr_fp16 cles_khr_int64 cl_khr_kernel_clock cl_khr_image2d_from_buffer cl_khr_3d_image_writes cl_khr_depth_images cl_ext_image_unorm_int_2_101010 cl_khr_priority_hints cl_khr_device_uuid
+  Platform Extensions with Version                cl_khr_icd                                                       0x800000 (2.0.0)
+                                                  cl_khr_byte_addressable_store                                    0x400000 (1.0.0)
+                                                  cl_khr_create_command_queue                                      0x400000 (1.0.0)
+                                                  cl_khr_expect_assume                                             0x400000 (1.0.0)
+                                                  cl_khr_extended_bit_ops                                          0x400000 (1.0.0)
+                                                  cl_khr_extended_versioning                                       0x400000 (1.0.0)
+                                                  cl_khr_global_int32_base_atomics                                 0x400000 (1.0.0)
+                                                  cl_khr_global_int32_extended_atomics                             0x400000 (1.0.0)
+                                                  cl_khr_il_program                                                0x400000 (1.0.0)
+                                                  cl_khr_local_int32_base_atomics                                  0x400000 (1.0.0)
+                                                  cl_khr_local_int32_extended_atomics                              0x400000 (1.0.0)
+                                                  cl_khr_integer_dot_product                                       0x800000 (2.0.0)
+                                                  cl_khr_spirv_no_integer_wrap_decoration                          0x400000 (1.0.0)
+                                                  cl_khr_spirv_queries                                             0x400000 (1.0.0)
+                                                  cl_khr_suggested_local_work_size                                 0x400000 (1.0.0)
+                                                  cl_ext_immutable_memory_objects                                  0x400000 (1.0.0)
+                                                  cl_khr_spirv_linkonce_odr                                        0x400000 (1.0.0)
+                                                  cl_khr_fp16                                                      0x400000 (1.0.0)
+                                                  cles_khr_int64                                                   0x400000 (1.0.0)
+                                                  cl_khr_kernel_clock                                              0x400000 (1.0.0)
+                                                  cl_khr_image2d_from_buffer                                       0x400000 (1.0.0)
+                                                  cl_khr_3d_image_writes                                           0x400000 (1.0.0)
+                                                  cl_khr_depth_images                                              0x400000 (1.0.0)
+                                                  cl_ext_image_unorm_int_2_101010                                  0x400000 (1.0.0)
+                                                  cl_khr_priority_hints                                            0x400000 (1.0.0)
+                                                  cl_khr_device_uuid                                               0x400000 (1.0.0)
+  Platform Numeric Version                        0xc00000 (3.0.0)
+  Platform Extensions function suffix             MESA
+  Platform Host timer resolution                  1ns
+
+  Platform Name                                   rusticl
+Number of devices                                 1
+  Device Name                                     FD690
+  Device Vendor                                   Qualcomm
+  Device Vendor ID                                0x5143
+  Device Version                                  OpenCL 3.0
+  Device UUID                                     463bc9b2-20ab-14eb-a880-fe78d7aeeb54
+  Driver UUID                                     b251c0ed-95c4-4ac2-0c0b-6df49772396f
+  Valid Device LUID                               No
+  Device LUID                                     0000-000000000000
+  Device Node Mask                                0
+  Device Numeric Version                          0xc00000 (3.0.0)
+  Driver Version                                  26.0.3-1ubuntu1
+  Device OpenCL C Version                         OpenCL C 1.2
+  Device OpenCL C Numeric Version                 0x402000 (1.2.0)
+  Device OpenCL C all versions                    OpenCL C                                                         0xc00000 (3.0.0)
+                                                  OpenCL C                                                         0x402000 (1.2.0)
+                                                  OpenCL C                                                         0x401000 (1.1.0)
+                                                  OpenCL C                                                         0x400000 (1.0.0)
+  Device OpenCL C features                        __opencl_c_integer_dot_product_input_4x8bit                      0x800000 (2.0.0)
+                                                  __opencl_c_integer_dot_product_input_4x8bit_packed               0x800000 (2.0.0)
+                                                  __opencl_c_int64                                                 0x400000 (1.0.0)
+                                                  __opencl_c_kernel_clock_scope_device                             0x400000 (1.0.0)
+                                                  __opencl_c_kernel_clock_scope_sub_group                          0x400000 (1.0.0)
+                                                  __opencl_c_images                                                0x400000 (1.0.0)
+                                                  __opencl_c_read_write_images                                     0x400000 (1.0.0)
+                                                  __opencl_c_3d_image_writes                                       0x400000 (1.0.0)
+                                                  __opencl_c_ext_image_unorm_int_2_101010                          0x400000 (1.0.0)
+  Latest conformance test passed                  v0000-01-01-00
+  Device Type                                     GPU
+  Device Profile                                  EMBEDDED_PROFILE
+  Device Available                                Yes
+  Compiler Available                              Yes
+  Linker Available                                Yes
+  Max compute units                               8
+  Max clock frequency                             690MHz
+  Device Partition                                (core)
+    Max number of sub-devices                     0
+    Supported partition types                     None
+    Supported affinity domains                    (n/a)
+  Max work item dimensions                        3
+  Max work item sizes                             1024x1024x64
+  Max work group size                             2048
+  Preferred work group size multiple (device)     16
+  Preferred work group size multiple (kernel)     128
+  Max sub-groups per work group                   0
+  Preferred / native vector sizes
+    char                                                 1 / 1
+    short                                                1 / 1
+    int                                                  1 / 1
+    long                                                 1 / 1
+    half                                                 1 / 1        (cl_khr_fp16)
+    float                                                1 / 1
+    double                                               0 / 0        (n/a)
+  Half-precision Floating-point support           (cl_khr_fp16)
+    Denormals                                     No
+    Infinity and NANs                             Yes
+    Round to nearest                              Yes
+    Round to zero                                 No
+    Round to infinity                             No
+    IEEE754-2008 fused multiply-add               No
+    Support is emulated in software               No
+  Single-precision Floating-point support         (core)
+    Denormals                                     No
+    Infinity and NANs                             Yes
+    Round to nearest                              Yes
+    Round to zero                                 No
+    Round to infinity                             No
+    IEEE754-2008 fused multiply-add               No
+    Support is emulated in software               No
+    Correctly-rounded divide and sqrt operations  No
+  Double-precision Floating-point support         (n/a)
+  Address bits                                    64, Little-Endian
+  Global memory size                              16071417856 (14.97GiB)
+  Error Correction support                        No
+  Max memory allocation                           2147483647 (2GiB)
+  Unified memory for Host and Device              Yes
+  Shared Virtual Memory (SVM) capabilities        (core)
+    Coarse-grained buffer sharing                 No
+    Fine-grained buffer sharing                   No
+    Fine-grained system sharing                   No
+    Atomics                                       No
+  Minimum alignment for any data type             128 bytes
+  Alignment of base address                       4096 bits (512 bytes)
+  Preferred alignment for atomics
+    SVM                                           0 bytes
+    Global                                        0 bytes
+    Local                                         0 bytes
+  Atomic memory capabilities                      relaxed, work-group scope
+  Atomic fence capabilities                       relaxed, acquire/release, work-group scope
+  Max size for global variable                    0
+  Preferred total size of global vars             0
+  Global Memory cache type                        None
+  Image support                                   Yes
+    Max number of samplers per kernel             16
+    Max size for 1D images from buffer            134217727 pixels
+    Max 1D or 2D image array size                 2048 images
+    Base address alignment for 2D image buffers   64 bytes
+    Pitch alignment for 2D image buffers          64 pixels
+    Max 2D image size                             16384x16384 pixels
+    Max 3D image size                             2048x2048x2048 pixels
+    Max number of read image args                 16
+    Max number of write image args                32
+    Max number of read/write image args           32
+  Pipe support                                    No
+  Max number of pipe args                         0
+  Max active pipe reservations                    0
+  Max pipe packet size                            0
+  Local memory type                               Global
+  Local memory size                               32768 (32KiB)
+  Max number of constant args                     16
+  Max constant buffer size                        67108864 (64MiB)
+  Generic address space support                   No
+  Max size of kernel argument                     4096 (4KiB)
+  Queue properties (on host)
+    Out-of-order execution                        Yes
+    Profiling                                     Yes
+  Device enqueue capabilities                     (n/a)
+  Queue properties (on device)
+    Out-of-order execution                        No
+    Profiling                                     No
+    Preferred size                                0
+    Max size                                      0
+  Max queues on device                            0
+  Max events on device                            0
+  Prefer user sync for interop                    Yes
+  Profiling timer resolution                      52ns
+  Execution capabilities
+    Run OpenCL kernels                            Yes
+    Run native kernels                            No
+    Non-uniform work-groups                       No
+    Work-group collective functions               No
+    Sub-group independent forward progress        No
+    IL version                                    SPIR-V_1.0 SPIR-V_1.1 SPIR-V_1.2 SPIR-V_1.3 SPIR-V_1.4 SPIR-V_1.5 SPIR-V_1.6
+    ILs with version                              SPIR-V                                                           0x400000 (1.0.0)
+                                                  SPIR-V                                                           0x401000 (1.1.0)
+                                                  SPIR-V                                                           0x402000 (1.2.0)
+                                                  SPIR-V                                                           0x403000 (1.3.0)
+                                                  SPIR-V                                                           0x404000 (1.4.0)
+                                                  SPIR-V                                                           0x405000 (1.5.0)
+                                                  SPIR-V                                                           0x406000 (1.6.0)
+  printf() buffer size                            1048576 (1024KiB)
+  Built-in kernels                                (n/a)
+  Built-in kernels with version                   (n/a)
+  Device Extensions                               cl_khr_byte_addressable_store cl_khr_create_command_queue cl_khr_expect_assume cl_khr_extended_bit_ops cl_khr_extended_versioning cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_il_program cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_integer_dot_product cl_khr_spirv_no_integer_wrap_decoration cl_khr_spirv_queries cl_khr_suggested_local_work_size cl_ext_immutable_memory_objects cl_khr_spirv_linkonce_odr cl_khr_fp16 cles_khr_int64 cl_khr_kernel_clock cl_khr_image2d_from_buffer cl_khr_3d_image_writes cl_khr_depth_images cl_ext_image_unorm_int_2_101010 cl_khr_priority_hints cl_khr_device_uuid
+  Device Extensions with Version                  cl_khr_byte_addressable_store                                    0x400000 (1.0.0)
+                                                  cl_khr_create_command_queue                                      0x400000 (1.0.0)
+                                                  cl_khr_expect_assume                                             0x400000 (1.0.0)
+                                                  cl_khr_extended_bit_ops                                          0x400000 (1.0.0)
+                                                  cl_khr_extended_versioning                                       0x400000 (1.0.0)
+                                                  cl_khr_global_int32_base_atomics                                 0x400000 (1.0.0)
+                                                  cl_khr_global_int32_extended_atomics                             0x400000 (1.0.0)
+                                                  cl_khr_il_program                                                0x400000 (1.0.0)
+                                                  cl_khr_local_int32_base_atomics                                  0x400000 (1.0.0)
+                                                  cl_khr_local_int32_extended_atomics                              0x400000 (1.0.0)
+                                                  cl_khr_integer_dot_product                                       0x800000 (2.0.0)
+                                                  cl_khr_spirv_no_integer_wrap_decoration                          0x400000 (1.0.0)
+                                                  cl_khr_spirv_queries                                             0x400000 (1.0.0)
+                                                  cl_khr_suggested_local_work_size                                 0x400000 (1.0.0)
+                                                  cl_ext_immutable_memory_objects                                  0x400000 (1.0.0)
+                                                  cl_khr_spirv_linkonce_odr                                        0x400000 (1.0.0)
+                                                  cl_khr_fp16                                                      0x400000 (1.0.0)
+                                                  cles_khr_int64                                                   0x400000 (1.0.0)
+                                                  cl_khr_kernel_clock                                              0x400000 (1.0.0)
+                                                  cl_khr_image2d_from_buffer                                       0x400000 (1.0.0)
+                                                  cl_khr_3d_image_writes                                           0x400000 (1.0.0)
+                                                  cl_khr_depth_images                                              0x400000 (1.0.0)
+                                                  cl_ext_image_unorm_int_2_101010                                  0x400000 (1.0.0)
+                                                  cl_khr_priority_hints                                            0x400000 (1.0.0)
+                                                  cl_khr_device_uuid                                               0x400000 (1.0.0)
+
+NULL platform behavior
+  clGetPlatformInfo(NULL, CL_PLATFORM_NAME, ...)  rusticl
+  clGetDeviceIDs(NULL, CL_DEVICE_TYPE_ALL, ...)   Success [MESA]
+  clCreateContext(NULL, ...) [default]            Success [MESA]
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_DEFAULT)  Success (1)
+    Platform Name                                 rusticl
+    Device Name                                   FD690
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_CPU)  No devices found in platform
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_GPU)  Success (1)
+    Platform Name                                 rusticl
+    Device Name                                   FD690
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_ACCELERATOR)  No devices found in platform
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_CUSTOM)  No devices found in platform
+  clCreateContextFromType(NULL, CL_DEVICE_TYPE_ALL)  Success (1)
+    Platform Name                                 rusticl
+    Device Name                                   FD690
+
+ICD loader properties
+  ICD loader Name                                 OpenCL ICD Loader
+  ICD loader Vendor                               OCL Icd free software
+  ICD loader Version                              2.3.4
+  ICD loader Profile                              OpenCL 3.0
+
+```
+
+## OpenCL Information
+
+### OpenCL platform information
+
+```text
+Platform Name        rusticl
+Platform Vendor      Mesa/X.org
+Platform Version     OpenCL 3.0
+Platform Profile     FULL_PROFILE
+```
+
+This indicates that the Mesa RustiCL OpenCL platform is enabled and supports the OpenCL 3.0 runtime.
+
+### GPU device information
+
+```text
+Device Name          FD690
+Device Vendor        Qualcomm
+Device Type          GPU
+Device Available     Yes
+Driver Version       26.0.3-1ubuntu1
+```
+
+### OpenCL C support
+
+```text
+Device OpenCL C Version    OpenCL C 1.2
+```
+
+This indicates that the system supports OpenCL C 1.2.
+
+### ICD loader information
+
+```text
+ICD loader Name      OpenCL ICD Loader
+ICD loader Vendor    OCL Icd free software
+ICD loader Version   2.3.4
+ICD loader Profile   OpenCL 3.0
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/rdp-login.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/rdp-login.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 2
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_rdp_remote.mdx
+---
+
+import RDP_LOGIN from '../../../common/radxa-os/system-config/_rdp-remote-gnome.mdx';
+
+# RDP Login
+
+<RDP_LOGIN desktop="gnome" board="dragon-q8b" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/video.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/video.md
@@ -10,20 +10,17 @@ This document records the video codec test methods and results for Radxa Dragon 
 
 - System image: [radxa-dragon-midstream rsdk-t2](https://github.com/radxa-build/radxa-dragon-midstream/releases/tag/rsdk-t2)
 - Kernel version: [linux-6.18.2](https://github.com/radxa/kernel/tree/linux-6.18.2)
-- SPI firmware: refer to the SPI firmware listed on the [Dragon Q8B download page](../download)
   :::
 
 :::tip
 Some sample videos in the test resources cannot be played correctly with GStreamer. To keep the test conditions consistent, it is recommended to generate all test videos with FFmpeg first, and then validate hardware decoding with GStreamer.
 :::
 
+:::tip
+It is recommended to test with the latest BIOS firmware and system image!
+:::
+
 ## Preparation
-
-### BIOS Setting for Hardware Encoder
-
-Before using the hardware encoder, enable the following BIOS option:
-
-`Radxa Platform Configuration -> Hypervisor Settings -> Hypervisor Override in UEFI Setup`
 
 ### Install GStreamer
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/video.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/video.md
@@ -4,20 +4,10 @@ sidebar_position: 4
 
 # Video Codec Test Guide
 
-This document records the video codec test methods and results for Radxa Dragon Q8B under the specified image and kernel versions.
-
-:::info Test Environment
-
-- System image: [radxa-dragon-midstream rsdk-t2](https://github.com/radxa-build/radxa-dragon-midstream/releases/tag/rsdk-t2)
-- Kernel version: [linux-6.18.2](https://github.com/radxa/kernel/tree/linux-6.18.2)
-  :::
+This guide shows how to generate test videos with FFmpeg and validate hardware video encode/decode on Radxa Dragon Q8B using GStreamer.
 
 :::tip
-Some sample videos in the test resources cannot be played correctly with GStreamer. To keep the test conditions consistent, it is recommended to generate all test videos with FFmpeg first, and then validate hardware decoding with GStreamer.
-:::
-
-:::tip
-It is recommended to test with the latest BIOS firmware and system image!
+It is recommended to test with the latest BIOS firmware and system image. Some sample videos in the test resources cannot be played correctly with GStreamer. To keep the test conditions consistent, generate all test videos with FFmpeg first, and then validate hardware decoding with GStreamer.
 :::
 
 ## Preparation

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/video.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/video.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 4
+---
+
+# Video Codec Test Guide
+
+This document records the video codec test methods and results for Radxa Dragon Q8B under the specified image and kernel versions.
+
+:::info Test Environment
+
+- System image: [radxa-dragon-midstream rsdk-t2](https://github.com/radxa-build/radxa-dragon-midstream/releases/tag/rsdk-t2)
+- Kernel version: [linux-6.18.2](https://github.com/radxa/kernel/tree/linux-6.18.2)
+- SPI firmware: refer to the SPI firmware listed on the [Dragon Q8B download page](../download)
+  :::
+
+:::tip
+Some sample videos in the test resources cannot be played correctly with GStreamer. To keep the test conditions consistent, it is recommended to generate all test videos with FFmpeg first, and then validate hardware decoding with GStreamer.
+:::
+
+## Preparation
+
+### BIOS Setting for Hardware Encoder
+
+Before using the hardware encoder, enable the following BIOS option:
+
+`Radxa Platform Configuration -> Hypervisor Settings -> Hypervisor Override in UEFI Setup`
+
+### Install GStreamer
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+sudo apt update
+sudo apt install gstreamer1.0-tools
+```
+
+</NewCodeBlock>
+
+### Install FFmpeg
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+sudo apt install ffmpeg
+```
+
+</NewCodeBlock>
+
+## Decode Examples
+
+The following examples use FFmpeg to generate a 10-second 1080p 30FPS test video, and then use GStreamer to validate hardware decoding.
+
+### AVC / H.264 Decode
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+ffmpeg -f lavfi -i testsrc=duration=10:size=1920x1080:rate=30 -c:v libx264 -pix_fmt yuv420p -preset fast -crf 18 1080p-AVC-8bit-30FPS.mp4
+gst-launch-1.0 filesrc location=./1080p-AVC-8bit-30FPS.mp4 ! qtdemux ! h264parse ! v4l2h264dec capture-io-mode=4 output-io-mode=4 ! video/x-raw,format=NV12 ! waylandsink fullscreen=true
+```
+
+</NewCodeBlock>
+
+### HEVC / H.265 Decode
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+ffmpeg -f lavfi -i testsrc=duration=10:size=1920x1080:rate=30 -c:v libx265 -preset fast -pix_fmt yuv420p -crf 14 1080p-HEVC-8bit-30FPS.mp4
+gst-launch-1.0 filesrc location=./1080p-HEVC-8bit-30FPS.mp4 ! qtdemux ! h265parse ! v4l2h265dec capture-io-mode=4 output-io-mode=4 ! video/x-raw,format=NV12 ! waylandsink fullscreen=true
+```
+
+</NewCodeBlock>
+
+### VP9 Decode
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+ffmpeg -f lavfi -i testsrc=duration=10:size=1920x1080:rate=30 -c:v libvpx-vp9 -pix_fmt yuv420p -b:v 0 -crf 30 -row-mt 1 -threads 8 1080p-VP9-8bit-30FPS.webm
+gst-launch-1.0 -e filesrc location=./1080p-VP9-8bit-30FPS.webm ! matroskademux ! v4l2vp9dec capture-io-mode=4 output-io-mode=4 ! video/x-raw,format=NV12 ! waylandsink fullscreen=true
+```
+
+</NewCodeBlock>
+
+## GStreamer Hardware Encode Validation
+
+Only the HEVC / H.265 1080p 30FPS encode validation example is kept below:
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+gst-launch-1.0 -e videotestsrc num-buffers=150 ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 ! v4l2h265enc ! h265parse ! mp4mux ! filesink location=1080p-HEVC-8bit-30FPS.mp4
+gst-launch-1.0 filesrc location=./1080p-HEVC-8bit-30FPS.mp4 ! qtdemux ! h265parse ! v4l2h265dec capture-io-mode=4 output-io-mode=4 ! video/x-raw,format=NV12 ! waylandsink fullscreen=true
+```
+
+</NewCodeBlock>


### PR DESCRIPTION
## Summary

Add the system-config tutorials for Radxa Dragon Q8B by adapting the
existing Dragon Q6A pages, with the BIOS path correction and the
verified OpenCL output captured on Q8B.

- `rdp-login.md`, `nomachine.md`, `fcitx-usage.md`: same wrapper
  structure as Q6A, just scoped to `dragon-q8b`.
- `video.md`: copy of the Q6A video codec test guide, but with the
  hardware encoder BIOS path updated to
  `Radxa Platform Configuration -> Hypervisor Settings -> Hypervisor
  Override in UEFI Setup` (the path observed on Q8B). System image
  reference follows the current Q8B image (rsdk-t2) and the kernel
  reference uses the same `linux-6.18.2` branch as Q6A.
- `opencl.md`: example `RUSTICL_ENABLE=freedreno clinfo` output and
  summary tables updated to the Q8B (FD690) run:
  - single `rusticl` platform (no Clover fallback),
  - FD690 GPU, Qualcomm vendor, 8 compute units, 690MHz,
  - `mesa-opencl-icd` 26.0.3-1ubuntu1, ICD loader 2.3.4,
  - 14.97GiB global memory, half-precision via `cl_khr_fp16`.

Both Chinese (`docs/`) and English (`i18n/en/...`) versions are added
together so the i18n / drift guards stay green.

## Source / verification

- OpenCL example output and Mesa / ICD versions verified on
  `radxa-dragon-q8b` (rsdk-t2) with `mesa-opencl-icd 26.0.3-1ubuntu1`.
- BIOS path correction verified against the Q8B UEFI Setup.
- No source-of-truth `common/radxa-os/system-config/*` files were
  modified.

## Checklist

- [x] Branch based on `radxa-docs/docs:main` (1 commit ahead)
- [x] `bash scripts/agent-doc-drift-guard.sh` passes
- [x] `bash scripts/agent-doc-translation-guard.sh` passes
- [x] `bash scripts/agent-doc-lint.sh <changed files>` passes
- [x] Chinese and English versions are updated together