### PR TITLE
docs(linkr): translate Linkr series tutorials to English

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/README.md
@@ -1,0 +1,6 @@
+---
+sidebar_position: 1
+slug: /linkr
+---
+
+# Linkr Series

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 2
+---
+
+# Linkr KVM
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/access-token.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/access-token.mdx
@@ -1,0 +1,167 @@
+---
+sidebar_position: 5
+---
+
+# Access Tokens
+
+Linkr KVM provides the **Access Token** feature for programmatically accessing some of the KVM's capabilities through the API without a web login session. It is suitable for automation scripts, monitoring integration, third-party tool calls, and similar scenarios.
+
+An access token is the equivalent of an API key. Once created, it can be used to call the device's public API endpoints.
+
+## Feature Overview
+
+| Capability | Description |
+| --- | --- |
+| Web UI management | Create, view name, and delete access tokens in System Settings |
+| Password verification | The KVM login password is required when generating a new token to prevent unauthorized creation |
+| One-time display | The plaintext token is only shown once at creation; it cannot be viewed again after the dialog is closed |
+| Persistent storage | Tokens are saved in the device's local configuration, remain valid after restart, and stay active until manually deleted |
+
+## Applicable Scenarios
+
+- **Remote screenshots**: Periodically capture the KVM's current screen snapshot for monitoring or inspection
+- **Remote control**: Send control commands (keyboard, mouse, etc.) through the API
+- **Automation integration**: Integrate the KVM into CI/CD, operations platforms, or custom scripts
+
+:::caution Security Notice
+Access tokens have API access permissions comparable to the creator. Please keep them safe; do not commit them to public code repositories or share them with untrusted parties. If a token is leaked, delete it in the management interface and generate a new one immediately.
+:::
+
+## Operation Steps
+
+### 1. Go to System Settings
+
+1. Open the KVM management web interface and log in.
+2. Click **System Settings** (the settings icon) in the left sidebar.
+3. Find the **Access Tokens** collapsible panel.
+
+### 2. Generate a New Token
+
+1. Click the **+ Generate** button, and the "Access Token" dialog will pop up.
+2. Fill in the **Secret Name** (required):
+   - Only lowercase letters `a-z`, digits `0-9`, and hyphens `-` are allowed
+   - Must start with a letter or digit, and cannot start or end with `-`
+   - Up to 20 characters
+   - Examples: `monitor-script`, `ci-deploy-01`
+3. Fill in the **User Password** (required): Enter the current KVM management account's login password for identity verification.
+4. Click the green **Generate** button.
+
+### 3. Save the Token
+
+After successful generation, the dialog will display the complete access token string (prefixed with `radxa_linkr_`).
+
+1. Click the **Copy** icon to the right of the token and save it to a secure location (password manager, secrets management system, etc.).
+2. Once you have confirmed it is safely saved, close the dialog.
+
+:::warning Important
+The plaintext token **is only shown once at creation**. After the dialog is closed, neither the UI nor the API can retrieve the full token. If the token is lost, you can only delete the old entry and generate a new one.
+:::
+
+### 4. Manage Existing Tokens
+
+In the **Access Tokens** panel, created tokens are shown as a list of **Secret Names**:
+
+- The list **does not display** the plaintext token, only the name, to make it easy to identify its purpose.
+- Click the **Delete** icon to the right of an entry and confirm to revoke the token. It will become invalid immediately.
+
+## Using Access Tokens to Call the API
+
+### Authentication
+
+Carry the access token in the HTTP request header:
+
+```
+Authorization: token <your access token>
+```
+
+Example:
+
+```bash
+curl -H "Authorization: token radxa_linkr_xxxxxxxx" \
+  https://<kvm-ip>/api/public/snapshot \
+  --output snapshot.jpg
+```
+
+Replace `<kvm-ip>` with the KVM's actual IP address or domain name (a LAN IP, Tailscale IP, etc. are all fine).
+
+### Available Public APIs
+
+The public endpoints currently supported for access-token-based authentication are listed below:
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/api/public/snapshot` | GET | Get the current frame as a JPEG snapshot |
+| `/api/public/control` | POST | Send remote control commands (request body is the control protocol data) |
+
+#### Example: Get a Snapshot
+
+```bash
+curl -H "Authorization: token radxa_linkr_xxxxxxxx" \
+  "https://192.168.1.100/api/public/snapshot" \
+  -o snapshot.jpg
+```
+
+On success, an `image/jpeg` image is returned.
+
+#### Example: Send a Control Command
+
+```bash
+curl -X POST \
+  -H "Authorization: token radxa_linkr_xxxxxxxx" \
+  -H "Content-Type: application/json" \
+  -d '<control data>' \
+  "https://192.168.1.100/api/public/control"
+```
+
+The format of the control data depends on the KVM control protocol. Refer to the API documentation or the integration SDK for the specific fields.
+
+### Authentication Failure
+
+If the response is `403 No Permission`, please check:
+
+- The `Authorization` header is in the format `token <token>` (note there is a single space between `token` and the token)
+- The token is complete and not truncated
+- The token has not been deleted
+- The KVM device's IP address or network is reachable
+
+## Token Format
+
+- **Prefix**: `radxa_linkr_`
+- **Body**: A Base64 URL-encoded random string (about 86 characters)
+- **Example**: `radxa_linkr_-yDJ3JYDST0BygX5ltq1aFfOom0imn6hnfLTrl4-fDgHTkO8Uk0vdkf_Gxuia_T-fn07GJmZ_MDvhRLnLQ73WA`
+
+The name of each token must be unique on the device. You cannot create two tokens with the same name.
+
+## Security Recommendations
+
+1. **Principle of least privilege**: Create tokens with different names for different purposes so they can be revoked individually.
+2. **Rotate regularly**: Periodically delete old tokens and generate new ones, especially after personnel changes or script migrations.
+3. **Secure storage**: Use environment variables or secrets management tools to store tokens. Do not hardcode them in source code.
+4. **HTTPS access**: In production, access the KVM API over HTTPS to prevent tokens from being intercepted in transit.
+5. **Revoke promptly**: If a token is leaked or no longer used, delete it in System Settings immediately.
+
+## FAQ
+
+### "Invalid Name Format" Message
+
+The secret name does not follow the rules. Please make sure that:
+
+- It only contains `a-z`, `0-9`, and `-`
+- It starts with a letter or digit
+- It does not end with `-`
+
+### "Wrong Password" Message
+
+The user password entered when generating the token is not the KVM login password. Use the correct password of the current management account.
+
+### "Name Already Exists" Message
+
+You cannot create two tokens with the same name on the same device. Use a different secret name, or first delete the old one with the same name.
+
+### Copy Failed
+
+If the browser does not support the Clipboard API (for example, a non-HTTPS and non-localhost environment), manually select the token text to copy.
+
+### The Script Still Gets 403 After Deleting the Token
+
+The deletion takes effect immediately. Update the script or environment to use the new token, or regenerate and reconfigure it.

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/advanced-usage/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/advanced-usage/README.md
@@ -1,0 +1,5 @@
+---
+sidebar_position: 6
+---
+
+# Advanced Usage

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/advanced-usage/remote-access.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/advanced-usage/remote-access.mdx
@@ -1,0 +1,132 @@
+---
+sidebar_position: 1
+---
+
+# Tailscale Remote Access
+
+Linkr KVM has a built-in [Tailscale](https://tailscale.com/) client that can join the device to your Tailscale virtual private network (VPN), allowing you to securely access the KVM management interface from anywhere over an encrypted tunnel, with no public IP or manual port forwarding required.
+
+Tailscale is based on the WireGuard protocol. The Tailscale coordination server handles node discovery and key exchange, and devices establish point-to-point encrypted connections with each other.
+
+## Feature Overview
+
+| Capability | Description |
+| --- | --- |
+| Built-in client | The firmware pre-installs the `tailscale` / `tailscaled` binaries; no extra installation is required |
+| Web UI management | Enable, log in, and unbind the Tailscale account in the KVM management interface |
+| Auto-start on boot | Once enabled, the configuration persists and `tailscaled` starts automatically after the device reboots |
+| Secure networking | Traffic is encrypted by WireGuard; only devices within the same Tailnet can communicate with each other |
+
+## Before You Start
+
+1. **Tailscale account**: Register a personal or team account on [tailscale.com](https://tailscale.com/) (the free plan is sufficient for personal use).
+2. **Network connection**: The KVM device must be able to access the Internet (RJ45 wired or Wi-Fi is fine) in order to communicate with the Tailscale coordination server.
+3. **Browser**: When binding an account, you need to complete Tailscale authorization in a browser. Please make sure the management browser allows pop-ups.
+
+## Operation Steps
+
+### 1. Go to the Settings Page
+
+1. Open the KVM management web interface and log in.
+2. In the left sidebar, go to **System** → **Advanced Settings**.
+3. Find the **Tailscale** option.
+
+### 2. Enable Tailscale
+
+Turn on the **Tailscale** switch. Once enabled, the device starts the `tailscaled` background service and writes the setting to the local configuration. The setting persists after a reboot.
+
+Turning off the switch stops the `tailscaled` service, and the device will be disconnected from the Tailnet (the bound account information is retained, but you need to re-bind the next time you enable it).
+
+### 3. Bind a Tailscale Account
+
+1. Confirm that Tailscale is enabled.
+2. Click **Bind**.
+3. The system will automatically open a browser window and redirect to the Tailscale login/authorization page.
+4. Log in with your Tailscale account and confirm on the authorization page to add this device to the Tailnet.
+5. After a successful authorization, the page displays the bound account name, and the status changes to authenticated.
+
+If the pop-up is blocked by the browser, please allow pop-ups for the current site and try again, or manually copy the authorization link to a new tab.
+
+![img](/img/linkr/tailscale-1.jpg)
+
+![img](/img/linkr/tailscale-2.png)
+
+![img](/img/linkr/tailscale-3.png)
+
+### 4. Access the KVM via Tailscale
+
+After a successful binding, you can view the Tailscale IP assigned to the device (usually in the `100.x.x.x` range) in the [Tailscale admin console](https://login.tailscale.com/admin/machines).
+
+On any device within the same Tailnet, use the following address to access the KVM:
+
+```
+https://<device's Tailscale IP>
+```
+
+You can also use the Tailscale MagicDNS hostname (if MagicDNS is enabled in the Tailnet):
+
+```
+https://<device hostname>.<your-tailnet>.ts.net
+```
+
+:::tip Note
+When accessing through Tailscale, you still need to use the KVM's local login credentials (username and password). Tailscale only provides network-layer connectivity and does not replace KVM authentication.
+:::
+
+### 5. Unbind the Account
+
+To remove the device from the Tailnet or switch to another account:
+
+1. Click **Unbind** on the Tailscale settings page.
+2. Wait for the operation to complete; the account information will be cleared.
+3. You can click **Bind** again to associate a different Tailscale account.
+
+## Interface Status Description
+
+| Status | Meaning |
+| --- | --- |
+| Switch off | Tailscale is not enabled; `tailscaled` is not running |
+| Switch on, not bound | The service is started, waiting to bind a Tailscale account |
+| Switch on, bound | The device has joined the Tailnet and can be accessed via the Tailscale IP |
+| Version number | Shows the version of the Tailscale client built into the firmware |
+
+## Technical Notes
+
+### Firmware Integration
+
+The Tailscale client is packaged into the firmware as built-in binaries:
+
+### Relationship with Local Access
+
+Enabling Tailscale does not affect the KVM's local network access. The device can still be accessed through the LAN IP, Wi-Fi, or USB network, and Tailscale works as an additional remote access channel on top of these.
+
+## FAQ
+
+### Binding Fails or Has No Response for a Long Time
+
+- Confirm that the KVM device is connected to the Internet.
+- Check whether the browser has blocked pop-ups.
+- Confirm that the Tailscale coordination server (`controlplane.tailscale.com`) is not blocked by a firewall.
+- Try turning Tailscale off and on again, then re-bind.
+
+### Cannot Access via the Tailscale IP After Enabling
+
+- In the Tailscale admin console, confirm the device is online.
+- Confirm that the accessing client and the KVM are in the same Tailnet.
+- Check that the Tailscale client on the accessing device is connected.
+- Confirm that you are using the `https://` protocol and the correct Tailscale IP.
+
+### Tailscale Does Not Auto-Connect After Reboot
+
+- Make sure the enable switch is on before the reboot.
+- If the account has already been bound, the connection should resume automatically after a reboot. If the device is in an unbound state, you need to re-bind.
+
+### The Device Still Appears in the Tailscale Admin Console After Unbinding
+
+Unbinding runs `tailscale logout` on the device. If the device still shows as an offline node in the admin console, you can manually delete the device record in the [Tailscale admin console](https://login.tailscale.com/admin/machines).
+
+## Related Links
+
+- [Tailscale Official Documentation](https://tailscale.com/kb/)
+- [Tailscale Admin Console](https://login.tailscale.com/admin/machines)
+- [WireGuard Protocol](https://www.wireguard.com/)

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/advanced-usage/wake-on-lan.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/advanced-usage/wake-on-lan.mdx
@@ -1,0 +1,152 @@
+---
+sidebar_position: 2
+---
+
+# Wake on LAN Device Wakeup
+
+Linkr KVM supports **Wake on LAN (WOL)**, which lets you remotely power on a target computer that is shut down or in sleep mode by sending a Magic Packet from the KVM to the target's network card — no need to press the power button in person.
+
+The KVM and the target computer are usually in the same LAN through a network cable or a switch. After the wake-up packet is sent, the target machine will start up once it receives a broadcast packet that matches its MAC address.
+
+## Feature Overview
+
+| Capability | Description |
+| --- | --- |
+| Web UI operation | Enter the MAC address in the management interface and send the wake-up packet with one click |
+| Standard WOL protocol | Sends a 102-byte standard Magic Packet via UDP broadcast to `255.255.255.255:9` |
+| MAC address validation | Supports `:` or `-` separated 6-byte MAC format; invalid input is reported with an error |
+
+## Before You Start
+
+Before using the KVM to wake up the target computer, please confirm that WOL has been correctly configured on the target machine:
+
+### 1. Enable Wake on LAN in BIOS/UEFI
+
+Enter the target computer's BIOS/UEFI settings and find and enable the following options (names vary by motherboard vendor):
+
+- **Wake on LAN**
+- **Power On By PCI-E / PME**
+- **Resume by LAN**
+
+Some motherboards require that the network card stays powered when the system is off (ErP / deep energy-saving related options need to be disabled).
+
+### 2. Enable Network Card Wake in the Operating System
+
+**Windows:**
+
+1. Open "Device Manager" → Network adapters → target network card properties.
+2. In "Advanced", enable **Wake on Magic Packet** (or a similar option).
+3. In "Power Management", check **Allow this device to wake the computer**.
+
+**Linux:**
+
+Use `ethtool` to check and enable (using `eth0` as an example):
+
+```bash
+sudo ethtool eth0 | grep Wake-on
+sudo ethtool -s eth0 wol g
+```
+
+### 3. Network Connection Requirements
+
+- After the target computer is powered off, the **wired network card** must remain physically connected to the network (network cable, switch, or the same LAN segment as the KVM).
+- The KVM and the target computer should be in the **same Layer 2 broadcast domain** (same LAN or VLAN); the wake-up packet is sent as a UDP broadcast.
+- Wireless network cards generally have poor WOL support. It is recommended to use the MAC address of the wired network port.
+
+### 4. Get the Target MAC Address
+
+With the target computer powered on, view the network card MAC address through a system command or the router's admin page, for example:
+
+- Windows: `ipconfig /all`
+- Linux: `ip link show`
+- macOS: `ifconfig`
+
+Write down the MAC address of the network card that is connected to the KVM's LAN.
+
+## Operation Steps
+
+### 1. Go to Advanced Settings
+
+1. Open the KVM management web interface and log in.
+2. Click **Advanced Settings** (the gear icon) at the bottom of the left sidebar.
+3. Find and expand the **Device Wakeup** collapsible panel on the page.
+
+### 2. Enter the MAC Address
+
+Fill in the target computer's network card MAC address in the **MAC Address** input field.
+
+Supported format examples:
+
+```
+00-E0-0C-1F-30-F1
+00:E0:0C:1F:30:F1
+```
+
+Each section has two hexadecimal digits, for a total of 6 sections, separated by `-` or `:` (case-insensitive).
+
+### 3. Send the Wake-Up Packet
+
+1. Confirm that the MAC address is entered correctly.
+2. Click the green **Wake Up** button on the right.
+3. Wait for the operation to complete:
+   - **Sent successfully**: The interface shows success. The target computer should start up within a few seconds to tens of seconds (depending on hardware and power state).
+   - **Send failed**: Please check the network connection and the WOL configuration on the target side, then try again.
+
+:::tip Note
+"Sent successfully" means the KVM has successfully sent the Magic Packet. It does not guarantee that the target computer will start. If the target side has not correctly configured WOL or is not in the same broadcast domain, the computer may still not wake up.
+:::
+
+## How It Works
+
+Wake on LAN uses the standard Magic Packet format:
+
+1. The packet body consists of 6 bytes of `0xFF` header followed by 16 repetitions of the target MAC address, for a total of 102 bytes.
+2. The KVM broadcasts the packet via UDP to `255.255.255.255:9` (the standard WOL port).
+3. The target network card listens for link-layer traffic in a powered-off / sleeping state. Once it identifies its own MAC, the motherboard powers on.
+
+```
+KVM management interface → Enter MAC → Click "Wake Up"
+       ↓
+  Construct Magic Packet (102 bytes)
+       ↓
+  UDP broadcast → 255.255.255.255:9
+       ↓
+  Target network card receives → motherboard powers on
+```
+
+## FAQ
+
+### "Invalid MAC Address" Message
+
+- Check that it is exactly 6 sections of 2 hexadecimal digits each.
+- Confirm that `-` or `:` is used as the separator. Do not use spaces or other symbols.
+- Example: `AA-BB-CC-DD-EE-FF` or `aa:bb:cc:dd:ee:ff`.
+
+### "Sent Successfully" but the Computer Does Not Power On
+
+- Confirm that Wake on LAN is enabled in the BIOS, and the network card wake-up is enabled in the operating system.
+- Confirm that you are using the **wired network card** MAC, and the network cable remains connected to the same LAN after power-off.
+- Check whether the motherboard has disabled power to the network card after shutdown (ErP, EuP, and other energy-saving options).
+- Some computers only support wake from **sleep / hibernation**, not from a full power-off (S5) state.
+- If the KVM and the target computer are not in the same network segment or VLAN, the broadcast packet may not reach the target network card.
+
+### Send Failed
+
+- Confirm the KVM device's network is normal. Being able to access the management interface indicates basic connectivity.
+- Check whether switches and routers between the KVM and the target device allow broadcast traffic to pass through.
+- Try again later. If it continues to fail, restart the KVM's network service or check the firmware version.
+
+### How to Confirm Which Network Card's MAC Is Being Used
+
+If the computer has multiple network cards (wired, wireless, virtual), use the **MAC of the wired network card that is actually connected to the KVM's LAN**. You can temporarily disable other network cards and run `ipconfig` / `ip link` to confirm.
+
+## Difference from the "Prevent Sleep" Feature
+
+The KVM also provides a **Prevent Sleep** feature: when connected to a remote computer, it periodically sends a tiny mouse movement to prevent the system from going to sleep. This feature applies to a scenario where **the computer is already powered on and connected through the KVM**.
+
+**Wake on LAN (Device Wakeup)** is used to **remotely power on a computer that is already shut down or in deep sleep** by sending a magic packet over the network. The two features have different uses; choose the one that fits your scenario.
+
+## Related Links
+
+- [Wake-on-LAN (Wikipedia)](https://en.wikipedia.org/wiki/Wake-on-LAN)
+- [IEEE 802.3 Magic Packet](https://en.wikipedia.org/wiki/Wake-on-LAN#Magic_packet)

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/develop-guide.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/develop-guide.mdx
@@ -1,0 +1,219 @@
+---
+sidebar_position: 7
+---
+
+# Developer Documentation
+
+## AI Agent Interface
+
+By calling the HTTP interfaces provided by Linkr (including screenshots, keyboard, and mouse control), you can remotely automate operations on the target machine.
+
+**Refer to the "How to generate an API Token" section in the user guide to obtain an API Token.**
+
+### Snapshot Interface
+
+- **URL**: `http://{linkr_ip}/api/public/snapshot`
+
+- **Method**: GET
+
+- **Purpose**: Get the current state of the target machine's screen for AI model analysis and decision making
+
+- **Returns**: A screen snapshot in JPEG format
+
+- **Request example:**
+
+```bash
+curl -X GET http://192.168.2.224:80/api/public/snapshot -H "Authorization: token {{your API Token}}" -o screen.jpeg
+```
+
+### Control Interface
+
+- **URL**: `http://{linkr_ip}/api/public/control`
+
+- **Method**: POST
+
+- **Purpose:** Send a sequence of events such as keyboard/mouse, text, and delay to remotely control the target machine
+
+- **Request example:**
+
+```bash
+curl -X POST http://192.168.2.224:80/api/public/control \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token {{your API Token}}" \
+  -d '{
+    "events": [
+      // Control interface event list. Each event is an array; the first element indicates the event type.
+      ["text", "Helloworld"],
+      ["delay", 300],
+      ["mouse_abs", 0, 0.1, 0.1, 0, 0],
+      ["keyboard", "MetaLeft", true],
+      ["keyboard", "MetaLeft", false],
+      ["mouse_abs", 0, 0.5, 0.5, 0, 0],
+      ["mouse_rel", 0, 100, 100, 0, 0]
+    ]
+  }'
+```
+
+- **Response:**
+
+```json
+{
+  "code": 0,                       // 0 indicates success; non-zero indicates failure
+  "data": null,
+  "message": "Request succeeded!"  // Returns error information on failure
+}
+```
+
+## Control Interface Parameter Details
+
+### Keyboard Event
+
+```bash
+["keyboard", keyCode, isPressed]
+```
+
+**Parameter description:**
+
+- Index 0: The fixed string `"keyboard"`, indicating pressing or releasing a key on the keyboard.
+
+- Index 1: Field type: String. The keyboard key identifier, using the web standard [`KeyboardEvent.code`](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values) value.
+
+- Index 2: Field type: Boolean. The key state; `true` means pressed, `false` means released.
+
+**Common key identifiers:**
+
+- `"MetaLeft"` - Left Meta key (Windows key / Command key)
+
+- `"KeyA"` - A key
+
+- `"KeyB"` - B key
+
+- `"KeyC"` - C key
+
+- `"KeyV"` - V key
+
+- `"Enter"` - Enter key
+
+- `"Escape"` - ESC key
+
+- `"Tab"` - Tab key
+
+- `"Space"` - Space key
+
+- `"ControlLeft"` - Left Ctrl key
+
+- `"AltLeft"` - Left Alt key
+
+- `"ShiftLeft"` - Left Shift key
+
+**Example:**
+
+```bash
+["keyboard", "MetaLeft", true],   // Press the Windows key
+["keyboard", "MetaLeft", false],  // Release the Windows key
+["keyboard", "KeyR", true],       // Press the R key
+["keyboard", "KeyR", false],      // Release the R key
+```
+
+### Absolute Mouse Event (`mouse_abs`)
+
+```bash
+["mouse_abs", 0, 0.1, 0.1, 0, 0],
+```
+
+**Parameter description:**
+
+- Index 0: The fixed string `"mouse_abs"`, indicating that the mouse moves using absolute coordinates. The origin is the top-left corner of the screen, and the X and Y coordinates are in the range [0.00, 1.00].
+
+- Index 1: Field type: Number. The mouse button state. `0` means no mouse button is pressed, or all mouse buttons are released. Bit 0 is the left button, bit 1 is the right button, and bit 2 is the middle (scroll) button. When multiple buttons are pressed at the same time, the corresponding values are added. For example, pressing both the left button (1) and the right button (2) gives 3 (i.e. 1 + 2).
+
+- Index 2: Field type: Number. The mouse's absolute X coordinate (0.00-1.00, with the top-left corner as the origin).
+
+- Index 3: Field type: Number. The mouse's absolute Y coordinate (0.00-1.00, with the top-left corner as the origin).
+
+- Index 4: Field type: Number. The mouse's vertical scroll value, in the range [-20, 20]. For example, a positive value (e.g. `n`) means the mouse scrolls down vertically by `n` pixels; a negative value (e.g. `-n`) means the mouse scrolls up vertically by `n` pixels.
+
+- Index 5: Field type: Number. The mouse's horizontal scroll value, in the range [-20, 20]. For example, a positive value (e.g. `n`) means the mouse scrolls right horizontally by `n` pixels; a negative value (e.g. `-n`) means the mouse scrolls left horizontally by `n` pixels.
+
+**Example:**
+
+```bash
+["mouse_abs", 0, 0.5, 0.5, 0, 0],      // Move the mouse to the center of the screen
+["mouse_abs", 1, 0.5, 0.5, 0, 0],      // Move the mouse to the center of the screen and click the left button
+["mouse_abs", 0, 0.5, 0.5, 0, 0],      // Move the mouse to the center of the screen and release the previously held mouse button
+["mouse_abs", 0, 0.5, 0.5, 20, 10],    // Move the mouse to the center of the screen, scroll the vertical wheel down by 20 pixels and the horizontal wheel right by 10 pixels
+```
+
+### Relative Mouse Event (`mouse_rel`)
+
+```bash
+["mouse_rel", 0, 100, 100, 0, 0],
+```
+
+**Parameter description:**
+
+- Index 0: The fixed string `"mouse_rel"`, indicating that the mouse moves using relative coordinates. The origin is the top-left corner of the screen, and the movement unit is pixels.
+
+- Index 1: Field type: Number. The mouse button state. `0` means no mouse button is pressed, or all mouse buttons are released. Bit 0 is the left button, bit 1 is the right button, and bit 2 is the middle (scroll) button. When multiple buttons are pressed at the same time, the corresponding values are added. For example, pressing both the left button (1) and the right button (2) gives 3 (i.e. 1 + 2).
+
+- Index 2: Field type: Number. The relative X movement in pixels. A positive value (e.g. `n`) means moving right by `n` pixels; a negative value (e.g. `-n`) means moving left by `n` pixels.
+
+- Index 3: Field type: Number. The relative Y movement in pixels. A positive value (e.g. `n`) means moving down by `n` pixels; a negative value (e.g. `-n`) means moving up by `n` pixels.
+
+- Index 4: Field type: Number. The mouse's vertical scroll value, in the range [-20, 20]. For example, a positive value (e.g. `n`) means the mouse scrolls down vertically by `n` pixels; a negative value (e.g. `-n`) means the mouse scrolls up vertically by `n` pixels.
+
+- Index 5: Field type: Number. The mouse's horizontal scroll value, in the range [-20, 20]. For example, a positive value (e.g. `n`) means the mouse scrolls right horizontally by `n` pixels; a negative value (e.g. `-n`) means the mouse scrolls left horizontally by `n` pixels.
+
+**Example:**
+
+```bash
+["mouse_rel", 0, 10, 10, 0, 0],        // From the current mouse position, move 10 pixels right and 10 pixels down
+["mouse_abs", 1, 0, 0, 0, 0],          // Click the left mouse button at the current position
+["mouse_abs", 0, 0, 0, 0, 0],          // Release the previously held mouse button at the current position
+["mouse_abs", 0, 10, 10, 20, 10],      // From the current mouse position, move 10 pixels right and 10 pixels down, scroll the vertical wheel down by 20 pixels and the horizontal wheel right by 10 pixels
+```
+
+### Text Event (`text`)
+
+```bash
+["text", "text_to_type"]
+```
+
+**Parameter description:**
+
+- Index 0: The fixed string `"text"`, indicating that a text string is to be input.
+
+- Index 1: Field type: String. The text string to input, up to 1024 characters long.
+
+Only the following ASCII characters are supported:
+
+- Control characters: **9 (Tab), 10 (Enter)**
+
+- Printable characters: **32 ~ 126**
+
+**Example:**
+
+```bash
+["text", "https://www.baidu.com"] // Type "https://www.baidu.com" at the current cursor position
+```
+
+### Delay Event (`delay`)
+
+```bash
+["delay", milliseconds]
+```
+
+**Parameter description:**
+
+- Index 0: The fixed string `"delay"`, indicating a pause to ensure that the IPKVM completes the previous operation. For example, used to ensure that a long text input completes.
+
+- Index 1: Field type: Number. The duration of the pause, in milliseconds.
+
+**Note:**
+A delay event is usually required after a text input event to ensure that the IPKVM has enough time to fully process long text input. If the IPKVM needs a longer time to perform the operation, multiple delay events may be required. As a general rule, when the input text length is 30, a delay of 1000 milliseconds is needed.
+
+**Example:**
+
+```bash
+["text", "https://www.baidu.com"] // Type "https://www.baidu.com" at the current cursor position
+["delay", 1000]                   // Pause for 1000 milliseconds to ensure the long text above is fully output

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/firmware-update.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/firmware-update.mdx
@@ -1,0 +1,156 @@
+---
+id: firmware-update
+sidebar_position: 3
+title: Firmware Update
+---
+
+# Firmware Update
+
+Linkr KVM supports **local upgrade** by uploading a firmware package through the web management interface, which is used to obtain new features, bug fixes, and security updates. The firmware file is downloaded from GitHub Releases, and the device automatically verifies, decrypts, and installs it after upload.
+
+:::info Current Version
+Firmware download page: [https://github.com/radxa-linkr/linkr/releases](https://github.com/radxa-linkr/linkr/releases)
+
+Latest release example: `linkr-ota-1.0.1.bin` (the version number in the file name changes with each release).
+:::
+
+## Before Updating
+
+1. **Check the current version**: In **About → Device Information**, view the "Current Firmware Version" and compare it with the version to be installed to make sure it is a higher version.
+2. **Download the firmware package**: Visit [GitHub Releases](https://github.com/radxa-linkr/linkr/releases), and download the `linkr-ota-<version>.bin` file from the **Assets** section of the corresponding version to your local computer.
+3. **Keep the network stable**: Please keep the connection between the browser and the KVM during the upgrade process; do not close the page or disconnect the network.
+4. **Reserve storage space**: The firmware package is about 50-60 MB, and the device needs to have enough free space. If space is insufficient, the message "Insufficient storage space" will be displayed.
+5. **Avoid interruption**: During the upgrade, the device's system indicator LED is **flashing white** (see [Product Overview](./product-introduction)). Do not power off or unplug cables.
+
+## Operation Steps
+
+### 1. Go to System Update
+
+1. Open the KVM management web interface and log in.
+2. Click **System Settings** (the settings icon) in the left sidebar.
+3. Find the **System Update** row, and click the **Update** button on the right.
+
+### 2. Open Local Upgrade
+
+In the **System Update** dialog that pops up:
+
+1. Confirm that the **Local Upgrade** tab is currently selected (the `?` icon next to the tab can be used to view the firmware download address).
+2. If you have not downloaded the firmware yet, you can click the link next to `?` to jump to [GitHub Releases](https://github.com/radxa-linkr/linkr/releases) to download.
+
+### 3. Upload the Firmware File
+
+In the **Click or drag a file to this area to upload** area:
+
+- **Click** the upload area and select the downloaded `linkr-ota-*.bin` file from your local disk; or
+- **Drag** the firmware file into the upload area.
+
+After upload starts, the interface will display a progress bar and the current stage.
+
+### 4. Wait for the Upgrade to Complete
+
+The upgrade is divided into the following stages:
+
+| Stage | UI Message | Description |
+| --- | --- | --- |
+| Uploading | Uploading... | The firmware file is transferred from the browser to the KVM device |
+| Upgrading | Upgrading... | The device verifies the signature, decrypts, and writes the firmware |
+| Complete | Upgraded, please restart the device | The installation is complete; takes effect after restart |
+
+You can click **Cancel** to abort the operation during the upgrade (it is recommended not to cancel once installation is nearly complete).
+
+### 5. Restart the Device
+
+When the progress reaches 100% and the message **Upgraded, please restart the device** is shown:
+
+1. Click the **Restart** button, and the device will restart automatically.
+2. After the restart, the browser will jump to the login page. Log in with your original username and password.
+3. In **About → Device Information**, confirm that the firmware version has been updated.
+
+:::caution Note
+A restart will briefly interrupt the KVM service and remote connection. Please perform the upgrade in an appropriate time window, and make sure that the target host will not be affected by the KVM restart.
+:::
+
+## Download the Firmware
+
+### Official Release Page
+
+[https://github.com/radxa-linkr/linkr/releases](https://github.com/radxa-linkr/linkr/releases)
+
+### How to Choose a Version
+
+1. Open the Releases page and look at the latest **Tag** (e.g. `v1.0.1`).
+2. Expand the **Assets** of that version, and download `linkr-ota-<version>.bin`.
+3. It is recommended to read the Release Notes for the changes and known issues.
+
+### File Description
+
+| Item | Description |
+| --- | --- |
+| File format | `linkr-ota-<semver>.bin` (encrypted OTA firmware package) |
+| Typical size | About 50-60 MB |
+| Source | Download only from the official GitHub Releases. Do not use files from unknown sources |
+
+## Version Rules
+
+The device automatically verifies the firmware version before installation:
+
+| Case | Result |
+| --- | --- |
+| Firmware version **higher than** the current version | Allowed to upgrade |
+| Firmware version **equal to** the current version | Rejected, with the message "The version number is the same as the current version" |
+| Firmware version **lower than** the current version | Rejected, with the message "The version number is lower than the current version" |
+
+Downgrade installation is not supported. To roll back to a previous version, please contact technical support.
+
+## FAQ
+
+### "A Restart Is Required Before Upgrading Again"
+
+If the previous upgrade has been installed but the device has not been restarted, attempting to upgrade again will prompt: **A previous upgrade operation was detected. The device needs to be restarted before another upgrade can be performed.**
+
+How to handle: Click **Restart** to complete the previous upgrade, and then perform the new upgrade operation after the restart.
+
+### Insufficient Storage Space
+
+The firmware package needs to be written to the device's local storage. Please delete unnecessary virtual disk images or other space-consuming files and try again.
+
+### Upload or Upgrade Failed
+
+- Confirm that the downloaded `linkr-ota-*.bin` file is complete and not corrupted. Try downloading it again.
+- Check whether the network connection between the browser and the KVM is stable.
+- Refresh the page and re-upload. Avoid running multiple upgrade tasks at the same time.
+- After an upgrade failure, the device usually still runs the original firmware. If there is an abnormality, you can long-press the FN key for 10 seconds to restore factory settings (this will clear all configuration).
+
+### Can I Close the Page During the Upgrade?
+
+Not recommended. Closing the page may cause the upload to be interrupted. If the upload is already complete and the "Upgrading" stage has been entered, the device will continue processing locally, but you will not be able to view the progress or perform the restart on the same page. It is recommended to keep the page open until the restart prompt appears.
+
+### How to View the Current Firmware Version?
+
+The sidebar where **System Settings** is located → **About** → **Device Information** → **Current Firmware Version**.
+
+### Is Online Upgrade Available?
+
+The current web interface is mainly **local upgrade**: first download the firmware from GitHub, and then upload it in the interface. The `?` icon next to the local upgrade tab provides a shortcut to the official download address.
+
+## Upgrade Process Overview
+
+```
+Download linkr-ota-*.bin from GitHub Releases
+        ↓
+System Settings → System Update → Update
+        ↓
+Local Upgrade → Click or drag to upload the firmware
+        ↓
+Uploading → Upgrading (device indicator LED flashing white)
+        ↓
+Upgraded, please restart the device → Click Restart
+        ↓
+Log in again and confirm the version number
+```
+
+## Related Links
+
+- [Firmware Download (GitHub Releases)](https://github.com/radxa-linkr/linkr/releases)
+- [Product Overview - LED Indicators](./product-introduction#led-indicators)
+- [FAQ](./faq)

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/getting-started.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/getting-started.mdx
@@ -1,0 +1,210 @@
+---
+id: getting-started
+sidebar_position: 1
+title: Getting Started Guide
+---
+
+# Getting Started Guide
+
+This guide helps you complete the initial wiring of your Linkr KVM, access the management interface, configure the account, and view the remote desktop of the target computer within **10 to 15 minutes**.
+
+For a more complete interface description, see the [Linkr Web User Guide](./usage). For hardware details, see [Product Overview](./product-introduction).
+
+## What You Need
+
+| Item | Description |
+| --- | --- |
+| Linkr KVM device | Includes an HDMI cable and a USB Type-C data cable |
+| Target computer | Has an HDMI output and a USB port (used for power and keyboard/mouse) |
+| Management computer / phone | Install Chrome or Edge browser (latest version recommended) |
+| Network | The same LAN, or connect via the device's hotspot first |
+
+## Step 1: Connect the Hardware
+
+Method 1 (USB direct connection, short distance):
+
+![img](/img/linkr/linkr-5.png)
+
+Method 2 (USB to RJ45, long distance):
+
+![img](/img/linkr/linkr-6.png)
+
+Wire everything up as follows:
+
+1. **HDMI**: KVM's HDMI male port → target computer's HDMI output port (capture the video).
+2. **USB Type-C (OTG)**: KVM's tail OTG port → target computer's USB port (power + emulate keyboard/mouse).
+3. **Network** (choose one of the following):
+   - **USB Type-C (network)** → management computer (direct connection, no router needed); or
+   - **USB Type-C (network)** → router / switch (wired LAN); or
+   - Configure **Wi-Fi** later through the web interface; or
+   - Use the device's **hotspot** to let the management computer connect to the KVM first.
+
+:::tip Wiring Tips
+The OTG port is responsible for both powering the KVM and injecting keyboard/mouse signals into the target machine, so please use a reliable data cable. The network Type-C port is used for communication between the KVM and the management computer or router. When directly connected to a management computer, it can be accessed via `linkr-usb.local` (see below).
+:::
+
+## Step 2: Confirm the Device Is Ready
+
+After powering on, observe the **system status LED next to the FN key**:
+
+| Indicator | Meaning |
+| --- | --- |
+| Solid red | Starting up, please wait |
+| **Solid blue** | System is normal, you can access it |
+| Solid green | Someone is remotely using it |
+
+You can also observe the **HDMI-side video LED**: it lights up to indicate that a video signal from the target machine has been detected.
+
+For a complete description of the indicator LEDs, see [Product Overview - LED Indicators](./product-introduction#led-indicators).
+
+## Step 3: Open the Management Interface
+
+We recommend using [linkr.now](https://linkr.now) to discover the device on the LAN:
+
+1. Open **https://linkr.now** in the browser on the management computer.
+2. Follow the on-page prompts to **grant local network access** (the browser needs to allow mDNS / local network discovery).
+3. (Optional) **Short-press the FN key once** on the KVM to help the page identify your device.
+4. Select your KVM in the device list and enter the management interface.
+
+![img](/img/linkr/linkr-now-0.png)
+
+![img](/img/linkr/linkr-now-1.png)
+
+### Other Access Methods
+
+If linkr.now cannot discover the device, try the following:
+
+| Method | Address | Applicable Scenario |
+| --- | --- | --- |
+| mDNS (LAN) | `https://linkr.local` | The network Type-C is connected to a router, or already connected to the same LAN via Wi-Fi |
+| mDNS (USB direct) | `https://linkr-usb.local` | The network Type-C is directly connected to a management computer, no router required |
+| mDNS (initialized) | `https://linkr-<username>.local` | After the initial configuration is complete, this address can also be used in LAN mode |
+| Device IP | `https://<KVM's IP address>` | Direct access when the IP is known |
+| Hotspot | Connect to the Wi-Fi `linkr-<device ID>` and then use the address above | Initial configuration when no router network is available |
+
+#### mDNS Domain Name Description
+
+The KVM automatically switches the mDNS hostname according to how the network Type-C is connected:
+
+- **Connected to a router / switch, or joined the LAN via Wi-Fi**: Uses `linkr.local` (factory default); after the initial configuration is complete, `linkr-<username>.local` is also available.
+- **Directly connected to a management computer**: The KVM communicates with the management computer over the USB network, and the mDNS domain name is **`linkr-usb.local`**, which is suitable for out-of-the-box use without a router.
+
+:::tip USB Direct Connection Access
+After plugging the network Type-C into a management computer, enter `https://linkr-usb.local` in the browser address bar to open the management interface (no need to go through linkr.now).
+:::
+
+:::info Certificate Notice
+When accessing over HTTPS, the browser may warn that the certificate is not trusted (self-signed certificate). Just choose to continue.
+:::
+
+If the page shows "Connection Lost", please check: whether the KVM's blue LED is solid on, whether the management computer and the KVM are on the same network, and whether the network cable / Wi-Fi is working. See [FAQ](#faq) below for details.
+
+## Step 4: Initial Configuration (New Device)
+
+A factory-uninitialized device will enter the **Initial Configuration** page. Please set:
+
+| Item | Required | Description |
+| --- | --- | --- |
+| Username | Required | 1-20 characters, only letters, numbers, `-`; cannot start or end with `-`; cannot be `usb` |
+| Login password | Required | At least 6 characters; the page shows password strength |
+| Device name | Optional | Used to distinguish devices; the page validates domain name uniqueness after entry |
+
+Submit the form to complete initialization. In LAN mode, the device's mDNS name will become `linkr-<username>.local`; for direct USB connection to a management computer, `linkr-usb.local` is still used.
+
+## Step 5: Log In
+
+An initialized device shows the login page:
+
+1. Enter the **username** and **password**.
+2. Click **Log In** to enter the remote console (`/home`).
+
+If the device is being used by another user, you will be prompted whether to continue before logging in (continuing will log the other session out).
+
+### Forgot Password
+
+Click **Reset Password** on the login page and follow the prompt to **long-press the FN key for 10 seconds** to restore the device to factory settings (all configuration will be cleared). You can also see [Product Overview - FN Button](./product-introduction#fn-button).
+
+## Step 6: Start Remote Control
+
+After a successful login you will enter the main control page, which consists of three parts:
+
+- **Middle**: Real-time video of the target computer
+- **Left**: Settings and tools (network, display, keyboard/mouse, system settings, etc.)
+- **Bottom**: Connection status, fullscreen, screenshot, recording, virtual keyboard, etc.
+
+Quick verification that everything is working:
+
+1. Confirm that the middle area shows the target computer's desktop (if "no signal" is displayed, check the HDMI connection and whether the target machine is powered on).
+2. Click and move on the screen to confirm that the mouse can control the target computer.
+3. Type on the keyboard to confirm that the input takes effect.
+
+For a detailed description of the functions, see the [User Interface Guide](./page-display).
+
+## Recommended Initial Settings
+
+After completing the first connection, we recommend configuring the following as needed:
+
+| Setting | Entry | Documentation |
+| --- | --- | --- |
+| Connect to Wi-Fi | Left sidebar → Network Settings | [User Interface Guide](./page-display) |
+| Change device name | System Settings → Device Name | [User Interface Guide](./page-display) |
+| Remote access (external network) | Advanced Settings → Tailscale | [Tailscale Remote Access](./tailscale) |
+| Firmware upgrade | System Settings → System Update | [Firmware Update](./firmware-update) |
+
+## Full Process Overview
+
+```
+Wiring (HDMI + OTG + Network)
+        ↓
+Solid blue system LED + video LED on
+        ↓
+Open linkr.now in the browser → grant local network access → select device
+        ↓
+Initial configuration (username / password) or log in
+        ↓
+Main page shows the video → keyboard/mouse operation
+        ↓
+Configure network, Tailscale, firmware, etc. as needed
+```
+
+## FAQ
+
+### linkr.now Cannot Find the Device
+
+- Confirm the KVM system LED is solid blue.
+- Confirm the management computer and the KVM are on the same LAN (or connected via hotspot).
+- The browser needs to allow local network access. Try a short press of the FN key and then refresh the page.
+- LAN mode: Use `https://linkr.local` or `https://linkr-<username>.local` instead.
+- USB direct mode: Use `https://linkr-usb.local` instead.
+- Or enter the KVM's IP address directly.
+
+### Page Shows "Connection Lost"
+
+- Check that the KVM's power and network are normal.
+- Make sure the network cable is plugged in tightly, or Wi-Fi is properly configured.
+- Click **Refresh** on the page to retry.
+
+### Cannot See the Target Computer's Screen
+
+- Confirm the target computer is powered on and has HDMI output.
+- Check that the HDMI cable is firmly connected.
+- Observe whether the KVM's **video status LED** is on; flashing means the signal is abnormal.
+
+### Mouse and Keyboard Are Not Responding
+
+- Confirm that the mouse / keyboard function is enabled in the bottom toolbar.
+- Check that the OTG Type-C cable is connected to the target computer's USB port.
+- The target computer needs to allow USB input devices (usually no extra setting is required).
+
+### Login Says Wrong Username or Password
+
+- Double-check the username case and the password.
+- If you forgot the password, long-press the FN key for 10 seconds to restore factory settings and reinitialize.
+
+For more questions, see [FAQ](./faq).
+
+## Next Steps
+
+- [User Interface Guide](./page-display) — Complete interface and feature description
+- [Product Overview](./product-introduction) — Interfaces, indicator LEDs, specifications
+- [Feature Details](./feature-details) — Tailscale, WOL, access tokens, and other advanced features

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/product-introduction.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/product-introduction.mdx
@@ -1,0 +1,131 @@
+---
+id: product-introduction
+sidebar_position: 0
+title: Product Overview
+---
+
+# Product Overview
+
+Linkr KVM (Radxa Linkr KVM) is a web-based IP KVM device that captures the video output of a target host over HDMI and emulates keyboard/mouse input over USB, allowing you to remotely view and control the target computer from any browser-equipped terminal — no dedicated client software required.
+
+The device is compact, supports wired Ethernet, Wi-Fi, and hotspot connectivity, and ships with built-in capabilities such as Tailscale, Wake on LAN, and access tokens. It is well suited for home labs, remote operations and maintenance, and embedded development scenarios.
+
+## Product Positioning
+
+Linkr KVM is positioned as a **lightweight, ready-to-use hardware KVM-over-IP solution**:
+
+- **Plug and play**: Connect to the target host via HDMI + USB Type-C and use it directly from a browser-based management page.
+- **Web-first**: Remote video, keyboard/mouse control, networking, and system management are all unified in the web console.
+- **Scenario-friendly**: Equally suitable for remote maintenance of desktop PCs, development boards, and headless servers.
+
+Compared with traditional rack-mount KVM appliances or pure-software remote desktop solutions, Linkr KVM strikes a balance between cost, deployment complexity, and ease of use, making it ideal for individual developers, small teams, and educational scenarios.
+
+## Target Users
+
+| User Group | Typical Scenarios |
+| --- | --- |
+| Developers and makers | Remotely debug development boards, install and troubleshoot systems without a display |
+| Home lab users | Manage home NAS, soft routers, and backup PCs without extra monitors or keyboards |
+| Operations and technical support | Remotely assist users with computer operations, capture screens, and send control commands |
+| Education and training | Classroom demonstrations, unified remote access and management of lab environments |
+
+## Core Value
+
+- **Access from anywhere**: Connect to the management interface from a LAN or over the Internet (in combination with Tailscale)
+- **Full remote control**: Video capture + keyboard/mouse injection for an experience close to local operation
+- **Unified management**: Network configuration, firmware upgrade, virtual disk mounting, and API integration are all in the same web interface
+- **Extensible integration**: Access tokens support public APIs for screenshots, control, and more, enabling automation and monitoring
+
+## Product Appearance
+
+Linkr KVM uses a compact design, with the HDMI port, USB Type-C ports, the FN function key, and status indicator LEDs distributed on the front and side panels. The actual appearance is subject to the physical product. Refer to the product packaging or official materials for illustrative diagrams.
+
+![img](/img/linkr/linkr.jpg)
+
+## Interfaces and Connections
+
+| Interface | Purpose |
+| --- | --- |
+| HDMI male port | Connects to the target host, captures the video signal |
+| USB Type-C (OTG) | Power supply and data transfer (emulates keyboard, mouse, and other HID devices on the target machine) |
+| USB Type-C (network) | Wired Ethernet communication |
+| Wi-Fi | Connect to a wireless network |
+| Hotspot | The device acts as an AP to share the network |
+
+### Connection Description
+
+1. **HDMI male port**: Connects to the HDMI video output of the target host to capture the video.
+2. **USB Type-C (OTG)**: Provides both power and a data channel; emulates USB HID devices (keyboard/mouse) on the target machine.
+3. **USB Type-C (network)**: 100 Mbps wired network for the KVM device's own network communication.
+4. **Wi-Fi**: Connects to an existing wireless network, eliminating the need for cabling.
+5. **Hotspot**: The KVM can act as a hotspot for other terminals to access the management interface or share the network.
+
+Typical wiring: the HDMI port connects to the target machine's video output; the OTG Type-C port connects to the target machine's USB port (power + keyboard/mouse); the network Type-C port or Wi-Fi provides network connectivity.
+
+## LED Indicators
+
+There is one indicator LED on each side of the device's **FN key**:
+
+- **The one closer to the HDMI side**: Video (HDMI) status LED
+- **The one farther from the HDMI side**: System status LED (RGB, indicates operating state by color)
+
+### System Status LED
+
+| LED State | Description |
+| --- | --- |
+| Solid red | System is starting up |
+| Solid blue | System is running normally |
+| Solid green | In active use (an active connection exists) |
+| Flashing white | Firmware is being upgraded |
+| Solid white | System is being reset |
+
+### HDMI / Video Status LED
+
+| LED State | Description |
+| --- | --- |
+| Off | No video signal |
+| On | Video signal is present |
+| Flashing | Video link is abnormal or in error |
+
+By observing the indicator LEDs, you can quickly determine the state of the device and the video link without opening the web interface.
+
+## FN Button
+
+| Action | Function |
+| --- | --- |
+| **Long press for 10 seconds or more** | Reset the system (restore all configuration to factory defaults) |
+| **Short press once** | Device identification (used for the device discovery feature on [linkr.now](https://linkr.now)) |
+
+:::caution Note
+A long-press reset of the FN key clears all local configuration (including network, account, Tailscale bindings, etc.). Make sure to back up any required information before performing this action.
+:::
+
+## Specifications
+
+| Item | Description |
+| --- | --- |
+| Video encoding | Up to 2K@30fps, supports H.264 or MJPEG |
+| Video transport | WebRTC, WebSocket |
+| Ethernet | 100 Mbps |
+| USB network | 100 Mbps |
+| Storage | 16 GB eMMC |
+| Onboard Wi-Fi | Supported |
+| USB | 1× USB (Host/Device) |
+| Power | USB 5 V |
+
+## Software Capabilities Overview
+
+In addition to the hardware KVM capabilities, the Linkr KVM firmware and the web management interface also provide:
+
+| Feature | Description | Documentation |
+| --- | --- | --- |
+| Web remote console | Video, keyboard/mouse, screenshots, recording, virtual keyboard, etc. | [User Interface Guide](./page-display) |
+| Tailscale | Built-in VPN, access the device remotely without a public IP | [Tailscale Remote Access](./tailscale) |
+| Wake on LAN | Send a magic packet on the LAN to wake the target host | [Wake on LAN](./wake-on-lan) |
+| Access tokens | API keys that support screenshot and control endpoints | [Access Tokens](./access-token) |
+
+## Related Links
+
+- [Getting Started Guide](./getting-started)
+- [Feature Details](./feature-details)
+- [FAQ](./faq)

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/usage.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/usage.mdx
@@ -1,0 +1,612 @@
+---
+id: usage
+title: Linkr Web User Guide
+sidebar_position: 2
+---
+
+# Linkr Web User Guide
+
+## What Does It Do?
+
+The Linkr Web is a web-based console for remotely managing target devices (computers, development boards, servers, ...). You can complete the following core tasks directly in the browser:
+
+- Remotely view the target device's screen in `H.264 / MJPEG video mode`
+- Send keyboard and mouse input remotely
+- Take screenshots, record video, use quick-paste and shortcut keys
+- Configure the network `Ethernet, USB network, Wi-Fi, hotspot`
+- Manage virtual disk mounts `ISO/IMG`
+- Perform system-level management `user, password, device name, upgrade, reset, API Key`
+
+In short: it combines a **remote KVM client and a device management backend** into a single web page.
+
+***
+
+## Page Structure Overview
+
+The project has three main routes:
+
+- `/`: Login page (initial setup or normal login)
+- `/home`: Main control page (video view + sidebar settings + bottom toolbar)
+
+Day-to-day usage is almost entirely on `/home`.
+
+***
+
+## Login Page
+
+The login page automatically branches based on whether the device has been initialized:
+
+- Not initialized: enter initial setup
+- Initialized: enter the username + password login
+
+### Initial Setup
+
+You need to set:
+
+- Username (required)
+- Login password (required)
+- Device name (optional)
+
+What each item does:
+
+- Username: used for subsequent login identity, and also affects domain-name-related features
+- Password: system login credential
+- Device name: used to generate a domain name to make it easy to distinguish the device on the network or in the management list; the username is used as the default device name
+
+Key validation rules:
+
+- The username has format restrictions and cannot be `usb`
+- The password must meet the minimum length requirement; the page shows password strength
+- If a device name is provided, domain-name uniqueness is validated first
+
+### Normal Login
+
+- Enter the username and password to log in.
+- The page supports **"Reset Password"** (long-press the device button for 10s, then release; the device will be reset).
+
+### Common Login Page Features
+
+- Language switcher in the top-right corner (Chinese / English)
+- Theme switcher in the top-right corner (dark / light)
+
+***
+
+## Workbench Layout
+
+The workbench consists of three parts:
+
+- Left: collapsible sidebar (entries for all settings and tools)
+- Middle: remote video area (the core control view)
+- Bottom: quick control bar (connection status, fullscreen, screenshot, recording, mouse, virtual keyboard)
+
+<img src="/img/linkr/navbar-view.webp" alt="Page layout" />
+
+### Middle Video Area States
+
+Video connection states are:
+
+- Playing normally
+- Connecting...
+- Error / interrupted (e.g. link abnormality, HDMI signal issue)
+
+### Bottom Toolbar Functions
+
+- Connection status and statistics: shows FPS / resolution
+- Fullscreen toggle: switch to an immersive remote control view
+- Screenshot mode: enter the screenshot interaction
+- Recording: start / stop recording, with preview and download of the result
+- Mouse quick switch: quickly enable/disable mouse input, show the local mouse
+- Keyboard switch: quickly enable/disable the on-screen keyboard
+
+<img src="/img/linkr/footer-bar.webp" alt="Bottom navigation bar" style={{maxWidth:"800px"}} />
+
+***
+
+## Left Sidebar
+
+### Left Sidebar Main Menu
+
+The left sidebar main menu (top to bottom) usually includes:
+
+- [Common Tools](#common-tools)
+- [Network Settings](#network-settings)
+- [Display Settings](#display-settings)
+- [Keyboard and Mouse](#keyboard-and-mouse)
+- [Virtual Devices](#virtual-devices)
+- [System Settings](#system-settings)
+- [About](#about)
+
+In addition, at the bottom of the left sidebar there are:
+
+- Theme switcher
+- Log out
+- Notifications
+
+<img src="/img/linkr/common-tools.webp" alt="Left sidebar" style={{maxWidth:"400px"}} />
+
+Each item is described below.
+
+***
+
+## Common Tools
+
+This is a customizable aggregation area. You can drag and reorder frequently used sub-functions and place them here to reduce the cost of switching menus.
+
+Configurable capabilities:
+
+- Choose which configuration items to use as common tools
+- Drag and reorder the selected tools
+- Select all / invert selection / clear
+
+<img src="/img/linkr/tools-options.webp" alt="Common tools configuration"  />
+
+***
+
+## Network Settings
+
+Includes four sections: Ethernet, USB network, Wi-Fi, and Wi-Fi hotspot.
+
+<img src="/img/linkr/network-setting.webp" alt="Network settings" style={{maxWidth:"400px"}}  />
+
+### Ethernet
+
+Main settings:
+
+- DHCP / Manual IP mode switch
+- IPv4 address
+- Subnet mask
+- Gateway
+- DNS
+
+<div className='flex-img'>
+  <img src="/img/linkr/dhcp1.webp" alt="Ethernet"  />
+  <img src="/img/linkr/dhcp2.webp" alt="Ethernet"  />
+</div>
+
+Purpose:
+
+- Determines how the device obtains an address on the wired network
+- Used for a fixed management address or joining an existing network
+
+:::tip
+
+- After saving manual configuration, the access address may change; you need to log in again using the new IP
+- The configuration is validated for IP / mask / gateway format
+- Conflicts with the Wi-Fi and hotspot subnets are detected to avoid network exclusion
+
+:::
+
+### USB Network
+
+Main settings:
+
+- USB network subnet (CIDR, e.g. `192.168.x.0/24`)
+
+<img src="/img/linkr/usb-item.webp" alt="USB network" style={{maxWidth:"400px"}}  />
+
+Purpose:
+
+- Provides a network channel for accessing the device over a USB cable
+- Commonly used for direct-connection debugging scenarios
+
+:::tip
+
+- After saving, the page will try to jump to a new available IP
+- The subnet format is validated, and conflicts with Wi-Fi / hotspot are checked
+
+:::
+
+### Wi-Fi
+
+Main settings and operations:
+
+- WLAN switch
+- Known network list (connect / disconnect / ignore)
+- Scan and refresh other networks
+- Add network manually (SSID, security mode, password, auto-connect)
+- Network advanced settings (DHCP / manual IP, DNS list)
+
+<img src="/img/linkr/wifi-item.webp" alt="Wi-Fi" style={{maxWidth:"400px"}}  />
+
+Purpose:
+
+- Lets the device join the network wirelessly
+- Manages saved Wi-Fi profiles
+
+:::tip
+
+- In manual IP mode, key parameters must be filled in
+- Subnet conflict checks are also performed (against USB / Ethernet / hotspot)
+
+:::
+
+### Wi-Fi Hotspot
+
+Main settings:
+
+- Hotspot switch
+- Hotspot name (SSID)
+- Security mode (Open / WPA2) and password
+- Device identifier
+- Hide hotspot
+- Hotspot subnet
+
+<img src="/img/linkr/host-item.webp" alt="Hotspot" style={{maxWidth:"400px"}}  />
+
+Purpose:
+
+- Turns the device into an AP that other terminals can connect to
+- Suitable for offline or temporary direct-connection maintenance
+
+:::tip
+
+- WPA2 mode requires the password to meet the length requirement (length >= 8)
+- After changing the subnet, the access address may also change
+- Conflicts with other network interfaces are detected
+
+:::
+
+***
+
+## Display Settings
+
+Includes: Fullscreen, scaling mode, EDID, image quality, video mode.
+
+<img src="/img/linkr/display-setting.webp" alt="Display settings" style={{maxWidth:"400px"}}  />
+
+### Fullscreen
+
+Purpose:
+
+- Toggle the in-browser fullscreen remote control view
+- Suitable for long-time operations and maintenance, or BIOS / installation scenarios
+
+### Scaling Mode
+
+Options:
+
+- Adaptive
+- Normal / original
+
+Purpose:
+
+- Controls how the video fits the current browser area
+
+### EDID (Resolution / Frame Rate)
+
+Purpose:
+
+- Controls the display capabilities presented to the signal source by the HDMI input
+- Commonly used to adjust the available resolution and compatibility
+
+Supported items:
+
+- Preset EDID
+
+Applicable scenarios:
+
+- Some hosts have abnormal output
+- A specific resolution / refresh-rate combination is required
+
+### Image Quality
+
+Purpose:
+
+- Adjusts the balance between clarity and bandwidth / smoothness of the remote video
+
+### Video Mode
+
+Options:
+
+- H.264 (default)
+- MJPEG
+
+Purpose:
+
+- Trade-off between encoding efficiency / bandwidth usage / compatibility
+
+Recommendation:
+
+- Use H.264 first for regular remote control
+- Switch to MJPEG for special compatibility scenarios
+
+***
+
+## Keyboard and Mouse
+
+Includes: on-screen keyboard, quick paste, shortcut keys, mouse settings.
+
+<img src="/img/linkr/mouse-keyboard.webp" alt="Keyboard and mouse" style={{maxWidth:"400px"}}  />
+
+### On-Screen Keyboard
+
+Purpose:
+
+- Show or hide the on-screen virtual keyboard
+- Very useful for touch devices or when no physical keyboard is available
+
+<img src="/img/linkr/keyboard.webp" alt="On-screen keyboard" />
+
+### Quick Paste
+
+Functions:
+
+- Enter text and send it to the remote side with one click
+- Reuse historical paste entries
+- Support clearing history
+
+<img src="/img/linkr/paste.webp" alt="Quick paste" style={{maxWidth:"400px"}} />
+
+Purpose:
+
+- Quickly enter repeated text such as commands, accounts, paths
+- Reduce the cost of typing character by character
+
+### Send Shortcut Keys
+
+Functions:
+
+- Customize combination keys (add / delete / edit)
+- Send configured shortcut keys with one click
+
+Purpose:
+
+- Quickly trigger common combinations (e.g. system shortcuts)
+- Reduce the failure rate of complex key input
+
+<img src="/img/linkr/add-keys.webp" alt="Add shortcut keys"  />
+
+### Mouse Settings
+
+Main settings:
+
+- Mouse master switch
+- Show local mouse
+- Mouse mode (absolute / relative)
+- Mouse sensitivity (in relative mode)
+- Scroll direction
+- Scroll speed
+- Prevent sleep (mouse jitter)
+
+<img src="/img/linkr/mouse-item.webp" alt="Mouse settings" style={{maxWidth:"400px"}}  />
+
+Purpose:
+
+- Adapt the mouse feel and behavior for different remote-control scenarios
+- Prevent the target device from sleeping due to long idle periods
+
+***
+
+## Virtual Devices
+
+Includes: virtual disks.
+
+### Virtual Disks
+
+Functions:
+
+- Upload `iso/img` files
+- View the disk file list
+- Mount / unmount
+- Delete files
+- Show available storage space and upload progress
+
+Purpose:
+
+- Used for mounting OS installation media, driver disks, and offline maintenance images
+
+:::tip
+
+- Only `.iso` and `.img` are supported
+- Free space is checked before upload
+- Uploading a file with the same name will prompt an overwrite confirmation
+
+:::
+
+***
+
+## System Settings
+
+Includes: user information and password, API key, language, device name, device reset, system update.
+
+### User Information and Password
+
+Contains two parts:
+
+- Change the username
+- Change the login password
+
+Purpose:
+
+- Maintain login security and account hygiene
+
+:::tip
+
+- Username changes are validated for format and uniqueness
+- After a successful password change, you need to log in again
+
+:::
+
+### Access Tokens
+
+Functions:
+
+- Create an API key (name + user password confirmation)
+- Delete an API key
+- Copy the newly generated key
+
+Purpose:
+
+- Used by scripts / automation tools to access the API. For detailed documentation, see [here](/linkr/linkr-kvm/access-token)
+
+:::warning
+
+- The API key is only visible at creation time and cannot be viewed later!
+
+:::
+
+### Language Settings
+
+Purpose:
+
+- Switch the interface language (Simplified Chinese / English)
+
+### Device Name
+
+Purpose:
+
+- Change the device display name (hostname)
+- Makes it easier to identify the current device on the network
+
+:::tip
+
+- The device name is used to generate the domain name and must conform to the domain name spec, for example `linkr-<device name>`
+- If the device name is not set during device initialization, the username is used as the default domain name; the username is not validated for format or uniqueness
+- After changing the device name, the domain name takes about 2 minutes to take effect. Try refreshing the page to update the domain name display
+
+:::
+
+### Device Reset
+
+Purpose:
+
+- Perform a system-level reset (requires password confirmation)
+
+:::warning
+
+- After the reset, the device will restart and disconnect
+- All configuration will be restored to defaults
+- The IP may change; you need to rediscover and log in
+- If a recording is in progress, the reset will interrupt it
+
+:::
+
+### System Update
+
+The currently available upgrade method: local upgrade.
+
+Functions:
+
+- Upload the upgrade package
+- Show upload / install progress
+- Restart after the installation is complete
+
+Notes:
+
+- The page provides a link to the release page (GitHub Releases)
+- Online upgrade code is reserved, but the main flow is local upgrade at the moment
+
+***
+
+## About
+
+Includes: device information, user agreement, Radxa Linkr introduction, log download.
+
+### Device Information
+
+Displays:
+
+- Current firmware version
+- Device model, SN, MAC, and other hardware information
+
+Purpose:
+
+- Quickly verify device identity for after-sales, operations, and asset management
+
+### User Agreement
+
+Purpose:
+
+- View the End User License Agreement online
+
+### Radxa Linkr Introduction
+
+Purpose:
+
+- View the product introduction
+
+### Log Download
+
+Purpose:
+
+- Export a log archive (`linkr_log.tar.gz`)
+- Used for troubleshooting and technical support
+
+***
+
+## Advanced Settings
+
+Includes: Tailscale, MAC device wakeup
+
+<img src="/img/linkr/advanced-settings.webp" alt="Advanced settings" style={{maxWidth:"400px"}}  />
+
+### Tailscale
+
+Purpose:
+
+- Configure the Tailscale network for secure cross-device communication. For detailed documentation, see [here](/linkr/linkr-kvm/advanced-usage/remote-access)
+- Used for remote access, file sharing, VPN, and other scenarios
+
+:::tip
+
+Before using Tailscale, make sure Linkr can connect to the external network via a USB-C to RJ45 cable or via Wi-Fi to a router
+
+:::
+
+### MAC Device Wakeup
+
+Purpose:
+
+- Configure MAC device wakeup to start the device remotely. For detailed documentation, see [here](/linkr/linkr-kvm/advanced-usage/wake-on-lan)
+- Used to wake the device when no power is available, keeping the connection alive
+
+***
+
+## Sidebar Bottom Functions
+
+### Theme Switcher
+
+- Switch between light and dark themes for better readability in different lighting environments
+
+### Log Out
+
+- Log out and return to the login page
+- If a recording is in progress, an interruption prompt will be shown
+
+### Notifications
+
+- Open the notification list to view tasks and status messages
+
+***
+
+## Recommended Onboarding Path for New Users
+
+We recommend getting familiar with the system in this order:
+
+1. Log in and enter the home page. Confirm that the video works.
+2. In Display Settings, first confirm the video mode and scaling mode.
+3. In Keyboard and Mouse, adjust the mouse mode and sensitivity.
+4. Configure one of Ethernet / Wi-Fi / Hotspot based on the network environment on site.
+5. When installing an OS, use Virtual Disks to upload and mount the image.
+6. Finally, complete password, device name, and API key management in System Settings.
+
+***
+
+## Important Notes
+
+- After changing network parameters, the device IP may change. Please reconnect using the new address.
+- Subnets of different network interfaces must not conflict (the system performs conflict checks).
+- Upgrade, reset, and logging out may interrupt the current recording task.
+- Virtual disks only support `iso/img` and are limited by the remaining space.
+- After changing the login password, you usually need to log in again.
+- MJPEG has higher performance pressure at high resolutions; H.264 is generally preferred.
+
+***
+
+## One-Sentence Summary
+
+If you treat this system as a web-based remote KVM console and a device management center combined, you can quickly understand all the pages:
+
+- Middle: view the screen
+- Bottom: instant control
+- Left: system configuration and maintenance


### PR DESCRIPTION
## Summary

Translate the Chinese Linkr (灵控系列) tutorials to English so the English docs site has a complete set of Linkr KVM documentation.

The Chinese source under `docs/linkr/` is currently not mirrored in `i18n/en/docusaurus-plugin-content-docs/current/linkr/`. This PR adds the English versions at the corresponding path.

## Files translated

- `i18n/en/docusaurus-plugin-content-docs/current/linkr/README.md` (Linkr series index)
- `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/README.md` (Linkr KVM index)
- `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/product-introduction.mdx` (Product overview)
- `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/getting-started.mdx` (Getting started guide)
- `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/usage.mdx` (Web user guide)
- `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/access-token.mdx` (Access tokens)
- `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/firmware-update.mdx` (Firmware update)
- `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/develop-guide.mdx` (Developer documentation / AI agent interface)
- `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/advanced-usage/README.md` (Advanced usage index)
- `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/advanced-usage/remote-access.mdx` (Tailscale remote access)
- `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/advanced-usage/wake-on-lan.mdx` (Wake on LAN)

## Notes

- The translations follow the existing i18n directory layout used by other product families (e.g. `dragon/q8b`).
- Front matter, sidebar positions, IDs, image paths, and table structures mirror the Chinese source.
- No Chinese source files were modified; this PR only adds the missing English counterparts.
- Local checks pass:
  - `scripts/agent-doc-lint.sh`
  - `scripts/agent-doc-drift-guard.sh`
  - `scripts/agent-doc-translation-guard.sh`
