### PR TITLE
docs(a7a): add explicit extract step for .img.xz UFS system install

### DIFF
--- a/docs/cubie/a7a/getting-started/install-system/ufs-system/no-reader.md
+++ b/docs/cubie/a7a/getting-started/install-system/ufs-system/no-reader.md
@@ -80,9 +80,27 @@ wget [url]
 在 PC 上下载系统镜像，然后使用U盘、FTP、SCP 等方式将系统镜像文件传输到 Cubie A7A 上。
 :::
 
-### 安装系统镜像
+:::tip 说明
+[资源汇总下载](../../../download) 页面提供的系统镜像是 `.img.xz` 压缩包，需要先解压为 `.img` 后才能使用 `dd` 命令写入 UFS 模块。
+:::
 
-使用 `dd` 命令将解压好的系统镜像安装到 UFS 模块中。
+### 解压系统镜像
+
+使用 `unxz` 命令解压系统镜像文件。
+
+<NewCodeBlock tip="radxa@cubie-a7a$" type="device">
+
+```bash
+sudo apt install xz-utils
+unxz [image_path]
+```
+
+</NewCodeBlock>
+
+参数解释：
+
+- `[image_path]`：需要替换为实际的 `.img.xz` 镜像文件路径
+- 也可以直接管道写入：`xz -dc [image_path] | sudo dd of=/dev/sda bs=4M status=progress`，无需先解压出 `.img`，节省磁盘空间
 
 ### 写入系统镜像
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/getting-started/install-system/ufs-system/no-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/getting-started/install-system/ufs-system/no-reader.md
@@ -77,9 +77,27 @@ Replace `[url]` with the actual download URL.
   Download the system image on your PC, then transfer it to the Cubie A7A using a USB drive, FTP, SCP, or other methods.
   :::
 
-### Install System Image
+:::tip Note
+The system images provided on the [Downloads](../../../download) page are `.img.xz` archives. They must be decompressed to `.img` before being written to the UFS module with `dd`.
+:::
 
-Use the `dd` command to install the extracted system image to the UFS module.
+### Extract System Image
+
+Use the `unxz` command to extract the system image.
+
+<NewCodeBlock tip="radxa@cubie-a7a$" type="device">
+
+```bash
+sudo apt install xz-utils
+unxz [image_path]
+```
+
+</NewCodeBlock>
+
+Parameter explanation:
+
+- `[image_path]`: replace with the actual path of your `.img.xz` archive
+- Alternatively, pipe directly to skip extracting a separate `.img` (saves disk space): `xz -dc [image_path] | sudo dd of=/dev/sda bs=4M status=progress`
 
 ### Write System Image
 


### PR DESCRIPTION
## docs(a7a): add explicit extract step for .img.xz UFS system install

### Source of the docs gap

Discussion #1832 (`en/cubie/a7a/getting-started/install-system/ufs-system/no-reader`):
a user reported the Downloads page serves `.img.xz` archives, but the no-reader
UFS install guide only says "download and extract" without showing how to
decompress, so users hit a dead end before the `dd` step.

### What this PR changes

- Add a `:::tip` callout under the Download Methods block making the
  `.img.xz → .img` decompression requirement explicit.
- Add an `### 解压系统镜像 / ### Extract System Image` section that mirrors
  the canonical `unxz` pattern already used in
  `docs/rock5/rock5t/getting-started/install-os/emmc_boot.md`.
- Document the pipe alternative (`xz -dc … | sudo dd of=/dev/sda …`) so users
  who don't want a separate `.img` on disk have a one-liner.

### Scope

Single scope `docs/cubie/a7a`. 1 commit / 2 files / +40 / -4. CN and EN in sync.

### Why docs-only

This is purely a documentation gap fix. The underlying mechanism (xz
decompression + `dd` to UFS) is correct, the missing piece is that the user
is never shown the decompression step. Discussion #1832 is the canonical
trigger.

Fixes discussion radxa-docs/docs#1832.
