### PR TITLE
docs(dragon-q8b): add MPV / Vulkan / WebGL / Waydroid tutorials

### DIFF
--- a/docs/dragon/q8b/system-config/mpv.md
+++ b/docs/dragon/q8b/system-config/mpv.md
@@ -1,0 +1,104 @@
+---
+sidebar_position: 6
+---
+
+# 视频硬件解码播放（MPV）
+
+在部分 ARM / 嵌入式平台（例如高通等 SoC）上，视频硬件编解码通常采用 V4L2 M2M（Memory-to-Memory） 架构，而不是 PC 常见的 VA-API / VDPAU。因此默认使用 `hwdec=vaapi` 往往无法生效。
+为了获得更流畅、更低功耗 的播放体验，建议将 mpv 的硬件解码后端设置为 `hwdec=v4l2m2m-copy`。
+
+## 安装 mpv
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo apt update
+sudo apt install mpv -y
+```
+
+</NewCodeBlock>
+
+## 配置 mpv
+
+创建目录并编辑配置：
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+mkdir -p ~/.config/mpv
+nano ~/.config/mpv/mpv.conf
+```
+
+</NewCodeBlock>
+
+将下面内容添加到用户配置文件内：
+
+<NewCodeBlock tip="mpv.conf" type="device">
+
+```bash
+# 适用于资源受限设备的快速预设
+profile=fast
+
+# 启用 V4L2 M2M 硬件解码（推荐）
+hwdec=v4l2m2m-copy
+
+# GPU 渲染输出（兼容 OpenGL ES / Vulkan）
+vo=gpu
+
+# 提升帧提交稳定性（对嵌入式设备更友好）
+swapchain-depth=8
+
+# 快速缩放算法，降低 CPU/GPU 负担
+sws-fast=yes
+```
+
+</NewCodeBlock>
+
+参数说明：
+
+- profile=fast：启用快速渲染预设，减少图像后处理开销，适合嵌入式设备
+- hwdec=v4l2m2m-copy：指定硬件解码器为 V4L2 M2M，高通平台标准硬解接口，-copy 表示将解码帧从 GPU 内存拷贝回 CPU 可访问内存，兼容性更好
+- vo=gpu：使用 GPU 渲染输出，支持 OpenGL ES（常见于 ARM Linux），是嵌入式平台推荐选项
+- swapchain-depth=8：设置 GPU 帧缓冲队列深度，提高帧提交稳定性，避免卡顿（尤其在低刷新率屏上）
+- sws-fast=yes：启用快速软件缩放，绕过高质量缩放算法，提升性能
+
+:::tip 配置优先级
+
+mpv 的配置文件优先级如下：
+
+1. 用户配置：`~/.config/mpv/mpv.conf`（优先级最高，推荐使用）
+2. 全局配置：`/etc/mpv/mpv.conf`
+
+注意事项：
+
+如果 `/etc/mpv/mpv.conf` 里设置了 `hwdec=vaapi`，用户级配置会覆盖它。
+
+如果你没有创建用户配置，mpv 会直接使用 `/etc/mpv/mpv.conf`，此时需要手动修改全局配置，或用命令行临时指定参数。
+
+:::
+
+## 验证 mpv
+
+可以在主板上播放任意视频来验证配置是否生效。需提前在主板上下载视频文件。
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+mpv /path/to/your/video.mp4
+```
+
+</NewCodeBlock>
+
+成功启用时，终端会显示类似 `Using hardware decoding (v4l2m2m-copy).` 的信息。
+
+## 临时指定 mpv 参数
+
+直接在命令行中指定 mpv 参数，例如：
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+mpv --hwdec=v4l2m2m-copy --vo=gpu --swapchain-depth=8 --sws-fast=yes /path/to/your/video.mp4
+```
+
+</NewCodeBlock>

--- a/docs/dragon/q8b/system-config/vulkan.md
+++ b/docs/dragon/q8b/system-config/vulkan.md
@@ -1,0 +1,105 @@
+---
+sidebar_position: 7
+---
+
+# Vulkan 使用指南
+
+本教程用于在 Dragon Q8B 上安装 Vulkan 相关组件并验证 Vulkan 是否可用（Mesa Turnip 驱动）。
+
+## 安装 Vulkan
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo apt update
+# mesa-vulkan-drivers: Vulkan ICD (Turnip/Freedreno)
+# vulkan-tools: provides vulkaninfo
+sudo apt install -y mesa-vulkan-drivers vulkan-tools
+```
+
+</NewCodeBlock>
+
+## 运行 vulkaninfo
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+vulkaninfo
+```
+
+</NewCodeBlock>
+
+若输出中能看到类似 `driverName = turnip` / `deviceName = ... Adreno ...`，说明 Vulkan 已正常工作。
+
+## 运行 vkpeak
+
+`vkpeak` 是一个简单的 Vulkan 性能测试工具，可用于快速验证 GPU 跑分与驱动工作状态。
+
+构建 `vkpeak`：
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo apt install -y git cmake g++
+git clone https://github.com/nihui/vkpeak.git
+cd vkpeak
+git submodule update --init --recursive
+
+mkdir build
+cd build
+cmake ..
+cmake --build . -j"$(nproc)"
+```
+
+</NewCodeBlock>
+
+运行 `vkpeak`：
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+cd ./vkpeak/build
+./vkpeak 0
+```
+
+</NewCodeBlock>
+
+输出结果如下：
+
+```text
+device       = Turnip Adreno (TM) 690
+driver       = turnip Mesa driver / Mesa 26.0.3-1ubuntu1
+
+fp32-scalar  = 2708.96 GFLOPS
+fp32-vec4    = 2774.66 GFLOPS
+
+fp16-scalar  = 3761.96 GFLOPS
+fp16-vec4    = 5542.70 GFLOPS
+fp16-matrix  = 0.00 GFLOPS
+
+fp64-scalar  = 0.00 GFLOPS
+fp64-vec4    = 0.00 GFLOPS
+
+int32-scalar = 694.37 GIOPS
+int32-vec4   = 701.89 GIOPS
+
+int16-scalar = 1822.40 GIOPS
+int16-vec4   = 1861.33 GIOPS
+
+int64-scalar = 121.03 GIOPS
+int64-vec4   = 102.85 GIOPS
+
+int8-dotprod = 7640.92 GIOPS
+int8-matrix  = 0.00 GIOPS
+
+bf16-dotprod = 0.00 GFLOPS
+bf16-matrix  = 0.00 GFLOPS
+
+fp8-matrix   = 0.00 GFLOPS
+bf8-matrix   = 0.00 GFLOPS
+
+copy-h2h     = 14.66 GBPS
+copy-h2d     = 14.59 GBPS
+copy-d2h     = 14.65 GBPS
+copy-d2d     = 28.93 GBPS
+```

--- a/docs/dragon/q8b/system-config/waydroid.md
+++ b/docs/dragon/q8b/system-config/waydroid.md
@@ -1,0 +1,180 @@
+---
+sidebar_position: 9
+---
+
+# Waydroid 使用指南
+
+Waydroid 是一个基于 Wayland 的 Android 桌面环境，可以在 Dragon Q8B 上运行 Android 应用。
+
+Waydroid 通过容器方式运行完整 Android 系统，并与桌面环境深度集成，使 Android 应用像原生应用一样运行。
+
+:::tip
+
+- [Waydroid 官方文档](https://docs.waydro.id/)
+  :::
+
+## 使用前提
+
+Waydroid 只能在 Wayland 窗口系统下运行，可以使用命令检查当前会话类型。
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+echo $XDG_SESSION_TYPE
+```
+
+</NewCodeBlock>
+
+输出结果为 `wayland` 时，说明当前会话类型为 Wayland，可以运行 Waydroid。
+
+若输出为其他会话类型，可以在登录界面的右下角选择 **GNOME (Wayland)** 会话（避免选择 Xorg），然后重新登录。
+
+## 安装 Waydroid
+
+### 添加 Waydroid 仓库
+
+添加 Waydroid 官方仓库。
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+curl -s https://repo.waydro.id | sudo bash
+```
+
+</NewCodeBlock>
+
+### 安装 Waydroid
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo apt update
+sudo apt install waydroid -y
+```
+
+</NewCodeBlock>
+
+## PSI 内核参数
+
+添加 PSI 参数。
+
+### 编辑启动参数
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo cp /etc/kernel/cmdline /etc/kernel/cmdline.bak
+grep -q 'psi=1' /etc/kernel/cmdline || sudo sed -i 's/$/ psi=1/' /etc/kernel/cmdline
+```
+
+</NewCodeBlock>
+
+### 更新启动项
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo kernel-install add $(uname -r) /boot/vmlinuz-$(uname -r)
+```
+
+</NewCodeBlock>
+
+最后，重启系统。
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo reboot
+```
+
+</NewCodeBlock>
+
+## 初始化 Waydroid
+
+首次使用需要初始化 Waydroid，可以点击 Waydroid 图标或者终端使用命令初始化。
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo waydroid init
+```
+
+</NewCodeBlock>
+
+初始化 Waydroid 会自动下载 `system.img` 和 `vendor.img`。
+
+:::tip 手动初始化 Waydroid
+
+若自动初始化 Waydroid 失败，下载缓慢，可以手动下载 system/vendor 的压缩包并解压到 `/etc/waydroid-extra/images` 目录。
+
+- 获取下载 URL
+
+复制下面 json 文件里面下载 URL，`system.img` 和 `vendor.img` 的下载时间日期需要对应，不然可能出现闪退现象。
+
+[system.img](https://ota.waydro.id/system/lineage/waydroid_arm64/VANILLA.json)
+
+[vendor.img](https://ota.waydro.id/vendor/waydroid_arm64/MAINLINE.json)
+
+- 解压镜像压缩包
+
+打开终端并进入下载的文件目录，将下载的 system/vendor 压缩包解压到 `/etc/waydroid-extra/images` 目录。
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo mkdir -p /etc/waydroid-extra/images
+sudo unzip lineage-*-system.zip -d /etc/waydroid-extra/images
+sudo unzip lineage-*-vendor.zip -d /etc/waydroid-extra/images
+rm lineage-*-system.zip lineage-*-vendor.zip
+```
+
+</NewCodeBlock>
+
+- 重新初始化 Waydroid
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo waydroid init -f
+```
+
+</NewCodeBlock>
+
+:::
+
+## 启动 Waydroid
+
+初始化完成后，启动 Waydroid 容器服务。
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo systemctl enable --now waydroid-container
+```
+
+</NewCodeBlock>
+
+然后启动 Waydroid 会话并打开界面。
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+waydroid session start
+waydroid show-full-ui
+```
+
+</NewCodeBlock>
+
+## 安装 Android 应用
+
+打开终端并进入安装包所在位置，通过命令行安装 Android 应用。
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+waydroid app install example-app.apk
+```
+
+</NewCodeBlock>
+
+安装完成后，应用会自动出现在应用菜单中。

--- a/docs/dragon/q8b/system-config/webgl.md
+++ b/docs/dragon/q8b/system-config/webgl.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 8
+---
+
+# WebGL 使用指南
+
+本教程用于在 Dragon Q8B 上验证浏览器是否启用了 WebGL（GPU 加速渲染）。
+
+:::tip
+如果你通过 SSH 远程操作，请确保系统已连接显示器并进入桌面环境，否则浏览器可能无法正常启用 GPU 加速。
+:::
+
+## 安装 chromium-browser
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo apt update
+sudo apt install chromium-browser
+```
+
+</NewCodeBlock>
+
+## 运行 chromium-browser
+
+启动 chromium-browser：
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+chromium-browser
+```
+
+</NewCodeBlock>
+
+打开以下任意页面即可查看 WebGL 支持情况：
+
+- https://webglreport.com/
+- https://get.webgl.org/
+
+如果页面显示 WebGL 不可用，可在 `chrome://gpu` 页面查看 Graphics Feature Status 以排查是否启用了硬件加速。

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/mpv.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/mpv.md
@@ -1,0 +1,104 @@
+---
+sidebar_position: 6
+---
+
+# Hardware-accelerated video playback (mpv)
+
+On some ARM/embedded platforms (for example, Qualcomm SoCs), hardware video encode/decode typically uses the V4L2 M2M (Memory-to-Memory) architecture rather than the PC-style VA-API/VDPAU. As a result, the default `hwdec=vaapi` often does not work.
+For smoother playback and lower power consumption, set mpv's hardware decode backend to `hwdec=v4l2m2m-copy`.
+
+## Install mpv
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo apt update
+sudo apt install mpv -y
+```
+
+</NewCodeBlock>
+
+## Configure mpv
+
+Create the directory and edit the config:
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+mkdir -p ~/.config/mpv
+nano ~/.config/mpv/mpv.conf
+```
+
+</NewCodeBlock>
+
+Add the following to the user configuration file:
+
+<NewCodeBlock tip="mpv.conf" type="device">
+
+```bash
+# Fast preset for resource-constrained devices
+profile=fast
+
+# Enable V4L2 M2M hardware decode (recommended)
+hwdec=v4l2m2m-copy
+
+# GPU output (compatible with OpenGL ES / Vulkan)
+vo=gpu
+
+# Improve frame submission stability (more friendly to embedded devices)
+swapchain-depth=8
+
+# Fast scaling to reduce CPU/GPU load
+sws-fast=yes
+```
+
+</NewCodeBlock>
+
+Parameter notes:
+
+- `profile=fast`: Enables a fast rendering preset to reduce post-processing overhead, suitable for embedded devices.
+- `hwdec=v4l2m2m-copy`: Uses the V4L2 M2M hardware decoder (standard on Qualcomm). `-copy` copies decoded frames from GPU memory to CPU-accessible memory for better compatibility.
+- `vo=gpu`: Uses GPU rendering output and supports OpenGL ES (common on ARM Linux). Recommended for embedded platforms.
+- `swapchain-depth=8`: Sets the GPU frame queue depth to improve stability and reduce stutter (especially on low-refresh displays).
+- `sws-fast=yes`: Enables fast software scaling to bypass high-quality scaling for better performance.
+
+:::tip Configuration priority
+
+mpv config file priority:
+
+1. User config: `~/.config/mpv/mpv.conf` (highest priority, recommended)
+2. Global config: `/etc/mpv/mpv.conf`
+
+Notes:
+
+If `/etc/mpv/mpv.conf` sets `hwdec=vaapi`, user-level config overrides it.
+
+If you do not create a user config, mpv uses `/etc/mpv/mpv.conf` directly. In that case, edit the global config or pass parameters on the command line.
+
+:::
+
+## Verify mpv
+
+Play any video on the board to verify the configuration. Download a video file to the board first.
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+mpv /path/to/your/video.mp4
+```
+
+</NewCodeBlock>
+
+When hardware decoding is enabled, the terminal will show a message like `Using hardware decoding (v4l2m2m-copy).`.
+
+## Temporarily set mpv parameters
+
+You can also set parameters on the command line, for example:
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+mpv --hwdec=v4l2m2m-copy --vo=gpu --swapchain-depth=8 --sws-fast=yes /path/to/your/video.mp4
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/vulkan.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/vulkan.md
@@ -1,0 +1,105 @@
+---
+sidebar_position: 7
+---
+
+# Vulkan User Guide
+
+This guide shows how to install Vulkan components and verify that Vulkan works on the Dragon Q8B (Mesa Turnip driver).
+
+## Install Vulkan
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo apt update
+# mesa-vulkan-drivers: Vulkan ICD (Turnip/Freedreno)
+# vulkan-tools: provides vulkaninfo
+sudo apt install -y mesa-vulkan-drivers vulkan-tools
+```
+
+</NewCodeBlock>
+
+## Run vulkaninfo
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+vulkaninfo
+```
+
+</NewCodeBlock>
+
+If you can see output like `driverName = turnip` and `deviceName = ... Adreno ...`, Vulkan is working.
+
+## Run vkpeak
+
+`vkpeak` is a simple Vulkan benchmark that can help quickly confirm the GPU and driver are working.
+
+Build `vkpeak`:
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo apt install -y git cmake g++
+git clone https://github.com/nihui/vkpeak.git
+cd vkpeak
+git submodule update --init --recursive
+
+mkdir build
+cd build
+cmake ..
+cmake --build . -j"$(nproc)"
+```
+
+</NewCodeBlock>
+
+Run `vkpeak`:
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+cd ./vkpeak/build
+./vkpeak 0
+```
+
+</NewCodeBlock>
+
+The output result is as follows:
+
+```text
+device       = Turnip Adreno (TM) 690
+driver       = turnip Mesa driver / Mesa 26.0.3-1ubuntu1
+
+fp32-scalar  = 2708.96 GFLOPS
+fp32-vec4    = 2774.66 GFLOPS
+
+fp16-scalar  = 3761.96 GFLOPS
+fp16-vec4    = 5542.70 GFLOPS
+fp16-matrix  = 0.00 GFLOPS
+
+fp64-scalar  = 0.00 GFLOPS
+fp64-vec4    = 0.00 GFLOPS
+
+int32-scalar = 694.37 GIOPS
+int32-vec4   = 701.89 GIOPS
+
+int16-scalar = 1822.40 GIOPS
+int16-vec4   = 1861.33 GIOPS
+
+int64-scalar = 121.03 GIOPS
+int64-vec4   = 102.85 GIOPS
+
+int8-dotprod = 7640.92 GIOPS
+int8-matrix  = 0.00 GIOPS
+
+bf16-dotprod = 0.00 GFLOPS
+bf16-matrix  = 0.00 GFLOPS
+
+fp8-matrix   = 0.00 GFLOPS
+bf8-matrix   = 0.00 GFLOPS
+
+copy-h2h     = 14.66 GBPS
+copy-h2d     = 14.59 GBPS
+copy-d2h     = 14.65 GBPS
+copy-d2d     = 28.93 GBPS
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/waydroid.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/waydroid.md
@@ -1,0 +1,180 @@
+---
+sidebar_position: 9
+---
+
+# Waydroid User Guide
+
+Waydroid is an Android container environment based on Wayland. It allows you to run Android apps on the Dragon Q8B.
+
+Waydroid runs a complete Android system in a container and integrates with the Linux desktop, so Android apps can run like native applications.
+
+:::tip
+
+- [Waydroid official documentation](https://docs.waydro.id/)
+  :::
+
+## Prerequisites
+
+Waydroid only works under a Wayland session. You can check your current session type with the following command.
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+echo $XDG_SESSION_TYPE
+```
+
+</NewCodeBlock>
+
+If the output is `wayland`, your current session is Wayland and you can run Waydroid.
+
+If the output is not `wayland`, select the **GNOME (Wayland)** session (avoid Xorg) from the login screen and log in again.
+
+## Install Waydroid
+
+### Add the Waydroid repository
+
+Add the official Waydroid repository.
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+curl -s https://repo.waydro.id | sudo bash
+```
+
+</NewCodeBlock>
+
+### Install Waydroid
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo apt update
+sudo apt install waydroid -y
+```
+
+</NewCodeBlock>
+
+## PSI kernel parameter
+
+Add the PSI kernel parameter.
+
+### Edit boot parameters
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo cp /etc/kernel/cmdline /etc/kernel/cmdline.bak
+grep -q 'psi=1' /etc/kernel/cmdline || sudo sed -i 's/$/ psi=1/' /etc/kernel/cmdline
+```
+
+</NewCodeBlock>
+
+### Update boot entry
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo kernel-install add $(uname -r) /boot/vmlinuz-$(uname -r)
+```
+
+</NewCodeBlock>
+
+Finally, reboot the system.
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo reboot
+```
+
+</NewCodeBlock>
+
+## Initialize Waydroid
+
+Before first use, you need to initialize Waydroid. You can click the Waydroid icon or run the command below in a terminal.
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo waydroid init
+```
+
+</NewCodeBlock>
+
+Initialization will automatically download `system.img` and `vendor.img`.
+
+:::tip Manually initialize Waydroid
+
+If automatic initialization fails or downloads are very slow, you can manually download the system/vendor archives and extract them to `/etc/waydroid-extra/images`.
+
+- Get the download URL
+
+Copy the download URL from the JSON files below. The dates of `system.img` and `vendor.img` should match; otherwise apps may crash.
+
+[system.img](https://ota.waydro.id/system/lineage/waydroid_arm64/VANILLA.json)
+
+[vendor.img](https://ota.waydro.id/vendor/waydroid_arm64/MAINLINE.json)
+
+- Extract the image archives
+
+Open a terminal, go to the directory where you downloaded the files, and extract the system/vendor archives to `/etc/waydroid-extra/images`.
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo mkdir -p /etc/waydroid-extra/images
+sudo unzip lineage-*-system.zip -d /etc/waydroid-extra/images
+sudo unzip lineage-*-vendor.zip -d /etc/waydroid-extra/images
+rm lineage-*-system.zip lineage-*-vendor.zip
+```
+
+</NewCodeBlock>
+
+- Re-initialize Waydroid
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo waydroid init -f
+```
+
+</NewCodeBlock>
+
+:::
+
+## Start Waydroid
+
+After initialization, start the Waydroid container service.
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo systemctl enable --now waydroid-container
+```
+
+</NewCodeBlock>
+
+Then start the Waydroid session and open the UI.
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+waydroid session start
+waydroid show-full-ui
+```
+
+</NewCodeBlock>
+
+## Install Android apps
+
+Open a terminal, change to the directory that contains the APK, and install it with the command below.
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+waydroid app install example-app.apk
+```
+
+</NewCodeBlock>
+
+After installation, the app will appear in your application menu.

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/webgl.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/webgl.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 8
+---
+
+# WebGL User Guide
+
+This guide shows how to verify that WebGL (GPU-accelerated rendering) is working in the browser on the Dragon Q8B.
+
+:::tip
+If you are working over SSH, make sure the board is connected to a display and you are in a desktop session. Otherwise, the browser may not enable GPU acceleration correctly.
+:::
+
+## Install chromium-browser
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+sudo apt update
+sudo apt install chromium-browser
+```
+
+</NewCodeBlock>
+
+## Run chromium-browser
+
+Start chromium-browser:
+
+<NewCodeBlock tip="radxa@dragon-q8b$" type="device">
+
+```bash
+chromium-browser
+```
+
+</NewCodeBlock>
+
+Open either of the following pages to check WebGL support:
+
+- https://webglreport.com/
+- https://get.webgl.org/
+
+If WebGL is reported as unavailable, open `chrome://gpu` and check the Graphics Feature Status to confirm whether hardware acceleration is enabled.


### PR DESCRIPTION
## Summary

- Add four system-config tutorials to Dragon Q8B so it matches Dragon Q6A:
  - `mpv` — hardware-accelerated video playback (V4L2 M2M)
  - `vulkan` — install/verify Mesa Turnip + run `vkpeak`
  - `webgl` — verify WebGL hardware acceleration in Chromium
  - `waydroid` — install, initialize and run Android in a container
- Both Chinese (`docs/`) and English (`i18n/en/`) versions are added.

## Why

Dragon Q6A already ships with these four tutorials under `system-config/`, but Dragon Q8B is missing all of them. They describe functionality that already works on Q8B's Qualcomm Adreno 690 / Mesa 26.0.3 stack and were verified locally (vkpeak on Adreno 690 returns a complete, sane result), so they fill a clear documentation gap and reduce repeated "does it work / how to set it up" support questions.

The new files are modeled on the corresponding Q6A tutorials and adapted for Q8B (prompt prefix `radxa@dragon-q8b$`, vkpeak output from Adreno 690 on Mesa 26.0.3-1ubuntu1).

## Verification

- `python3 scripts/github_pr_guard.py check --repo-path ~/radxa-docs/docs --fetch` reports `ok: true`
- All four CN files at `docs/dragon/q8b/system-config/{mpv,vulkan,webgl,waydroid}.md`
- All four EN files at `i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/system-config/{mpv,vulkan,webgl,waydroid}.md`
- Bilingual guard: `missing_en: []`, `missing_zh: []`
- `vkpeak` output in `vulkan.md` matches the actual run on the board
