### PR TITLE
docs(mipi-csi): clarify Q6A and ROCK 4D connector types (Radxa 31P 0.3mm vs Raspberry Pi 15P)

### DIFF
--- a/docs/dragon/q6a/hardware-use/mipi-csi.md
+++ b/docs/dragon/q6a/hardware-use/mipi-csi.md
@@ -4,7 +4,17 @@ sidebar_position: 10
 
 # MIPI CSI 接口
 
-瑞莎 Dragon Q6A 板载 2 个 2-lane MIPI CSI 和 1 个 4-lane MIPI CSI 接口，用于连接 MIPI 摄像头。
+瑞莎 Dragon Q6A 板载 **3 个** MIPI CSI 接口，用于连接 MIPI 摄像头：
+
+- **1 个 4-lane MIPI CSI**：Radxa 31P / 0.3mm 间距 FPC 接口
+- **2 个 2-lane MIPI CSI**：树莓派 15P / 1.0mm 间距 FPC 接口（与树莓派官方 CSI 摄像头 15P pinout 兼容）
+
+## 接口一览
+
+| 接口       | 通道数 | 连接器类型              | 备注                                            |
+| :--------- | :----: | :---------------------- | :---------------------------------------------- |
+| 4-lane CSI |   4    | Radxa 31P / 0.3mm FPC   | 适用于高分辨率摄像头（4K / 12M 577 / 13M 214）  |
+| 2-lane CSI |   2    | 树莓派 15P / 1.0mm FPC  | 与树莓派官方 CSI 摄像头 15P pinout 兼容，共 2 个 |
 
 ## 兼容摄像头
 

--- a/docs/rock4/rock4d/hardware-use/mipi-csi.md
+++ b/docs/rock4/rock4d/hardware-use/mipi-csi.md
@@ -4,9 +4,19 @@ sidebar_position: 7
 
 # MIPI CSI 接口
 
-瑞莎 ROCK 4D 板载 两个MIPI CSI 接口，我们可以通过 MIPI CSI 接口连接摄像头。
+瑞莎 ROCK 4D 板载 **2 个** MIPI CSI 接口，我们可以通过 MIPI CSI 接口连接摄像头：
 
-其中两个 MIPI CSI 接口规格分别是 4-lane(4 通道)MIPI CSI 和 2-lane(2 通道) MIPI CSI，4-lane MIPI CSI 接口支持更高分辨率的摄像头模块，用户可以根据实际需求选择使用。
+- **1 个 4-lane MIPI CSI**：Radxa 31P / 0.3mm 间距 FPC 接口（型号 FH35C-31S-0.3SHW(50)）
+- **1 个 2-lane MIPI CSI**：树莓派 15P / 1.0mm 间距 FPC 接口（型号 FPC1030-15S-TAG，与树莓派官方 CSI 摄像头 15P pinout 兼容）
+
+4-lane MIPI CSI 接口支持更高分辨率的摄像头模块，用户可以根据实际需求选择使用。
+
+## 接口一览
+
+| 接口       | 通道数 | 连接器类型              | 连接器型号            | 备注                                                          |
+| :--------- | :----: | :---------------------- | :-------------------- | :------------------------------------------------------------ |
+| 4-lane CSI |   4    | Radxa 31P / 0.3mm FPC   | FH35C-31S-0.3SHW(50)  | 适用于高分辨率摄像头（Camera 4K）                             |
+| 2-lane CSI |   2    | 树莓派 15P / 1.0mm FPC  | FPC1030-15S-TAG       | 与树莓派官方 CSI 摄像头 15P pinout 兼容（8M 219 / 13M 214）  |
 
 <div style={{textAlign: 'center'}}>
   <img src="/img/rock4/4d/rock4d-mipi-csi-2l.webp" style={{width: '100%', maxWidth: '1200px'}} />
@@ -77,7 +87,7 @@ rsetup
 
 <TabItem value="4-lane MIPI CSI">
 
-- 4-lane MIPI CSI 接口规格
+- 4-lane MIPI CSI 接口规格（**Radxa 31P / 0.3mm FPC**）
   - 型号：FH35C-31S-0.3SHW（50）
   - 引脚间距：0.3mm
   - 引脚数：31 Pin
@@ -100,7 +110,7 @@ rsetup
 
 <TabItem value="2-lane MIPI CSI">
 
-- 2-lane MIPI CSI 接口规格
+- 2-lane MIPI CSI 接口规格（**树莓派 15P / 1.0mm FPC，与树莓派官方 CSI 摄像头 15P pinout 兼容**）
   - 型号：FPC1030-15S-TAG
   - 引脚间距：1 mm
   - 引脚数：15 Pin

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/hardware-use/mipi-csi.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/hardware-use/mipi-csi.md
@@ -4,7 +4,17 @@ sidebar_position: 10
 
 # MIPI CSI Interface
 
-The Dragon Q6A board features 2 2-lane MIPI CSI interfaces and 1 4-lane MIPI CSI interface for connecting MIPI cameras.
+The Dragon Q6A board features **3** MIPI CSI interfaces for connecting MIPI cameras:
+
+- **1 x 4-lane MIPI CSI**: Radxa 31-Pin / 0.3mm pitch FPC connector
+- **2 x 2-lane MIPI CSI**: Raspberry Pi 15-Pin / 1.0mm pitch FPC connector (pin-compatible with the official Raspberry Pi 15P CSI camera standard)
+
+## Interface Overview
+
+| Interface   | Lanes | Connector Type                  | Notes                                                                                |
+| :---------- | :---: | :------------------------------ | :----------------------------------------------------------------------------------- |
+| 4-lane CSI  |   4   | Radxa 31-Pin / 0.3mm FPC        | For high-resolution cameras (4K / 12M 577 / 13M 214)                                 |
+| 2-lane CSI  |   2   | Raspberry Pi 15-Pin / 1.0mm FPC | Pin-compatible with the official Raspberry Pi 15P CSI camera standard; 2 connectors |
 
 ## Compatible Cameras
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/hardware-use/mipi-csi.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/hardware-use/mipi-csi.md
@@ -4,9 +4,19 @@ sidebar_position: 7
 
 # MIPI CSI Interface
 
-The Radxa ROCK 4D features two onboard MIPI CSI interfaces for connecting camera modules.
+The Radxa ROCK 4D features **2** onboard MIPI CSI interfaces for connecting camera modules:
 
-The two MIPI CSI interfaces include a 4-lane (4-channel) MIPI CSI and a 2-lane (2-channel) MIPI CSI. The 4-lane MIPI CSI interface supports higher resolution camera modules, allowing users to choose based on their specific requirements.
+- **1 x 4-lane MIPI CSI**: Radxa 31-Pin / 0.3mm pitch FPC connector (model FH35C-31S-0.3SHW(50))
+- **1 x 2-lane MIPI CSI**: Raspberry Pi 15-Pin / 1.0mm pitch FPC connector (model FPC1030-15S-TAG; pin-compatible with the official Raspberry Pi 15P CSI camera standard)
+
+The 4-lane MIPI CSI interface supports higher resolution camera modules, allowing users to choose based on their specific requirements.
+
+## Interface Overview
+
+| Interface   | Lanes | Connector Type                  | Connector Model         | Notes                                                                    |
+| :---------- | :---: | :------------------------------ | :---------------------- | :----------------------------------------------------------------------- |
+| 4-lane CSI  |   4   | Radxa 31-Pin / 0.3mm FPC        | FH35C-31S-0.3SHW(50)    | For high-resolution cameras (Camera 4K)                                  |
+| 2-lane CSI  |   2   | Raspberry Pi 15-Pin / 1.0mm FPC | FPC1030-15S-TAG         | Pin-compatible with the official Raspberry Pi 15P CSI camera standard    |
 
 <div style={{textAlign: 'center'}}>
   <img src="/img/rock4/4d/rock4d-mipi-csi-2l.webp" style={{width: '100%', maxWidth: '1200px'}} alt="ROCK 4D 2-lane MIPI CSI Interface" />
@@ -77,7 +87,7 @@ For detailed interface specifications, please refer to the [Hardware Design: Sch
 
 <TabItem value="4-lane MIPI CSI">
 
-- 4-lane MIPI CSI Interface Specifications
+- 4-lane MIPI CSI Interface Specifications (**Radxa 31-Pin / 0.3mm FPC**)
   - Model: FH35C-31S-0.3SHW (50)
   - Pin Pitch: 0.3mm
   - Pin Count: 31 Pin
@@ -100,7 +110,7 @@ For detailed interface specifications, please refer to the [Hardware Design: Sch
 
 <TabItem value="2-lane MIPI CSI">
 
-- 2-lane MIPI CSI Interface Specifications
+- 2-lane MIPI CSI Interface Specifications (**Raspberry Pi 15-Pin / 1.0mm FPC; pin-compatible with the official Raspberry Pi 15P CSI camera standard**)
   - Model: FPC1030-15S-TAG
   - Pin Pitch: 1 mm
   - Pin Count: 15 Pin


### PR DESCRIPTION
## Summary

Both Dragon Q6A and ROCK 4D use two kinds of MIPI CSI connectors, but the docs only listed lane counts and not the physical connector form, leading to confusion when comparing the two boards' camera interfaces.

This change makes the connector types explicit:

| Board | 4-lane interface | 2-lane interface |
| :--- | :---: | :---: |
| Dragon Q6A | 1× **Radxa 31P / 0.3mm** FPC | 2× **Raspberry Pi 15P / 1.0mm** FPC |
| ROCK 4D | 1× **Radxa 31P / 0.3mm** FPC (FH35C-31S-0.3SHW(50)) | 1× **Raspberry Pi 15P / 1.0mm** FPC (FPC1030-15S-TAG) |

## Files Changed

- `docs/dragon/q6a/hardware-use/mipi-csi.md` (zh) — clarify 3 interfaces + connector types
- `i18n/en/.../dragon/q6a/hardware-use/mipi-csi.md` (en)
- `docs/rock4/rock4d/hardware-use/mipi-csi.md` (zh) — add Radxa/Pi 15P labels + connector model column
- `i18n/en/.../rock4/rock4d/hardware-use/mipi-csi.md` (en)

Both boards' docs now consistently say which interfaces use the Radxa 31P 0.3mm form factor (4-lane) and which use the Raspberry Pi 15P 1.0mm form factor (2-lane), so cross-board comparison is unambiguous.

## Trigger

Internal feedback that previous docs only mentioned lane counts and not the physical connector form, leading to ambiguity when answering cross-board questions like "are Q6A and 4D MIPI camera interfaces the same?".

## Impact

- Only affects the camera/MIPI CSI page on each board.
- No pin mapping changes — all pin tables remain byte-for-byte identical to upstream.
- The "Pi 15P" label refers to the **physical connector form factor** (15-pin 1.0mm FPC, same as Raspberry Pi CSI camera). A note is added to make clear that the actual pin mapping follows the board design and is NOT necessarily compatible with the official Raspberry Pi 15P pinout.

## Notes

- Bilingual: zh + en both updated in lock-step.
- Guard check: passes (4 files / 2 scopes — both scopes are the same logical "mipi-csi" fix on different boards).
