### PR TITLE
docs(linkr): sync LED indicator and User Guide URL fixes to English (#1839)

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/getting-started.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/getting-started.mdx
@@ -49,7 +49,7 @@ After powering on, observe the **system status LED next to the FN key**:
 
 | Indicator | Meaning |
 | --- | --- |
-| Solid red | Starting up, please wait |
+| Flashing blue | Starting up, please wait |
 | **Solid blue** | System is normal, you can access it |
 | Solid green | Someone is remotely using it |
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/product-introduction.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/product-introduction.mdx
@@ -73,7 +73,7 @@ There is one indicator LED on each side of the device's **FN key**:
 
 | LED State | Description |
 | --- | --- |
-| Solid red | System is starting up |
+| Flashing blue | System is starting up |
 | Solid blue | System is running normally |
 | Solid green | In active use (an active connection exists) |
 | Flashing white | Firmware is being upgraded |
@@ -119,7 +119,7 @@ In addition to the hardware KVM capabilities, the Linkr KVM firmware and the web
 
 | Feature | Description | Documentation |
 | --- | --- | --- |
-| Web remote console | Video, keyboard/mouse, screenshots, recording, virtual keyboard, etc. | [User Interface Guide](./page-display) |
+| Web remote console | Video, keyboard/mouse, screenshots, recording, virtual keyboard, etc. | [User Interface Guide](./usage) |
 | Tailscale | Built-in VPN, access the device remotely without a public IP | [Tailscale Remote Access](./tailscale) |
 | Wake on LAN | Send a magic packet on the LAN to wake the target host | [Wake on LAN](./wake-on-lan) |
 | Access tokens | API keys that support screenshot and control endpoints | [Access Tokens](./access-token) |


### PR DESCRIPTION
## Description

Sync the Chinese-only changes from PR #1839 (already merged into upstream `main`) to the English tutorial.

PR #1839 changed the Linkr KVM system status LED documentation to match actual firmware behavior (the booting state is **flashing blue**, not solid red) and fixed a stale User Interface Guide link. The Chinese `docs/` files were updated in that PR, but the corresponding English `i18n/en/...` files were left behind. This PR closes the gap so the two locales stay consistent.

## Changes

| File | Change |
| --- | --- |
| `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/getting-started.mdx` | Booting indicator: `Solid red` → `Flashing blue` |
| `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/product-introduction.mdx` | Booting indicator: `Solid red` → `Flashing blue` |
| `i18n/en/docusaurus-plugin-content-docs/current/linkr/linkr-kvm/product-introduction.mdx` | User Interface Guide link: `./page-display` → `./usage` |

Mirrors PR #1839 (`docs(Linkr): update system status LED indicator documentation`) one-to-one for the English locale.

## Source

- Upstream PR: https://github.com/radxa-docs/docs/pull/1839
- Upstream merge commit: `03b6358e3` on `radxa-docs/docs` `main`
- Base branch: `upstream-docs/main` (created fresh off the latest `main` after PR #1839 was merged)

## Validation

- `git diff --stat`: 2 files changed, 3 insertions(+), 3 deletions(-) — exactly matches the upstream PR's stat.
- Only English files touched; the Chinese counterpart in `docs/linkr/linkr-kvm/` was already updated upstream in PR #1839, so this PR does not re-touch it.
