### PR TITLE
docs(cubie): add GStreamer install step before gst-launch-1.0 sections

### DIFF
--- a/docs/common/dev/_a733-video-codec.mdx
+++ b/docs/common/dev/_a733-video-codec.mdx
@@ -9,7 +9,7 @@
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y gstreamer1.0-plugins-base-apps
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
 ```
 
 </NewCodeBlock>

--- a/docs/cubie/a5e/accessories/camera-13m-214.md
+++ b/docs/cubie/a5e/accessories/camera-13m-214.md
@@ -13,6 +13,17 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 
 <Camera13M214 product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a5e'/>
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 预览摄像头画面。

--- a/docs/cubie/a5e/accessories/camera-4k.md
+++ b/docs/cubie/a5e/accessories/camera-4k.md
@@ -13,6 +13,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 
 <Camera4K product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a5e' enable_camera='Enable Radxa Camera 4K'/>
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 预览摄像头画面。

--- a/docs/cubie/a5e/accessories/camera-8m-219.md
+++ b/docs/cubie/a5e/accessories/camera-8m-219.md
@@ -13,6 +13,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 
 <Camera8M219 product='瑞莎 Cubie A5E' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='同面' board='cubie-a5e' />
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 预览摄像头画面。

--- a/docs/cubie/a7a/accessories/camera-13m-214.md
+++ b/docs/cubie/a7a/accessories/camera-13m-214.md
@@ -13,6 +13,17 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 
 <Camera13M214 product='瑞莎 Cubie A7A' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a7a'/>
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 预览摄像头画面。

--- a/docs/cubie/a7a/accessories/camera-4k.md
+++ b/docs/cubie/a7a/accessories/camera-4k.md
@@ -13,6 +13,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 
 <Camera4K product='瑞莎 Cubie A7A' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a7a' enable_camera='Enable Radxa Camera 4K'/>
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 预览摄像头画面。

--- a/docs/cubie/a7a/accessories/camera-8m-219.md
+++ b/docs/cubie/a7a/accessories/camera-8m-219.md
@@ -13,6 +13,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 
 <Camera8M219 product='瑞莎 Cubie A7A' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='同面' board='cubie-a7a' />
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 预览摄像头画面。

--- a/docs/cubie/a7s/accessories-use/camera-13m-214.md
+++ b/docs/cubie/a7s/accessories-use/camera-13m-214.md
@@ -19,6 +19,17 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 
 <Camera13M214 product='瑞莎 Cubie A7S' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a7s'/>
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7s$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 工具预览摄像头画面。

--- a/docs/cubie/a7s/accessories-use/camera-4k.md
+++ b/docs/cubie/a7s/accessories-use/camera-4k.md
@@ -19,6 +19,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 
 <Camera4K product='瑞莎 Cubie A7S' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a7s'/>
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7s$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 工具预览摄像头画面。

--- a/docs/cubie/a7s/accessories-use/camera-8m-219.md
+++ b/docs/cubie/a7s/accessories-use/camera-8m-219.md
@@ -19,6 +19,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 
 <Camera8M219 product='瑞莎 Cubie A7S' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='同面' board='cubie-a7s'/>
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7s$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 工具预览摄像头画面。

--- a/docs/cubie/a7z/accessories/camera-13m-214.md
+++ b/docs/cubie/a7z/accessories/camera-13m-214.md
@@ -13,6 +13,17 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 
 <Camera13M214 product='瑞莎 Cubie A7Z' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a7z'/>
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 预览摄像头画面。

--- a/docs/cubie/a7z/accessories/camera-4k.md
+++ b/docs/cubie/a7z/accessories/camera-4k.md
@@ -13,6 +13,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 
 <Camera4K product='瑞莎 Cubie A7Z' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='异面' board='cubie-a7z' enable_camera='Enable Radxa Camera 4K'/>
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 预览摄像头画面。

--- a/docs/cubie/a7z/accessories/camera-8m-219.md
+++ b/docs/cubie/a7z/accessories/camera-8m-219.md
@@ -13,6 +13,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 
 <Camera8M219 product='瑞莎 Cubie A7Z' interface='31-Pin 0.3 mm 间距 SMD 卧式 FPC 接口' connect='翻盖式，下接触' pins='31-Pin' pitch='0.3mm 间距' orientation='同面' board='cubie-a7z' />
 
+## 安装 GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## 预览摄像头
 
 使用 GStreamer 预览摄像头画面。

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_a733-video-codec.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_a733-video-codec.mdx
@@ -10,7 +10,7 @@ Radxa Cubie A7A, Radxa Cubie A7S, and Radxa Cubie A7Z running Debian desktop ima
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y gstreamer1.0-plugins-base-apps
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-13m-214.md
@@ -13,6 +13,17 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 
 <Camera13M214 product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a5e' />
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera image.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-4k.md
@@ -13,6 +13,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 
 <Camera4K product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a5e' enable_camera='Enable Radxa Camera 4K' />
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera image.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/accessories/camera-8m-219.md
@@ -13,6 +13,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 
 <Camera8M219 product='Radxa Cubie A5E' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='same side' board='cubie-a5e' />
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a5e$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera image.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-13m-214.md
@@ -13,6 +13,17 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 
 <Camera13M214 product='Radxa Cubie A7A' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a7a' />
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera image.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-4k.md
@@ -13,6 +13,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 
 <Camera4K product='Radxa Cubie A7A' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a7a' enable_camera='Enable Radxa Camera 4K' />
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera image.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/accessories/camera-8m-219.md
@@ -13,6 +13,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 
 <Camera8M219 product='Radxa Cubie A7A' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='same side' board='cubie-a7a' />
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7a$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera image.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-13m-214.md
@@ -19,6 +19,17 @@ This tutorial applies to the Radxa OS system image.
 
 <Camera13M214 product='Radxa Cubie A7S' interface='31-pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a7s'/>
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7s$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera stream.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-4k.md
@@ -19,6 +19,17 @@ This tutorial applies to the Radxa OS system image.
 
 <Camera4K product='Radxa Cubie A7S' interface='31-pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a7s'/>
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7s$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera stream.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/accessories-use/camera-8m-219.md
@@ -19,6 +19,17 @@ This tutorial applies to the Radxa OS system image.
 
 <Camera8M219 product='Radxa Cubie A7S' interface='31-pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='same side' board='cubie-a7s'/>
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7s$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera stream.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-13m-214.md
@@ -13,6 +13,17 @@ import Camera13M214 from '../../../common/accessories/\_camera-13m-214.mdx';
 
 <Camera13M214 product='Radxa Cubie A7Z' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a7z' />
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera image.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-4k.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-4k.md
@@ -13,6 +13,17 @@ import Camera4K from '../../../common/accessories/\_camera-4k.mdx';
 
 <Camera4K product='Radxa Cubie A7Z' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='opposite side' board='cubie-a7z' enable_camera='Enable Radxa Camera 4K' />
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera image.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-8m-219.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/accessories/camera-8m-219.md
@@ -13,6 +13,17 @@ import Camera8M219 from '../../../common/accessories/\_camera-8m-219.mdx';
 
 <Camera8M219 product='Radxa Cubie A7Z' interface='31-Pin 0.3 mm pitch SMD horizontal FPC connector' connect='Flip type, bottom contact' pins='31-Pin' pitch='0.3mm pitch' orientation='same side' board='cubie-a7z' />
 
+## Install GStreamer
+
+<NewCodeBlock tip='radxa@cubie-a7z$' type="device">
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base-apps
+```
+
+</NewCodeBlock>
+
 ## Preview the camera
 
 Use GStreamer to preview the camera image.


### PR DESCRIPTION
## Summary

The Radxa Cubie Debian desktop image does **not** ship GStreamer by default, so following the camera preview and A733 video codec tutorials directly throws `gst-launch-1.0: command not found`.

This PR adds a "Install GStreamer" section ahead of the first `gst-launch-1.0` command in every Cubie camera tutorial, and aligns the existing video-codec install command to use the canonical `gstreamer1.0-tools` package.

Both Chinese and English tutorials are updated in sync.

## Background

Customer report in the internal 售后技术支持 group: a user ran the camera preview command from `https://docs.radxa.com/cubie/a7s/accessories-use/camera-8m-219` and got `gst-launch-1.0: command not found`. The product owner (张剑锋) confirmed the image does not pre-install GStreamer and suggested `sudo apt install gstreamer1.0-tools`.

## Changes

### 1. New "Install GStreamer" section added to all Cubie camera tutorials (CN + EN)

Inserted before `## 预览摄像头` / `## Preview the camera`:

```bash
sudo apt-get update
sudo apt-get install -y gstreamer1.0-tools
```

Files touched (4 products × 3 cameras × 2 languages = 24 files):

- `docs/cubie/{a5e,a7a,a7s,a7z}/.../camera-4k.md`
- `docs/cubie/{a5e,a7a,a7s,a7z}/.../camera-8m-219.md`
- `docs/cubie/{a5e,a7a,a7s,a7z}/.../camera-13m-214.md`
- `i18n/en/.../current/cubie/{a5e,a7a,a7s,a7z}/.../camera-*.md`

### 2. Update the existing A733 video-codec install command (CN + EN)

`docs/common/dev/_a733-video-codec.mdx` and the EN counterpart already have an install section, but the package was `gstreamer1.0-plugins-base-apps`. Aligned to the canonical `gstreamer1.0-tools` for consistency with the camera tutorials.

## Why `gstreamer1.0-tools`

This is the minimum package needed to make `gst-launch-1.0` available. Customers were instructed by the product owner (张剑锋) to install exactly this package, and the new camera pages now use the same command.

## Impact

- docs-only change, no code, no image, no behavior change at runtime
- Bilingual: all 26 files have CN+EN counterparts (verified by `github_pr_guard.py`)
- A single commit (`e761c4ebd`) on a fresh branch from `upstream-docs/main`

## Test

- Verified line ordering: `## 安装 GStreamer` / `## Install GStreamer` always appears before the first `gst-launch-1.0` command in every touched file
- Verified no other lines were altered (`git diff --stat`: 26 files, 266 insertions, 2 deletions)
