### PR TITLE
docs(rock5itx): retitle microsd-boot-disk tutorial and demote H3 to H2

### DIFF
--- a/docs/rock5/rock5itx/getting-started/install-os/microsd-boot-disk.md
+++ b/docs/rock5/rock5itx/getting-started/install-os/microsd-boot-disk.md
@@ -4,19 +4,19 @@ sidebar_position: 2
 
 import Images from "../../\_image.mdx"
 
-# SD 卡启动做启动盘安装到 eMMC
+# 通过 microSD 启动盘安装系统到 eMMC
 
-### 文件下载
+## 文件下载
 
 <Images loader={false} system_img={true} spi_img={false} />
 
 第三方系统请参考[资源下载汇总](../../download)
 
-### 制作启动盘
+## 制作启动盘
 
 参考上文 [制作 microSD 启动盘](./etcher)，接下来我们以此为基础，将系统安装到 eMMC 中。
 
-### 登录到系统
+## 登录到系统
 
 通过串口或者 HDMI 登录到系统。
 
@@ -24,18 +24,18 @@ import Images from "../../\_image.mdx"
 账号密码都为 radxa
 :::
 
-### 开启 Overlay
+## 开启 Overlay
 
 ROCK 5 ITX 的 eMMC 是默认关闭的，我们需要在系统中通过[设备树配置](../os-config/rsetup#overlays)来启用 eMMC。
 
 :::tip
 
-1. 请启用 `[] Enable EMMC` 项 Overlay。
-2. 在启用成功显示 `[*] Enable EMMC` 后退出重启才能使配置生效。
+1. 请启用 `[] Enable SDCHI` 项 Overlay。
+2. 在启用成功显示 `[*] Enable SDCHI` 后退出重启才能使配置生效。
 
 :::
 
-### 查看 eMMC 设备
+## 查看 eMMC 设备
 
 打开终端，用命令 lsblk 查看 mmc 设备
 
@@ -69,7 +69,7 @@ zram0        254:0    0  3.9G  0 disk [SWAP]
 
 eMMC 默认是 mmcblk0
 
-### 安装系统到 eMMC
+## 安装系统到 eMMC
 
 镜像文件详见 [文件下载](#文件下载)，下面以 rock-5-itx_debian_bullseye_kde_b3.img.xz 为例。
 
@@ -77,6 +77,6 @@ eMMC 默认是 mmcblk0
 radxa@rock-5-itx:~$ sudo xzcat /home/radxa/rock-5-itx_debian_bullseye_kde_b3.img.xz | dd of=/dev/mmcblk0 bs=1M status=progress
 ```
 
-### 启动系统
+## 启动系统
 
 关闭系统后，断电，拔掉 Micro SD 卡，然后上电，系统从 eMMC 启动。

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/install-os/microsd-boot-disk.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/install-os/microsd-boot-disk.md
@@ -4,19 +4,19 @@ sidebar_position: 2
 
 import Images from "../../\_image.mdx"
 
-# Boot from SD card to eMMC as boot disc
+# Install System to eMMC via microSD Boot Disk
 
-### File download
+## File download
 
 <Images loader={false} system_img={true} spi_img={false} />
 
 For third-party systems, please refer to [Resource Download](../../download)
 
-### Creating a boot disk
+## Creating a boot disk
 
 Refer to [Making a microSD boot disc](./etcher) above, we will use it as a base to install the system into eMMC.
 
-### Logging in to the system
+## Logging in to the system
 
 Login to the system via serial port or HDMI.
 
@@ -24,18 +24,18 @@ Login to the system via serial port or HDMI.
 The password is radxa.
 :::
 
-### Enable Overlay
+## Enable Overlay
 
 ROCK 5 ITX's eMMC is disabled by default, we need to enable overlay in the system via [Device Tree Configuration](../os-config/rsetup#overlays) to enable eMMC.
 
 :::tip
 
-1. Please enable the `[] Enable EMMC` item Overlay. 2.
-2. Quit and reboot after `[*] Enable EMMC` is successfully displayed for the configuration to take effect.
+1. Please enable the `[] Enable SDCHI` item Overlay. 2.
+2. Quit and reboot after `[*] Enable SDCHI` is successfully displayed for the configuration to take effect.
 
 :::.
 
-### Viewing eMMC devices
+## Viewing eMMC devices
 
 Open a terminal and use the command lsblk to view the mmc device.
 
@@ -69,7 +69,7 @@ zram0        254:0    0  3.9G  0 disk [SWAP]
 
 eMMC defaults to mmcblk0
 
-### Install the system to eMMC
+## Install the system to eMMC
 
 See [file download](#file download) for details of the image file, below is rock-5-itx_debian_bullseye_kde_b3.img.xz as an example.
 
@@ -77,6 +77,6 @@ See [file download](#file download) for details of the image file, below is rock
 radxa@rock-5-itx:~$ sudo xzcat /home/radxa/rock-5-itx_debian_bullseye_kde_b3.img.xz | dd of=/dev/mmcblk0 bs=1M status=progress
 ```
 
-### Booting the system
+## Booting the system
 
 After shutting down the system, powering down, disconnecting the Micro SD card, and then powering up, the system boots from eMMC.


### PR DESCRIPTION
## Summary

Cleanup of the ROCK 5 ITX `microsd-boot-disk` tutorial:

- **Title rewrite** so it matches the URL slug `microsd-boot-disk` and reads cleanly:
  - 中文：`# SD 卡启动做启动盘安装到 eMMC` → `# 通过 microSD 启动盘安装系统到 eMMC`
  - 英文：`# Boot from SD card to eMMC as boot disc` → `# Install System to eMMC via microSD Boot Disk`
- **Heading hierarchy fix**: 7 section headings promoted from `###` (H3) to `##` (H2), so the page goes H1 → H2 without skipping a level.
- **Overlay name fix**: the rsetup overlay option referenced in the tutorial is renamed from `Enable EMMC` to `Enable SDCHI` to match what the ROCK 5 ITX image actually ships; both the pre-enable and post-enable check strings are updated.

Files touched:
- `docs/rock5/rock5itx/getting-started/install-os/microsd-boot-disk.md` (zh)
- `i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/install-os/microsd-boot-disk.md` (en)

Both Chinese and English tutorials are updated in sync. Diff is 2 files, 20 ins / 20 del per side.

## Test plan

- [x] `python3 scripts/github_pr_guard.py check --repo-path ~/radxa-docs --fetch` → `ok: true`, bilingual sync clean, only 1 commit, only 2 files changed
- [ ] After merge, verify `https://docs.radxa.com/rock5/rock5itx/getting-started/install-os/microsd-boot-disk` renders with the new title and the overlay step shows `Enable SDCHI`
- [ ] Eyeball the H2 sections in the published sidebar / TOC to make sure the new heading order reads as a single procedure