### PR TITLE
docs(productlist): add SC8280XP part number to Dragon Q8B description

### DIFF
--- a/docs/productlist.md
+++ b/docs/productlist.md
@@ -96,7 +96,7 @@ displayed_sidebar: home
 | 型号                       | 简介                              |
 | -------------------------- | --------------------------------- |
 | [Dragon Q6A](/dragon/q6a/) | 基于高通 QCS6490 的迷你主板       |
-| [Dragon Q8B](/dragon/q8b/) | 基于高通骁龙 8cx Gen 3 的迷你主板 |
+| [Dragon Q8B](/dragon/q8b/) | 基于高通骁龙 8cx Gen 3 (高通 SC8280XP) 的迷你主板 |
 
 ## 瑞莎主板
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/productlist.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/productlist.md
@@ -95,7 +95,7 @@ Welcome to the Radxa Product Center! We specialize in mini PCs, compute modules,
 | Model                      | Description                                          |
 | -------------------------- | ---------------------------------------------------- |
 | [Dragon Q6A](/dragon/q6a/) | Qualcomm QCS6490 based Mini Motherboard              |
-| [Dragon Q8B](/dragon/q8b/) | Qualcomm Snapdragon 8cx Gen 3 based Mini Motherboard |
+| [Dragon Q8B](/dragon/q8b/) | Qualcomm Snapdragon 8cx Gen 3 (Qualcomm SC8280XP) based Mini Motherboard |
 
 ## Radxa Motherboards
 


### PR DESCRIPTION
## 背景
按官方对外宣传口径，Dragon Q8B 的处理器应使用完整料号：
- en: `Qualcomm Snapdragon 8cx Gen 3 (Qualcomm SC8280XP)`
- zh: `高通 Snapdragon 8cx Gen 3 (高通 SC8280XP)`

`productlist.md` 的 Q8B 行当前只写了营销名，本次把 SC8280XP 补上；同时把 "高通骁龙" 改成 "高通 Snapdragon" 统一。

## 范围
**仅改 Q8B 行**，Q6A / rCore-Q9075 行不碰（已由 PR #1850 覆盖）。
**仅改非 NPU 教程**，NPU 教程（`common/ai/qualcomm/_*.mdx`）按约定**不动**。

**修改 2 个文件**（zh + en 各 1）：
- `docs/productlist.md` L99
- `i18n/en/.../productlist.md` L98

## 自检
- `github_pr_guard.py check` → ok: True，1 scope，2 files，bilingual 对齐

## 关系链
- PR #1849 (fix/q6a-soc-naming) — Q6A 教程命名统一
- PR #1850 (fix/q6a-productlist-naming) — productlist Q6A / rCore-Q9075
- PR #1851 (fix/q8b-soc-naming，本仓库) — Q8B 教程命名统一
- PR #1852 (fix/q8b-productlist-naming，本 PR) — productlist Q8B

4 个 PR 都从 `upstream-docs/main` 干净切出，guard ok: True，无相互冲突
