### PR TITLE
docs(rock3/rock3b): widen Maskrom erase pin images from 500 to 1200

### DIFF
--- a/docs/rock3/rock3b/low-level-dev/maskrom/erase.md
+++ b/docs/rock3/rock3b/low-level-dev/maskrom/erase.md
@@ -31,7 +31,7 @@ import ERASE from "../../../../common/dev/\_erase-spi-emmc.mdx";
 - 若需要清除 SPI Flash，则主板上电后取下短接 DIS SPI 和 GND 引脚的跳线帽或杜邦线
 - 若需要清除 eMMC 模块，则主板上电后取下短接 DIS eMMC 和 GND 引脚的跳线帽或杜邦线
 
-<img src="/img/rock3/3b/rock3b-maskrom-pins.webp" alt="ROCK 3B maskrom pins" width="500" />
+<img src="/img/rock3/3b/rock3b-maskrom-pins.webp" alt="ROCK 3B maskrom pins" width="1200" />
 
     </TabItem>
     <TabItem value="ROCK 3B+">
@@ -49,7 +49,7 @@ import ERASE from "../../../../common/dev/\_erase-spi-emmc.mdx";
 - 若需要清除 SPI Flash，则主板上电后取下短接 DIS SPI 和 GND 引脚的跳线帽或杜邦线
 - 若需要清除 eMMC 模块，则主板上电后取下短接 DIS eMMC 和 GND 引脚的跳线帽或杜邦线
 
-<img src="/img/rock3/3b/rock3b-plus-maskrom-pins.webp" alt="ROCK 3B+ maskrom pins" width="500" />
+<img src="/img/rock3/3b/rock3b-plus-maskrom-pins.webp" alt="ROCK 3B+ maskrom pins" width="1200" />
 
     </TabItem>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/low-level-dev/maskrom/erase.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/low-level-dev/maskrom/erase.md
@@ -31,7 +31,7 @@ Notes:
 - To clear SPI Flash, remove the jumper cap or jumper wire shorting the DIS SPI and GND pins after powering on the board.
 - To clear the eMMC module, remove the jumper cap or jumper wire shorting the DIS eMMC and GND pins after powering on the board.
 
-<img src="/img/rock3/3b/rock3b-maskrom-pins.webp" alt="ROCK 3B maskrom pins" width="500" />
+<img src="/img/rock3/3b/rock3b-maskrom-pins.webp" alt="ROCK 3B maskrom pins" width="1200" />
 
     </TabItem>
     <TabItem value="ROCK 3B+">
@@ -49,7 +49,7 @@ Notes:
 - To clear SPI Flash, remove the jumper cap or jumper wire shorting the DIS SPI and GND pins after powering on the board.
 - To clear the eMMC module, remove the jumper cap or jumper wire shorting the DIS eMMC and GND pins after powering on the board.
 
-<img src="/img/rock3/3b/rock3b-plus-maskrom-pins.webp" alt="ROCK 3B+ maskrom pins" width="500" />
+<img src="/img/rock3/3b/rock3b-plus-maskrom-pins.webp" alt="ROCK 3B+ maskrom pins" width="1200" />
 
     </TabItem>
 


### PR DESCRIPTION
## Summary

- Bump the rendered display width of the ROCK 3B / 3B+ Maskrom pin reference images from `500` to `1200` in `docs/rock3/rock3b/low-level-dev/maskrom/erase.md`, so the pin labels and silkscreen markings stay legible at typical docs viewport sizes.
- Mirror the same change in the English translation at `i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/low-level-dev/maskrom/erase.md` so the two languages stay in sync.

## Scope

- 2 files, 4 lines changed
- Pure docs / docs-i18n touch, no code, no script, no asset
- Affects only the ROCK 3B / ROCK 3B+ tab in the Maskrom erase tutorial

## Why

The original `width="500"` makes the pinout reference images render quite small in the side-by-side Maskrom tab view, and several readers (including on mobile widths) reported having to open the image in a new tab to read the silkscreen. `1200` matches the wider render convention used in other recent ROCK 3B tutorials and keeps the image inside the normal docs column at common viewport sizes.

## Files

- `docs/rock3/rock3b/low-level-dev/maskrom/erase.md` — ROCK 3B and ROCK 3B+ `<img ... width="500" />` -> `width="1200"`
- `i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/low-level-dev/maskrom/erase.md` — same change in the English version

## Checklist

- [x] Both Chinese (`docs/`) and English (`i18n/en/`) updated together
- [x] Only the targeted image width attribute changed; no other lines touched
- [x] Branched from `upstream-docs/main` and `github_pr_guard` passes (`ok: true`, bilingual clean)