### PR TITLE
docs(dragon/q8b): rename system image version tip from R2 to T2

### DIFF
--- a/docs/dragon/q8b/app-dev/npu-dev/fastrpc-setup.md
+++ b/docs/dragon/q8b/app-dev/npu-dev/fastrpc-setup.md
@@ -13,7 +13,7 @@ import FASTRPCSETUP from '../../../../common/ai/qualcomm/\_fastrpc_setup.mdx';
 
 :::tip
 
-使用 R2 或更高版本的系统镜像时，NPU 运行环境已预装，无需额外安装。
+使用 T2 或更高版本的系统镜像时，NPU 运行环境已预装，无需额外安装。
 
 :::
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/npu-dev/fastrpc-setup.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/npu-dev/fastrpc-setup.md
@@ -13,7 +13,7 @@ import FASTRPCSETUP from '../../../../common/ai/qualcomm/\_fastrpc_setup.mdx';
 
 :::tip
 
-When using system image version R2 or higher, the NPU runtime environment is pre-installed and no additional installation is required.
+When using system image version T2 or higher, the NPU runtime environment is pre-installed and no additional installation is required.
 
 :::
 


### PR DESCRIPTION
## Summary

- Q8B-only rename of the system image version tip from **R2** to **T2** in the NPU preinstalled-runtime line, in both the Chinese source and the English translation.
- Files touched:
  - `docs/dragon/q8b/app-dev/npu-dev/fastrpc-setup.md`
  - `i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/npu-dev/fastrpc-setup.md`

## Scope (deliberately narrow)

- 2 files, 2 lines changed (1 line per file)
- Only the **Q8B** wrapper is modified
- The **Q6A** wrapper (`docs/dragon/q6a/app-dev/npu-dev/fastrpc-setup.md`, which also has the `R2` text) and the shared `common/ai/qualcomm/_fastrpc_setup.mdx` (which does not carry any `R2` / `T2` text) are **intentionally left untouched** — this PR is a scoped Q8B-only change as instructed.

## Why

Internal instruction to update the Q8B fastrpc-setup tutorial so the "NPU runtime preinstalled" tip refers to system image version **T2** instead of **R2**. Keeping this scoped to Q8B only because the same `R2` text in the Q6A wrapper is treated as a separate concern.

## Checklist

- [x] Both Chinese (`docs/`) and English (`i18n/en/`) updated together
- [x] Q6A wrapper and `common/ai/qualcomm/_fastrpc_setup.mdx` left untouched
- [x] Branched from `upstream-docs/main` and `github_pr_guard` passes (`ok: true`, bilingual clean)