### PR TITLE
docs(q8b/model-zoo): re-point SC8280XP AI HUB proxy from QCS8550 to QCS6490 (REQUESTED, needs owner sign-off)

### DIFF
--- a/docs/common/ai/qualcomm/_qairt-model-zoo.mdx
+++ b/docs/common/ai/qualcomm/_qairt-model-zoo.mdx
@@ -18,7 +18,7 @@
   :::tip
   QCS6490 模型请选择 `Qualcomm QCS6490(Proxy)`
 
-  SC8280XP 模型请选择 `Qualcomm QCS8550(Proxy)`
+  SC8280XP 模型和 QCS6490 模型是通用的，请选择 QCS6490
 
   QCS9075 模型请选择 `Qualcomm QCS9075(Proxy)` 和 `Snapdragon X Elite`
   :::

--- a/docs/common/ai/qualcomm/_qairt-model-zoo.mdx
+++ b/docs/common/ai/qualcomm/_qairt-model-zoo.mdx
@@ -18,7 +18,7 @@
   :::tip
   QCS6490 模型请选择 `Qualcomm QCS6490(Proxy)`
 
-  SC8280XP 模型请选择 `Qualcomm QCS6490(Proxy)`
+  SC8280XP 模型和 QCS6490 模型是通用的，请选择 `Qualcomm QCS6490(Proxy)`
 
   QCS9075 模型请选择 `Qualcomm QCS9075(Proxy)` 和 `Snapdragon X Elite`
   :::

--- a/docs/common/ai/qualcomm/_qairt-model-zoo.mdx
+++ b/docs/common/ai/qualcomm/_qairt-model-zoo.mdx
@@ -18,7 +18,7 @@
   :::tip
   QCS6490 模型请选择 `Qualcomm QCS6490(Proxy)`
 
-  SC8280XP 模型和 QCS6490 模型是通用的，请选择 QCS6490
+  SC8280XP 模型请选择 `Qualcomm QCS6490(Proxy)`
 
   QCS9075 模型请选择 `Qualcomm QCS9075(Proxy)` 和 `Snapdragon X Elite`
   :::

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/qualcomm/_qairt-model-zoo.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/qualcomm/_qairt-model-zoo.mdx
@@ -18,7 +18,7 @@ Model types include:
   :::tip
   For QCS6490 models, select `Qualcomm QCS6490(Proxy)`
 
-  For SC8280XP models, they are compatible with QCS6490 models, so select `QCS6490`
+  For SC8280XP models, select `Qualcomm QCS6490(Proxy)`
 
   For QCS9075 models, select `Qualcomm QCS9075(Proxy)` and `Snapdragon X Elite`
   :::

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/qualcomm/_qairt-model-zoo.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/qualcomm/_qairt-model-zoo.mdx
@@ -18,7 +18,7 @@ Model types include:
   :::tip
   For QCS6490 models, select `Qualcomm QCS6490(Proxy)`
 
-  For SC8280XP models, select `Qualcomm QCS6490(Proxy)`
+  For SC8280XP models, they are compatible with QCS6490 models, so select `Qualcomm QCS6490(Proxy)`
 
   For QCS9075 models, select `Qualcomm QCS9075(Proxy)` and `Snapdragon X Elite`
   :::

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/qualcomm/_qairt-model-zoo.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/qualcomm/_qairt-model-zoo.mdx
@@ -18,7 +18,7 @@ Model types include:
   :::tip
   For QCS6490 models, select `Qualcomm QCS6490(Proxy)`
 
-  For SC8280XP models, select `Qualcomm QCS8550(Proxy)`
+  For SC8280XP models, they are compatible with QCS6490 models, so select `QCS6490`
 
   For QCS9075 models, select `Qualcomm QCS9075(Proxy)` and `Snapdragon X Elite`
   :::


### PR DESCRIPTION
## Summary

In the Q8B model-zoo tutorial, re-point the Qualcomm AI HUB proxy selection for **SC8280XP** from `Qualcomm QCS8550(Proxy)` to `Qualcomm QCS6490(Proxy)`, and add a short `和 QCS6490 模型是通用的 / compatible with QCS6490` explanation in front of the proxy name. The row keeps the same `Qualcomm <Proxy>(Proxy)` selection format as the QCS6490 / QCS9075 rows in the same `:::tip` block.

Touched files (both Chinese source and English translation, in the shared common):

- `docs/common/ai/qualcomm/_qairt-model-zoo.mdx`
- `i18n/en/docusaurus-plugin-content-docs/current/common/ai/qualcomm/_qairt-model-zoo.mdx`

Final diff (Chinese, in the AI HUB `:::tip` block):

```diff
   QCS6490 模型请选择 `Qualcomm QCS6490(Proxy)`

-  SC8280XP 模型请选择 `Qualcomm QCS8550(Proxy)`
+  SC8280XP 模型和 QCS6490 模型是通用的，请选择 `Qualcomm QCS6490(Proxy)`

   QCS9075 模型请选择 `Qualcomm QCS9075(Proxy)` 和 `Snapdragon X Elite`
```

English:

```diff
   For QCS6490 models, select `Qualcomm QCS6490(Proxy)`

-  For SC8280XP models, select `Qualcomm QCS8550(Proxy)`
+  For SC8280XP models, they are compatible with QCS6490 models, so select `Qualcomm QCS6490(Proxy)`

   For QCS9075 models, select `Qualcomm QCS9075(Proxy)` and `Snapdragon X Elite`
```

The **AI Developer Home** section for SC8280XP (still pointing at `Snapdragon X Elite (8380)`) is intentionally left untouched, since the explanation refers to the AI HUB tip block specifically.

## Why three commits instead of one

The branch is intentionally **not** force-squashed; the three commits mirror the iteration that happened in the support topic:

- `c5b2ee1c6` — initial wording directly from the original chat request (含"和 QCS6490 模型是通用的")
- `02e0a5eb0` — review note "参考其他型号表达的格式和风格": dropped the explanation and aligned the row to the `Qualcomm <Proxy>(Proxy)` pattern of its siblings
- `232dc422f` — follow-up "后面的提示也修改下": restored the explanation in front of the proxy name while keeping the format-aligned selection

Keeping the iteration visible makes the review history traceable back to the conversation; reviewers can squash on merge if they prefer a single commit.

## ⚠️ Cross-board impact — please read before merging

The two files above live under `common/ai/qualcomm/` and are **imported by Q6A, Q8B, and Q900** (and their English counterparts) via:

- `dragon/q6a/app-dev/npu-dev/model-zoo.md`
- `dragon/q8b/app-dev/npu-dev/model-zoo.md`
- `fogwise/airbox-q900/ai-dev/model-zoo.md`

So this single change updates the model-zoo page on **all three boards at once**, not just Q8B. The new SC8280XP line appears in the Q6A and Q900 model-zoo pages too, even though they have nothing to do with SC8280XP — that is harmless from a docs-rendering point of view (the other two pages just show the new SC8280XP line inside the same shared tip), but it does mean any rollback has to be coordinated across all three boards.

If the intent is to only affect the Q8B page, the cleaner follow-up is to **stop sharing the AI HUB tip across boards**: split the SC8280XP line out of the common file into a Q8B-only wrapper, and keep the QCS6490 / QCS9075 lines in the shared common. Happy to follow up with that PR if reviewers want it.

## ⚠️ Risk / conflict with recent docs history

This change **directly contradicts** the line that was explicitly added on **2026-06-15** in:

- commit `e67adac5a` — `docs(dragon/q8b): revise NPU dev docs with QCS8550 support and fix props.tag across common MDX` (author: Ronin <dengluoning@radxa.com>)

That commit added the exact line `QCS8550 模型请选择 Qualcomm QCS8550(Proxy)` for SC8280XP, and the same author subsequently renamed it from `QCS8550` to `SC8280XP` on 2026-06-18. Both commits are already merged into `main` (latest merge: PR #1855, "fix/npu-q8b-tab"). So this PR is reverting a deliberate, recent docs decision by the Q8B NPU docs owner.

Background on why the original `QCS8550` choice was made:

- **SC8280XP** and **QCS8550** are both Snapdragon 8cx Gen 3 compute-platform SKUs from Qualcomm; they share the same Hexagon NPU architecture and the same SDK / runtime generation, which is why `Qualcomm QCS8550(Proxy)` is the AI HUB target that maps to SC8280XP silicon.
- **QCS6490** is a different product line (Q6A uses it), based on a different Hexagon generation. Models compiled for one are not guaranteed to run on the other. The new wording re-asserts "SC8280XP 模型和 QCS6490 模型是通用的" — this is a strong compatibility claim that could not be verified from the docs, the BOM, or vendor material at the time of opening this PR, and no verification evidence was provided in the support topic either.

## Why this PR exists anyway

This PR is being opened **at the explicit request of a support-team member** in the internal 售后技术支持 group, who iterated on the wording three times. The Support Agent (me) is not in a position to unilaterally override a team member's instruction, but it is also flagging the conflict here so that **a product / docs owner (likely Ronin) gives explicit sign-off before merge**.

If the team confirms the change is correct, please merge as-is. If the change is incorrect, please close this PR and revert in the next docs pass. If the wording needs further adjustment, please leave a review comment and I will follow up.

## Checklist

- [x] Both Chinese (`docs/`) and English (`i18n/en/`) updated together
- [x] AI Developer Home section for SC8280XP left untouched (only the AI HUB tip was changed)
- [x] Branched from `upstream-docs/main` and `github_pr_guard` passes (`ok: true`, bilingual clean, 3 commits / 2 files)
- [ ] **Awaiting explicit sign-off from a product / docs owner before merge** — see risk section above