### PR TITLE
docs(orion/o6): swap positions 28 (TPM) and 29 (MIPI CSI) in interface table

### DIFF
--- a/docs/orion/o6/README.md
+++ b/docs/orion/o6/README.md
@@ -70,8 +70,8 @@ sidebar_position: 10
 | 5    | UART 接口                                                 | 15   | 2x 5G 以太网                                                             | 25   | 40-Pin GPIO 排针                         |
 | 6    | eDP 接口                                                  | 16   | DP 接口                                                                  | 26   | LPDDR5                                   |
 | 7    | RTC 电池座                                                | 17   | HDMI 接口                                                                | 27   | ATX 电源接口                             |
-| 8    | PCIe x16 插槽（PCIe Gen x4）                              | 18   | 2x USB 3.2 Type-A                                                        | 28   | 2x MIPI CSI 4-lane                       |
-| 9    | M.2 M Key 插槽                                            | 19   | 2x USB 2.0 Type-A                                                        | 29   | TPM (Unsoldered)                         |
+| 8    | PCIe x16 插槽（PCIe Gen x4）                              | 18   | 2x USB 3.2 Type-A                                                        | 28   | TPM (Unsoldered)                         |
+| 9    | M.2 M Key 插槽                                            | 19   | 2x USB 2.0 Type-A                                                        | 29   | 2x MIPI CSI 4-lane                       |
 | 10   | M.2 E Key 2230 插槽                                       | 20   | 2x USB Type-C<br/>- 20V Type-C 供电，支持 PD 协议<br/>- 支持 DP 视频输出 |      |                                          |
 
 ## 应用场景

--- a/docs/orion/o6/hardware-use/hardware-info.md
+++ b/docs/orion/o6/hardware-use/hardware-info.md
@@ -31,8 +31,8 @@ sidebar_position: 10
 | 5    | UART 接口                                                 | 15   | 2x 5G 以太网                                                             | 25   | 40-Pin GPIO 排针                         |
 | 6    | eDP 接口                                                  | 16   | DP 接口                                                                  | 26   | LPDDR5                                   |
 | 7    | RTC 电池座                                                | 17   | HDMI 接口                                                                | 27   | ATX 电源接口                             |
-| 8    | PCIe x16 插槽（PCIe Gen x4）                              | 18   | 2x USB 3.2 Type-A                                                        | 28   | 2x MIPI CSI 4-lane                       |
-| 9    | M.2 M Key 插槽                                            | 19   | 2x USB 2.0 Type-A                                                        | 29   | TPM (Unsoldered)                         |
+| 8    | PCIe x16 插槽（PCIe Gen x4）                              | 18   | 2x USB 3.2 Type-A                                                        | 28   | TPM (Unsoldered)                         |
+| 9    | M.2 M Key 插槽                                            | 19   | 2x USB 2.0 Type-A                                                        | 29   | 2x MIPI CSI 4-lane                       |
 | 10   | M.2 E Key 2230 插槽                                       | 20   | 2x USB Type-C<br/>- 20V Type-C 供电，支持 PD 协议<br/>- 支持 DP 视频输出 |      |                                          |
 
 ### 电源按键

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/README.md
@@ -70,8 +70,8 @@ Note: The actual contents may vary depending on the purchase platform. The acryl
 | 5   | UART Interface                                                          | 15  | 2x 5G Ethernet                                                | 25  | 40-pin GPIO Header                       |
 | 6   | eDP Interface                                                           | 16  | DisplayPort                                                   | 26  | LPDDR5                                   |
 | 7   | RTC Battery Holder                                                      | 17  | HDMI Port                                                     | 27  | ATX Power Connector                      |
-| 8   | PCIe x16 Slot (PCIe Gen4 x8)                                            | 18  | 2x USB 3.2 Type-A                                             | 28  | 2x MIPI CSI 4-lane                       |
-| 9   | M.2 M Key Slot                                                          | 19  | 2x USB 2.0 Type-A                                             | 29  | TPM (Unsoldered)                         |
+| 8   | PCIe x16 Slot (PCIe Gen4 x8)                                            | 18  | 2x USB 3.2 Type-A                                             | 28  | TPM (Unsoldered)                         |
+| 9   | M.2 M Key Slot                                                          | 19  | 2x USB 2.0 Type-A                                             | 29  | 2x MIPI CSI 4-lane                       |
 | 10  | M.2 E Key 2230 Slot                                                     | 20  | 2x USB Type-C<br/>- 20V Type-C PD Input<br/>- DP Video Output |     |                                          |
 
 ## Application Scenarios

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/hardware-use/hardware-info.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/hardware-use/hardware-info.md
@@ -31,8 +31,8 @@ sidebar_position: 10
 | 5   | UART Interface                                               | 15  | 2x 5G Ethernet                                                                          | 25  | 40-Pin GPIO Header                                                |
 | 6   | eDP Interface                                                | 16  | DisplayPort                                                                             | 26  | LPDDR5                                                            |
 | 7   | RTC Battery Holder                                           | 17  | HDMI Port                                                                               | 27  | ATX Power Connector                                               |
-| 8   | PCIe x16 Slot (PCIe Gen x4)                                  | 18  | 2x USB 3.2 Type-A                                                                       | 28  | 2x MIPI CSI 4-lane                                                |
-| 9   | M.2 M Key Slot                                               | 19  | 2x USB 2.0 Type-A                                                                       | 29  | TPM (Unsoldered)                                                  |
+| 8   | PCIe x16 Slot (PCIe Gen x4)                                  | 18  | 2x USB 3.2 Type-A                                                                       | 28  | TPM (Unsoldered)                                                  |
+| 9   | M.2 M Key Slot                                               | 19  | 2x USB 2.0 Type-A                                                                       | 29  | 2x MIPI CSI 4-lane                                                |
 | 10  | M.2 E Key 2230 Slot                                          | 20  | 2x USB Type-C<br/>- 20V Type-C Power Delivery (PD) Supported<br/>- Supports DP Alt Mode |     |                                                                   |
 
 ### Power Button


### PR DESCRIPTION
## Summary

Fix the 接口说明 table in Orion O6 docs: positions 28 and 29 were reversed.

- 28 = TPM (Unsoldered)
- 29 = 2x MIPI CSI 4-lane

Reported by RadxaYuntian (internal hardware maintainer) via issue #1845.

## Files changed

- `docs/orion/o6/README.md` — 接口说明 表格 28/29 行对调
- `docs/orion/o6/hardware-use/hardware-info.md` — 接口说明 表格 28/29 行对调
- `i18n/en/docusaurus-plugin-content-docs/current/orion/o6/README.md` — interface table 28/29 swapped
- `i18n/en/docusaurus-plugin-content-docs/current/orion/o6/hardware-use/hardware-info.md` — interface table 28/29 swapped

CN and EN kept in sync; only the two swapped rows differ from the previous text, no other content touched.

## Source

- GitHub issue: <https://github.com/radxa-docs/docs/issues/1845> (filed by RadxaYuntian)
- Internal hardware maintainer confirms on-board TPM header sits at position 28, not 29.

## Impact

- Pure docs-only fix; no code, build, or image change.
- Only one product (Orion O6) is affected; O6N has a different layout and does not need this change.
- All four files (CN/EN × README/hardware-info) are updated together to keep bilingual parity.

Fixes radxa-docs/docs#1845