### PR TITLE
docs(aicore-ax-m1/download): add Hardware Design section with 3D model download link

### DIFF
--- a/docs/aicore/ax-m1/download.md
+++ b/docs/aicore/ax-m1/download.md
@@ -18,5 +18,9 @@ sidebar_position: 15
 
 ## 参考文档
 
-- [Radxa 智核 AX-M1 产品规格书（英文）](https://dl.radxa.com/aicore/ax_m1/radxa_aicore_ax_m1_product_brief_en.pdf)
-- [Radxa 智核 AX-M1 产品规格书（中文）](https://dl.radxa.com/aicore/ax_m1/radxa_aicore_ax_m1_product_brief_zh.pdf)
+- [瑞莎智核 AX-M1 产品规格书（英文）](https://dl.radxa.com/aicore/ax_m1/radxa_aicore_ax_m1_product_brief_en.pdf)
+- [瑞莎智核 AX-M1 产品规格书（中文）](https://dl.radxa.com/aicore/ax_m1/radxa_aicore_ax_m1_product_brief_zh.pdf)
+
+## 硬件设计
+
+- [瑞莎智核 AX-M1 3D 模型](https://dl.radxa.com/aicore/ax_m1/radxa_aicore_ax_m1_3d_stp.zip)

--- a/i18n/en/docusaurus-plugin-content-docs/current/aicore/ax-m1/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/aicore/ax-m1/download.md
@@ -20,3 +20,7 @@ sidebar_position: 15
 
 - [Radxa AICore AX-M1 product brief (English)](https://dl.radxa.com/aicore/ax_m1/radxa_aicore_ax_m1_product_brief_en.pdf)
 - [Radxa AICore AX-M1 product brief (Chinese)](https://dl.radxa.com/aicore/ax_m1/radxa_aicore_ax_m1_product_brief_zh.pdf)
+
+## Hardware design
+
+- [Radxa AICore AX-M1 3D model](https://dl.radxa.com/aicore/ax_m1/radxa_aicore_ax_m1_3d_stp.zip)


### PR DESCRIPTION
## 背景

为 Radxa AICore AX-M1 的下载页补充 3D 模型下载入口，同时修正中文文案中
"Radxa" 应为 "瑞莎" 的历史笔误。

## 变更内容

- `docs/aicore/ax-m1/download.md`:
  - 新增「硬件设计」二级标题，补充 3D 模型下载链接
  - 将现有「Radxa 智核 AX-M1 产品规格书」统一改为「瑞莎智核 AX-M1 产品规格书」，
    与 aicore/ax-m1/ 其它文档命名一致
- `i18n/en/docusaurus-plugin-content-docs/current/aicore/ax-m1/download.md`:
  - 同步英文版「Hardware design」+ 3D model 下载链接（英文保持 "Radxa AICore"）

## 下载链接

- 3D 模型 (STP): https://dl.radxa.com/aicore/ax_m1/radxa_aicore_ax_m1_3d_stp.zip

## 参考格式

参考 Dragon Q8B 下载页的「硬件设计」章节写法（#1865）。

## 关联

需求来自售后技术支持群同步：吴闽龙 / 2026-06-22。
