### PR TITLE
docs(dragon/q8b): add Docker / Conda virtual-env tutorials

### DIFF
--- a/docs/dragon/q8b/app-dev/virtual-env/conda-install.md
+++ b/docs/dragon/q8b/app-dev/virtual-env/conda-install.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 4
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/application-dev/virtual-env/_conda_install.mdx
+---
+
+import CondaInstall from '../../../../common/radxa-os/application-dev/virtual-env/\_conda_install.mdx';
+
+# Conda 安装
+
+<CondaInstall board="dragon-q8b" />

--- a/docs/dragon/q8b/app-dev/virtual-env/conda-use.md
+++ b/docs/dragon/q8b/app-dev/virtual-env/conda-use.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 5
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/application-dev/virtual-env/_conda_use.mdx
+---
+
+import CondaUse from '../../../../common/radxa-os/application-dev/virtual-env/\_conda_use.mdx';
+
+# Conda 使用
+
+<CondaUse board="dragon-q8b" />

--- a/docs/dragon/q8b/app-dev/virtual-env/docker-install.md
+++ b/docs/dragon/q8b/app-dev/virtual-env/docker-install.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/application-dev/virtual-env/_docker_install.mdx
+---
+
+import DockerInstall from '../../../../common/radxa-os/application-dev/virtual-env/\_docker_install.mdx';
+
+# Docker 安装
+
+<DockerInstall board="dragon-q8b" />

--- a/docs/dragon/q8b/app-dev/virtual-env/docker-use.md
+++ b/docs/dragon/q8b/app-dev/virtual-env/docker-use.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 2
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/radxa-os/application-dev/virtual-env/_docker_use.mdx
+---
+
+import DockerUse from '../../../../common/radxa-os/application-dev/virtual-env/\_docker_use.mdx';
+
+# Docker 使用
+
+<DockerUse board="dragon-q8b" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/conda-install.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/conda-install.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 4
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/application-dev/virtual-env/_conda_install.mdx
+---
+
+import CondaInstall from '../../../../common/radxa-os/application-dev/virtual-env/\_conda_install.mdx';
+
+# Conda Install
+
+<CondaInstall board="dragon-q8b" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/conda-use.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/conda-use.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 5
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/application-dev/virtual-env/_conda_use.mdx
+---
+
+import CondaUse from '../../../../common/radxa-os/application-dev/virtual-env/\_conda_use.mdx';
+
+# Conda Use
+
+<CondaUse board="dragon-q8b" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/docker-install.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/docker-install.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 1
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/application-dev/virtual-env/_docker_install.mdx
+---
+
+import DockerInstall from '../../../../common/radxa-os/application-dev/virtual-env/\_docker_install.mdx';
+
+# Docker Install
+
+<DockerInstall board="dragon-q8b" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/docker-use.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/app-dev/virtual-env/docker-use.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 2
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/application-dev/virtual-env/_docker_use.mdx
+---
+
+import DockerUse from '../../../../common/radxa-os/application-dev/virtual-env/\_docker_use.mdx';
+
+# Docker Use
+
+<DockerUse board="dragon-q8b" />


### PR DESCRIPTION
## Summary

给 Dragon Q8B 补齐应用开发下的虚拟环境教程，对齐 Q6A 已经有的 Docker / Conda 教程。

复用 `common/radxa-os/application-dev/virtual-env/` 下的公共模板，每个新 wrapper 显式传入 `board="dragon-q8b"`。等配套的 #1868 模板改动合并后，渲染出来的终端提示会显示 `radxa@dragon-q8b$`；在那之前，Conda 教程会回退到默认的 `radxa@device$`，但页面结构 / 文档内容是正确的。

## 新增文件

- `docs/dragon/q8b/app-dev/virtual-env/docker-install.md` -> `<DockerInstall board="dragon-q8b" />`
- `docs/dragon/q8b/app-dev/virtual-env/docker-use.md` -> `<DockerUse board="dragon-q8b" />`
- `docs/dragon/q8b/app-dev/virtual-env/conda-install.md` -> `<CondaInstall board="dragon-q8b" />`
- `docs/dragon/q8b/app-dev/virtual-env/conda-use.md` -> `<CondaUse board="dragon-q8b" />`
- `i18n/en/.../dragon/q8b/app-dev/virtual-env/` 下同样 4 个英文版

已有的 `venv-usage.md`（Python venv）保持不动。

## 依赖

- 依赖 #1868 合并：模板层先把 `tip` 改成 `props?.board ?? 'device'` 之后，wrapper 传 `board="dragon-q8b"` 才会真正渲染出 `radxa@dragon-q8b$`
- 没有传 `board` 的 wrapper（cubie a5e / a7a / a7s / a7z、som cm4 等）行为不变

## 验证

- `bash scripts/agent-doc-lint.sh <files>` 通过
- `bash scripts/agent-doc-translation-guard.sh docs/dragon/q8b/app-dev/virtual-env/` 通过
- `python3 scripts/github_pr_guard.py check` 通过（1 scope / 8 files）
