### PR TITLE
docs(dragon/q6a): add AIC8800D80 Wi-Fi/BT driver section to Windows on ARM guide

### DIFF
--- a/docs/dragon/q6a/other-system/windows.md
+++ b/docs/dragon/q6a/other-system/windows.md
@@ -114,6 +114,19 @@ Windows 安装完成后，系统仍然缺少诸如网络、GPU、音频等专用
 
 此时，大部分硬件（包括网络、GPU、多媒体、音频等）应可在 Windows 中正常工作。
 
+## 无线与蓝牙驱动
+
+默认的 Dragon Q6A 驱动包中尚未包含 Wi-Fi 与蓝牙驱动。如需在 Windows 上使用 Wi-Fi 与蓝牙，可按以下步骤操作。
+
+1. 下载驱动包 [aicwlan_arm64_0935761.zip]([https://github.com/worproject/dldserv-mirror/releases/download/13%2F02%2F2024/aicwlan_arm64_0935761.zip](https://github.com/worproject/dldserv-mirror/releases/download/13%2F02%2F2024/aicwlan_arm64_0935761.zip))
+2. 解压下载的压缩包，右键解压目录中的 aicwlan.inf 文件，选择 install 进行驱动安装
+3. 检查 Wi-Fi 与蓝牙功能是否正常
+
+:::tip
+本驱动是社区（由 Mario 在 [worproject/dldserv-mirror]([https://github.com/worproject/dldserv-mirror](https://github.com/worproject/dldserv-mirror)) 维护）提供的**测试签名版本**，目前已覆盖大部分 client-mode Wi-Fi 能力；如果遇到连接、吞吐或稳定性问题，建议回到论坛原帖反馈：
+- [Wi-Fi + BT support for Windows on Q6A - Radxa Community]([https://forum.radxa.com/t/wi-fi-bt-support-for-windows-on-arm-on-q6a/31091](https://forum.radxa.com/t/wi-fi-bt-support-for-windows-on-arm-on-q6a/31091))
+:::
+
 ## 后续建议
 
 - 通过 Windows Update 检查并安装最新系统更新；

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/other-system/windows.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/other-system/windows.md
@@ -118,6 +118,19 @@ After Windows installation, the system still lacks specific drivers (network, GP
 
 At this point, most hardware including networking, GPU, multimedia and audio should work properly under Windows.
 
+### 3.4 Wi-Fi and Bluetooth Driver
+
+The default Dragon Q6A driver package does not include Wi-Fi and Bluetooth drivers. To use Wi-Fi and Bluetooth on Windows, follow the steps below.
+
+1. Download the driver package [aicwlan_arm64_0935761.zip]([https://github.com/worproject/dldserv-mirror/releases/download/13%2F02%2F2024/aicwlan_arm64_0935761.zip](https://github.com/worproject/dldserv-mirror/releases/download/13%2F02%2F2024/aicwlan_arm64_0935761.zip))
+2. Extract the downloaded archive, right-click `aicwlan.inf` in the extracted folder, and select **Install** to install the driver.
+3. Check that Wi-Fi and Bluetooth work as expected.
+
+:::tip
+This driver is a **test-signed build** maintained by the community (Mario in [worproject/dldserv-mirror]([https://github.com/worproject/dldserv-mirror](https://github.com/worproject/dldserv-mirror))). It currently covers most client-mode Wi-Fi functionality. If you encounter connectivity, throughput, or stability issues, please report back in the original forum thread:
+- [Wi-Fi + BT support for Windows on Q6A - Radxa Community]([https://forum.radxa.com/t/wi-fi-bt-support-for-windows-on-arm-on-q6a/31091](https://forum.radxa.com/t/wi-fi-bt-support-for-windows-on-arm-on-q6a/31091))
+:::
+
 ## 4. Next Steps
 
 - Use Windows Update to check for and install the latest system updates;


### PR DESCRIPTION
## Summary

Add a new section to the Dragon Q6A Windows on ARM installation guide documenting the community-maintained **AIC8800D80 USB Wi-Fi/BT driver** that brings Wi-Fi and Bluetooth support to Q6A under Windows 11 24H2 (ARM64).

- New section sits between the existing "Install Drivers" block and "Next Steps", in both Chinese and English.
- Covers system requirements (Win11 24H2 / build 26100, ARM64), download source, install steps (right-click `aicwlan.inf` → Install), device-manager verification, and known limitations (Wi-Fi Direct / SoftAP / Miracast, throughput tuning, BT coexistence, settings UI are still WIP).
- Adds an explicit warning that this is a test-signed, community-maintained build (not part of the official Dragon Q6A Windows driver package), and points users back to the community forum thread for feedback.

## Source

Summarized from the Radxa community forum thread by Mario (worproject):

- https://forum.radxa.com/t/wi-fi-bt-support-for-windows-on-arm-on-q6a/31091

Driver binary (test-signed, ARM64):

- https://github.com/worproject/dldserv-mirror/releases/download/13%2F02%2F2024/aicwlan_arm64_0935761.zip

## Files changed

- `docs/dragon/q6a/other-system/windows.md` (zh, +26 lines)
- `i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/other-system/windows.md` (en, +26 lines)

## Impact

- Fills a documentation gap surfaced by forum thread #31091: the official Windows on ARM guide currently states that the system "lacks a wireless NIC driver" without providing any path forward, even though a working community driver exists.
- No docs-only change; no product/feature claims are made beyond what the forum author and the upstream driver README already publish.
- Bilingual sync enforced (both `docs/` and `i18n/en/` updated in the same commit).
