### PR TITLE
docs(dragon/q8b): add VarStore to SPI erase commands and reorder -l flag

### DIFF
--- a/docs/dragon/q8b/low-level-dev/spi-fw.md
+++ b/docs/dragon/q8b/low-level-dev/spi-fw.md
@@ -119,10 +119,11 @@ sudo edl-ng --memory=spinor rawprogram rawprogram0.xml patch0.xml --loader=prog_
     <NewCodeBlock tip="Windows$" type="host">
 
     ```text
-    .\edl-ng.exe --memory spinor erase-part ddr -l C:\path\to\prog_firehose_ddr.elf
-    .\edl-ng.exe --memory spinor erase-part uefi  -l C:\path\to\prog_firehose_ddr.elf
-    .\edl-ng.exe --memory spinor erase-part devcfg  -l C:\path\to\prog_firehose_ddr.elf
-    .\edl-ng.exe --memory spinor erase-part xbl  -l C:\path\to\prog_firehose_ddr.elf
+    .\edl-ng.exe --memory spinor -l prog_firehose_ddr.elf erase-part ddr
+    .\edl-ng.exe --memory spinor -l prog_firehose_ddr.elf erase-part uefi
+    .\edl-ng.exe --memory spinor -l prog_firehose_ddr.elf erase-part devcfg
+    .\edl-ng.exe --memory spinor -l prog_firehose_ddr.elf erase-part xbl
+    .\edl-ng.exe --memory spinor -l prog_firehose_ddr.elf erase-part VarStore
     ```
 
     </NewCodeBlock>
@@ -189,10 +190,11 @@ sudo edl-ng --memory=spinor rawprogram rawprogram0.xml patch0.xml --loader=prog_
     <NewCodeBlock tip="Linux$" type="host">
 
     ```bash
-    sudo edl-ng --memory spinor erase-part ddr -l prog_firehose_ddr.elf
-    sudo edl-ng --memory spinor erase-part uefi  -l prog_firehose_ddr.elf
-    sudo edl-ng --memory spinor erase-part devcfg  -l prog_firehose_ddr.elf
-    sudo edl-ng --memory spinor erase-part xbl  -l prog_firehose_ddr.elf
+    sudo edl-ng --memory spinor -l prog_firehose_ddr.elf erase-part ddr
+    sudo edl-ng --memory spinor -l prog_firehose_ddr.elf erase-part uefi
+    sudo edl-ng --memory spinor -l prog_firehose_ddr.elf erase-part devcfg
+    sudo edl-ng --memory spinor -l prog_firehose_ddr.elf erase-part xbl
+    sudo edl-ng --memory spinor -l prog_firehose_ddr.elf erase-part VarStore
     ```
 
     </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/spi-fw.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/spi-fw.md
@@ -119,10 +119,11 @@ Erasing the SPI boot firmware will prevent the device from booting. You must ref
     <NewCodeBlock tip="Windows$" type="host">
 
     ```text
-    .\edl-ng.exe --memory spinor erase-part ddr -l C:\path\to\prog_firehose_ddr.elf
-    .\edl-ng.exe --memory spinor erase-part uefi  -l C:\path\to\prog_firehose_ddr.elf
-    .\edl-ng.exe --memory spinor erase-part devcfg  -l C:\path\to\prog_firehose_ddr.elf
-    .\edl-ng.exe --memory spinor erase-part xbl  -l C:\path\to\prog_firehose_ddr.elf
+    .\edl-ng.exe --memory spinor -l prog_firehose_ddr.elf erase-part ddr
+    .\edl-ng.exe --memory spinor -l prog_firehose_ddr.elf erase-part uefi
+    .\edl-ng.exe --memory spinor -l prog_firehose_ddr.elf erase-part devcfg
+    .\edl-ng.exe --memory spinor -l prog_firehose_ddr.elf erase-part xbl
+    .\edl-ng.exe --memory spinor -l prog_firehose_ddr.elf erase-part VarStore
     ```
 
     </NewCodeBlock>
@@ -189,10 +190,11 @@ Erasing the SPI boot firmware will prevent the device from booting. You must ref
     <NewCodeBlock tip="Linux$" type="host">
 
     ```bash
-    sudo edl-ng --memory spinor erase-part ddr -l prog_firehose_ddr.elf
-    sudo edl-ng --memory spinor erase-part uefi  -l prog_firehose_ddr.elf
-    sudo edl-ng --memory spinor erase-part devcfg  -l prog_firehose_ddr.elf
-    sudo edl-ng --memory spinor erase-part xbl  -l prog_firehose_ddr.elf
+    sudo edl-ng --memory spinor -l prog_firehose_ddr.elf erase-part ddr
+    sudo edl-ng --memory spinor -l prog_firehose_ddr.elf erase-part uefi
+    sudo edl-ng --memory spinor -l prog_firehose_ddr.elf erase-part devcfg
+    sudo edl-ng --memory spinor -l prog_firehose_ddr.elf erase-part xbl
+    sudo edl-ng --memory spinor -l prog_firehose_ddr.elf erase-part VarStore
     ```
 
     </NewCodeBlock>


### PR DESCRIPTION
## 背景

Dragon Q8B 的 SPI 启动固件擦除教程（`docs/dragon/q8b/low-level-dev/spi-fw.md`）里的 `edl-ng erase-part` 命令有两点问题：

1. 旧版只擦 4 个分区（`ddr` / `uefi` / `devcfg` / `xbl`），漏掉 `VarStore`。
2. `-l` 参数位置放在 `erase-part` 之后，部分版本下参数解析顺序与新固件不匹配。

## 改动

把"擦除 SPI 启动固件"一节里的命令按 `edl-ng` 当前使用方式调整：

- `-l prog_firehose_ddr.elf` 移到 `erase-part` 之前
- 增补 `VarStore` 分区
- Windows 和 Linux 命令同步更新

中英文两个版本都改了。

## 文件

- `docs/dragon/q8b/low-level-dev/spi-fw.md`
- `i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/spi-fw.md`

## 来源

售后技术支持群同事 @吴闽龙 提供新命令，要求同步更新教程。
