### PR TITLE
docs(airbox-q900): add QIM SDK development guide with 14 verified demo pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 /.vs
 node_modules
+.claude

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/README.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/README.md
@@ -1,0 +1,176 @@
+---
+sidebar_position: 101
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# QIM SDK 开发指南
+
+Qualcomm Intelligent Multimedia SDK (IM SDK) 是基于 GStreamer 的 AI/ML 应用开发框架，提供开箱即用的命令行工具和硬件加速插件，覆盖从视频采集、AI 推理到结果渲染的完整 pipeline。
+
+## 与 QAIRT 的关系
+
+QIM SDK 位于 QAIRT SDK 之上，两者的分工如下：
+
+| 层级                 | 内容                                                  | 在 Q900 上的状态              |
+| -------------------- | ----------------------------------------------------- | ----------------------------- |
+| **QAIRT Runtime**    | QNN / SNPE / LiteRT 运行时库                          | 通过 apt 安装（`qairt-libs`） |
+| **QIM SDK 插件**     | GStreamer ML 插件（采集、预处理、推理、后处理、渲染） | 通过 apt 安装                 |
+| **QIM SDK 示例应用** | `gst-ai-*` 命令行工具                                 | 通过 apt 安装                 |
+
+安装 QIM SDK 前需先安装 QAIRT 基础库（`sudo apt install -y qairt-libs`），详见下方安装步骤。
+
+## 前提条件
+
+- Radxa AIRbox Q900
+- Ubuntu 24.04，已连接网络
+- 显示器已连接（Wayland）
+
+## 安装
+
+### 步骤 1：安装 QAIRT 基础库
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install -y qairt-libs
+```
+
+</NewCodeBlock>
+
+### 步骤 2：安装 QIM SDK
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install -y \
+    gstreamer1.0-tools \
+    tensorflow-lite-qcom-apps \
+    gstreamer1.0-qcom-sample-apps \
+    gstreamer1.0-qcom-python-examples
+```
+
+</NewCodeBlock>
+
+所有 ML 推理插件和视频处理插件会作为依赖自动安装，无需单独指定。
+
+### 步骤 3：验证安装
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls /usr/bin/gst-ai-*
+```
+
+</NewCodeBlock>
+
+预期输出 20 个 `gst-ai-*` 命令行工具。
+
+## 下载模型和测试资源
+
+使用官方脚本一键下载模型、标签和测试视频：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install -y unzip
+curl -L -O https://raw.githubusercontent.com/quic/sample-apps-for-qualcomm-linux/refs/heads/main/download_artifacts.sh
+chmod +x download_artifacts.sh
+sudo ./download_artifacts.sh -v GA1.6-rel -c QCS9075
+```
+
+</NewCodeBlock>
+
+下载完成后：
+
+| 目录            | 内容                                 |
+| --------------- | ------------------------------------ |
+| `/etc/models/`  | 10 个 `.tflite` 量化模型             |
+| `/etc/labels/`  | 16 个标签和配置文件                  |
+| `/etc/media/`   | 4 个测试视频                         |
+| `/etc/configs/` | 38 个应用配置 JSON（包安装时已就位） |
+
+## 快速验证
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-classification --config-file=/etc/configs/config_classification.json
+```
+
+</NewCodeBlock>
+
+成功启动后，显示器上播放测试视频并叠加分类标签。终端输出中可见 `Using DSP Delegate` 和 `Pipeline state changed to PLAYING`。
+
+按 `Ctrl + C` 停止。
+
+## 可用示例应用
+
+以下应用已在 Q900 (QCS9075) 上验证通过：
+
+| 应用                                                         | 说明               | 模型                                     | NPU        |
+| ------------------------------------------------------------ | ------------------ | ---------------------------------------- | ---------- |
+| [图像分类](./classification.md)                              | 识别图像主体       | InceptionV3                              | DSP        |
+| [目标检测](./object-detection.md)                            | 检测并框出物体     | YOLOX                                    | DSP        |
+| [姿态检测](./pose-detection.md)                              | 人体关键点检测     | HRNet                                    | DSP        |
+| [图像分割](./segmentation.md)                                | 逐像素语义分割     | DeepLabV3+                               | DSP        |
+| [单目深度估计](./monodepth.md)                               | 深度热力图         | MiDaS V2                                 | DSP        |
+| [视频超分辨率](./superresolution.md)                         | 低分辨率重建       | QuickSRNet                               | DSP (部分) |
+| [音频分类](./audio-classification.md)                        | 音频事件分类       | YAMNet                                   | CPU        |
+| [菊花链检测与分类](./daisychain-detection-classification.md) | 级联检测+分类      | YOLOX + InceptionV3                      | DSP        |
+| [菊花链检测与姿态](./daisychain-detection-pose.md)           | 级联检测+姿态      | YOLOX + HRNet                            | DSP        |
+| [并行 AI 融合](./parallel-inference.md)                      | 4 模型同时推理     | YOLOX + InceptionV3 + HRNet + DeepLabV3+ | DSP        |
+| [事件编码器](./event-encoder.md)                             | 检测事件编码输出   | YOLOX                                    | DSP        |
+| [元数据解析](./metadata-parser.md)                           | 检测结果元数据导出 | YOLOX                                    | DSP        |
+| [多流推理](./multistream-inference.md)                       | 多路同步检测       | YOLOX                                    | DSP        |
+| [人脸检测](./face-detection.md)                              | 人脸关键点检测     | Lightweight Face Detection               | DSP        |
+
+> 完整列表参见 [IM SDK 参考手册](https://docs.qualcomm.com/doc/80-70020-50SC/topic/download-model-and-label-files.html) 第 3 章。
+
+## 参考
+
+- [Python GStreamer 应用](./python-apps.md) — Python 绑定示例
+- [源码编译](./build-from-source.md) — 在设备上编译自定义 GStreamer 应用
+
+## 排障
+
+### 显示器无画面
+
+检查 Wayland socket 是否存在：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY
+```
+
+</NewCodeBlock>
+
+### DSP 推理失败
+
+确认 FastRPC 设备节点存在：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls /dev/fastrpc-cdsp*
+```
+
+</NewCodeBlock>
+
+如果没有输出，请参考 [板端启用 NPU](../fastrpc-setup.md)。
+
+### 模型文件缺失
+
+重新运行下载脚本：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo ./download_artifacts.sh -v GA1.6-rel -c QCS9075
+```
+
+</NewCodeBlock>

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/audio-classification.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/audio-classification.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 7
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 音频分类
+
+`gst-ai-audio-classification` 对音频流执行音频事件分类，识别声音类型（如人声、音乐、环境噪声等）。
+
+使用 YAMNet 模型，默认配置为 CPU 推理。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型和标签
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/yamnet.tflite
+ls -l /etc/labels/yamnet.json
+```
+
+</NewCodeBlock>
+
+### 2. 查看配置
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config-audio-classification.json
+```
+
+</NewCodeBlock>
+
+关键字段：
+
+| 字段        | 默认值                      | 说明                          |
+| ----------- | --------------------------- | ----------------------------- |
+| `file-path` | `/etc/media/video-mp3.mp4`  | 输入音频/视频文件（MP3 编码） |
+| `model`     | `/etc/models/yamnet.tflite` | 模型文件                      |
+| `labels`    | `/etc/labels/yamnet.json`   | 标签文件                      |
+| `threshold` | `10`                        | 置信度阈值                    |
+| `codec`     | `mp3`                       | 音频编码格式                  |
+| `runtime`   | `cpu`                       | 推理硬件                      |
+
+> 默认使用 CPU 推理。如需 DSP 推理，将 `runtime` 改为 `dsp` 并添加 `ml-framework: "tflite"`。
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-audio-classification --config-file=/etc/configs/config-audio-classification.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Running app with model: /etc/models/yamnet.tflite and labels: /etc/labels/yamnet.json
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放测试视频，音频分类结果叠加显示。
+
+## 验证
+
+- Pipeline 进入 `PLAYING` 状态
+- 终端持续输出音频分类结果
+- 显示器显示分类标签
+
+## 工作原理
+
+YAMNet 是基于 AudioSet 数据集训练的音频事件分类模型，支持 521 种音频类别。Pipeline 流程：
+
+```text
+filesrc → qtdemux → (音频解码) → qtimlaudioconverter
+                                          ↓
+                                qtimltflite (推理)
+                                          ↓
+                               qtimlaclassification
+                                          ↓
+                               (分类标签叠加显示)
+```

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/build-from-source.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/build-from-source.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 16
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 源码编译
+
+QIM SDK 的所有 GStreamer 插件和示例应用已通过 [apt 安装](./README.md#安装) 提供预编译包，一般情况下无需自行编译。
+
+你也可以在设备上直接编译源码，用于以下场景：
+
+- 修改插件源码，定制后处理逻辑或添加自定义模型支持
+- 调试插件内部行为
+- 需要与预编译包不同的编译选项
+
+编译产物包括 34 个 GStreamer 插件动态库（`.so`），覆盖 AI 推理引擎（`mltflite`、`mlqnn`、`mlsnpe`）、预处理（`mlvconverter`）、后处理（`mlpostprocess` 等）、视频处理（`vcomposer` 等）。详见下方步骤。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装)
+
+## 安装编译依赖
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt-add-repository -s ppa:ubuntu-qcom-iot/qcom-ppa
+sudo apt update
+sudo apt install -y \
+    qcom-adreno-dev \
+    libgstreamer1.0-qcom-sample-apps-utils-dev
+```
+
+</NewCodeBlock>
+
+## 编译 QIM 插件（从源码）
+
+### 步骤 1：下载 QIM 源码
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cd ~
+apt source gst-plugins-qti-oss
+cd gst-plugins-qti-oss-*
+```
+
+</NewCodeBlock>
+
+### 步骤 2：CMake 编译
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+mkdir build && cd build
+
+cmake \
+   -DCMAKE_INSTALL_PREFIX=/usr \
+   -DCMAKE_INSTALL_LIBDIR=lib/aarch64-linux-gnu \
+   -DCMAKE_INSTALL_BINDIR=bin \
+   -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+   -DGST_VERSION_REQUIRED=1.24.0 \
+   -DENABLE_GST_PLUGIN_BASE=ON \
+   -DENABLE_GST_ML_PLUGINS=ON \
+   -DENABLE_GST_VIDEOPROC_PLUGINS=ON \
+   -DENABLE_GST_SAMPLE_APPS=ON \
+   ..
+
+make -j$(nproc)
+```
+
+</NewCodeBlock>
+
+### 步骤 3：安装
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo make install
+```
+
+</NewCodeBlock>
+
+### 步骤 4：验证
+
+```bash
+ls /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqti*.so | wc -l
+```
+
+编译安装约 34 个插件动态库，输出如 `libgstqtimltflite.so`、`libgstqtimlvclassification.so` 等。
+
+## 排障
+
+### CMake 找不到 GStreamer
+
+确认 GStreamer 开发包已安装：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+pkg-config --modversion gstreamer-1.0
+```
+
+</NewCodeBlock>
+
+如果提示找不到，安装：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install libgstreamer1.0-dev
+```
+
+</NewCodeBlock>
+
+## 参考
+
+- [Python GStreamer 应用](./python-apps.md) — Python 开发方式

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/classification.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/classification.md
@@ -1,0 +1,126 @@
+---
+sidebar_position: 1
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 图像分类
+
+`gst-ai-classification` 对视频流逐帧执行图像分类，识别画面主体并叠加分类标签和置信度。
+
+与 [目标检测](./object-detection.md) 的区别：分类回答"这是什么"，给出整张图的类别；检测回答"哪里有什么"，框出每个物体的位置和类别。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型和标签
+
+`download_artifacts.sh` 已自动下载所需文件：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/inception_v3_quantized.tflite
+ls -l /etc/labels/classification.json
+```
+
+</NewCodeBlock>
+
+### 2. 查看配置
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config_classification.json
+```
+
+</NewCodeBlock>
+
+默认配置使用 InceptionV3 量化模型、LiteRT 框架、DSP 推理。关键字段：
+
+| 字段           | 默认值                                      | 说明                                |
+| -------------- | ------------------------------------------- | ----------------------------------- |
+| `file-path`    | `/etc/media/video.mp4`                      | 输入视频路径                        |
+| `ml-framework` | `tflite`                                    | 推理框架：`tflite` / `snpe` / `qnn` |
+| `model`        | `/etc/models/inception_v3_quantized.tflite` | 模型文件                            |
+| `labels`       | `/etc/labels/classification.json`           | 标签文件                            |
+| `threshold`    | `40`                                        | 置信度阈值 (1-100)                  |
+| `runtime`      | `dsp`                                       | 推理硬件：`cpu` / `gpu` / `dsp`     |
+| `output-type`  | `waylandsink`                               | 输出方式                            |
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-classification --config-file=/etc/configs/config_classification.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Running app with model: /etc/models/inception_v3_quantized.tflite and labels: /etc/labels/classification.json
+Using DSP Delegate
+VERBOSE: Replacing 142 out of 142 node(s) with delegate (TfLiteQnnDelegate) node, yielding 1 partitions for the whole graph.
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放测试视频，画面顶部叠加分类结果（如 "goldfish"）及置信度百分比。
+
+## 验证
+
+- `Using DSP Delegate`：推理在 NPU 上运行
+- `Replacing 142 out of 142 node(s)`：全部 142 个算子委派到 DSP，无 CPU 回退
+- Pipeline 进入 `PLAYING` 状态
+- 显示器正确显示分类标签
+
+## 切换输入源
+
+修改配置文件中的输入源字段：
+
+```json
+// 切换视频文件
+"file-path": "/etc/media/video1.mp4"
+
+// 或使用 RTSP 流
+"rtsp-ip-port": "rtsp://192.168.1.100:8554/live.mkv"
+```
+
+## 切换推理硬件
+
+修改 `runtime` 字段：
+
+```json
+"runtime": "cpu"   // CPU 推理
+"runtime": "gpu"   // GPU 推理
+"runtime": "dsp"   // NPU 推理（默认，推荐）
+```
+
+## Pipeline 流程
+
+```text
+filesrc → qtdemux → h264parse → v4l2h264dec → qtimlvconverter
+                                                       ↓
+                                              (张量预处理)
+                                                       ↓
+                                          qtimltflite (DSP 推理)
+                                                       ↓
+                                          qtimlvclassification
+                                          (阈值/标签映射)
+                                                       ↓
+                                                qtivcomposer
+                                                       ↓
+                                                 waylandsink
+```

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/daisychain-detection-classification.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/daisychain-detection-classification.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 9
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 菊花链检测与分类
+
+`gst-ai-daisychain-detection-classification` 对视频流执行级联推理：先用 [目标检测](./object-detection.md) 定位物体，再对检测到的每个物体执行 [图像分类](./classification.md)，进一步细化识别结果。
+
+这种级联方式适合需要先定位再细分的场景，例如先检测到"动物"，再分类为"金鱼"。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型文件
+
+应用复用检测和分类模型，均由 `download_artifacts.sh` 自动下载：
+
+```bash
+ls -l /etc/models/yolox_quantized.tflite /etc/models/inception_v3_quantized.tflite
+```
+
+### 2. 查看配置
+
+```bash
+cat /etc/configs/config_daisychain_detection_classification.json
+```
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-daisychain-detection-classification --config-file=/etc/configs/config_daisychain_detection_classification.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Using DSP delegate with TFLITE for Classification
+Using DSP delegate with TFLITE for Detection
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+VERBOSE: Replacing 142 out of 142 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放测试视频，先检测物体位置（边界框），再对每个物体显示细粒度分类标签。
+
+## 验证
+
+- 检测模型（YOLOX, 329 节点）和分类模型（InceptionV3, 142 节点）同时在 DSP 上运行
+- Pipeline 进入 `PLAYING` 状态
+- 显示器同时显示边界框和分类标签
+
+## 工作原理
+
+Pipeline 分两级：
+
+```text
+filesrc → qtdemux → h264parse → v4l2h264dec
+                ↓                        ↓
+           (分流)               qtimlvconverter
+                                        ↓
+                           qtimltflite (YOLOX 检测, DSP)
+                                        ↓
+                                  qtimlvdetection
+                                        ↓
+                           qtimlvconverter (ROI 裁剪)
+                                        ↓
+                           qtimltflite (InceptionV3 分类, DSP)
+                                        ↓
+                               qtimlvclassification
+                                        ↓
+                                  qtivcomposer
+                                        ↓
+                                   waylandsink
+```
+
+与单独的 [目标检测](./object-detection.md) 或 [图像分类](./classification.md) 相比，菊花链方式可以在检测基础上提供更细粒度的分类结果。

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/daisychain-detection-pose.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/daisychain-detection-pose.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 10
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 菊花链检测与姿态估计
+
+`gst-ai-daisychain-detection-pose` 对视频流执行级联推理：先用 [目标检测](./object-detection.md) 定位人体，再对检测到的每个人体执行 [姿态检测](./pose-detection.md)，绘制骨架连线。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型文件
+
+应用复用检测和姿态模型，均由 `download_artifacts.sh` 自动下载：
+
+```bash
+ls -l /etc/models/yolox_quantized.tflite /etc/models/hrnet_pose_quantized.tflite
+```
+
+### 2. 查看配置
+
+```bash
+cat /etc/configs/config-daisychain-detection-pose.json
+```
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-daisychain-detection-pose --config-file=/etc/configs/config-daisychain-detection-pose.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Using DSP delegate with TFLITE for Pose
+Using DSP delegate with TFLITE for Detection
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+VERBOSE: Replacing 518 out of 518 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放测试视频，检测到的人体周围显示边界框并绘制骨架连线。
+
+## 验证
+
+- 检测模型（YOLOX, 329 节点）和姿态模型（HRNet, 518 节点）同时在 DSP 上运行
+- Pipeline 进入 `PLAYING` 状态
+- 显示器同时显示边界框和人体骨架
+
+## 工作原理
+
+Pipeline 分两级：
+
+```text
+filesrc → qtdemux → h264parse → v4l2h264dec
+                ↓                        ↓
+           (分流)               qtimlvconverter
+                                        ↓
+                           qtimltflite (YOLOX 检测, DSP)
+                                        ↓
+                                  qtimlvdetection
+                                        ↓
+                           qtimlvconverter (ROI 裁剪)
+                                        ↓
+                           qtimltflite (HRNet 姿态, DSP)
+                                        ↓
+                                   qtimlvpose
+                                        ↓
+                                  qtivcomposer
+                                        ↓
+                                   waylandsink
+```
+
+与 [菊花链检测与分类](./daisychain-detection-classification.md) 的区别在于第二级使用姿态估计而非分类。

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/event-encoder.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/event-encoder.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 13
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 事件编码器
+
+`gst-ai-event-encoder` 对视频流执行目标检测，并将检测到的事件（目标出现/移动等）编码输出。适合安防监控、视频分析等需要输出结构化事件信息的场景。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型
+
+```bash
+ls -l /etc/models/yolox_quantized.tflite
+```
+
+### 2. 查看配置
+
+```bash
+cat /etc/configs/config-event-encoder.json
+```
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-event-encoder --config-file=/etc/configs/config-event-encoder.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Running app with model: /etc/models/yolox_quantized.tflite and labels: /etc/labels/yolox.json
+Using DSP delegate
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放检测画面，同时终端输出检测到的事件元数据。
+
+## 验证
+
+- YOLOX 模型（329 节点）在 DSP 上运行
+- Pipeline 进入 `PLAYING` 状态
+- 终端持续输出事件编码数据

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/face-detection.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/face-detection.md
@@ -1,0 +1,89 @@
+---
+sidebar_position: 8
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-25
+---
+
+# 人脸检测
+
+`gst-ai-face-detection` 对视频流逐帧执行人脸检测，标记人脸位置和关键点（眼睛、鼻子、嘴等）。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 安装 ffmpeg 并转码视频
+
+默认视频格式与 Q900 的 GStreamer 渲染管线存在兼容性问题，需转码为 baseline H.264：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install -y ffmpeg
+sudo ffmpeg -y -i /etc/media/video.mp4 \
+    -c:v libx264 \
+    -profile:v baseline \
+    -level 3.1 \
+    -pix_fmt yuv420p \
+    -vf scale=640:480 \
+    -r 30 \
+    -g 30 \
+    -keyint_min 30 \
+    -bf 0 \
+    -an \
+    -movflags +faststart \
+    /etc/media/video_safe.mp4
+```
+
+</NewCodeBlock>
+
+### 2. 创建配置文件
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+python3 -c "
+import json
+with open('/etc/configs/config_face_detection.json') as f:
+    c = json.load(f)
+c['file-path'] = '/etc/media/video_safe.mp4'
+json.dump(c, open('/tmp/cfg_face_detection.json', 'w'), indent=2)
+"
+```
+
+</NewCodeBlock>
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-face-detection --config-file=/tmp/cfg_face_detection.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Running app with model: /etc/models/face_det_lite_quantized.tflite and labels: /etc/labels/face_detection.json
+VERBOSE: Replacing 90 out of 90 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放视频，检测到的人脸周围显示边界框和关键点。
+
+## 验证
+
+- 90 个算子全部委派到 DSP
+- Pipeline 进入 `PLAYING` 状态
+- 显示器正确显示人脸边界框和关键点

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/metadata-parser.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/metadata-parser.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 14
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 元数据解析
+
+`gst-ai-metadata-parser-example` 对视频流执行目标检测，并将检测结果的元数据（坐标、类别、置信度）解析输出，可用于对接外部分析系统或存储检测日志。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型
+
+```bash
+ls -l /etc/models/yolox_quantized.tflite
+```
+
+### 2. 查看配置
+
+```bash
+cat /etc/configs/config-metadata-parser.json
+```
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-metadata-parser-example --config-file=/etc/configs/config-metadata-parser.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Running app with model: /etc/models/yolox_quantized.tflite and labels: /etc/labels/yolox.json
+Using DSP delegate
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放检测画面，终端持续输出结构化的检测元数据（JSON 格式）。
+
+## 验证
+
+- YOLOX 模型（329 节点）在 DSP 上运行
+- Pipeline 进入 `PLAYING` 状态
+- 终端输出有效的元数据结构

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/monodepth.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/monodepth.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 5
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 单目深度估计
+
+`gst-ai-monodepth` 对视频流逐帧执行单目深度估计，生成深度图并以热力图叠加渲染。暖色调（红/橙）表示距离较近，冷色调（蓝）表示距离较远。
+
+使用 MiDaS V2 模型。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型和标签
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/midas_quantized.tflite
+ls -l /etc/labels/monodepth.json
+```
+
+</NewCodeBlock>
+
+### 2. 查看配置
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config_monodepth.json
+```
+
+</NewCodeBlock>
+
+关键字段：
+
+| 字段           | 默认值                               | 说明         |
+| -------------- | ------------------------------------ | ------------ |
+| `file-path`    | `/etc/media/video.mp4`               | 输入视频路径 |
+| `ml-framework` | `tflite`                             | 推理框架     |
+| `model`        | `/etc/models/midas_quantized.tflite` | 模型文件     |
+| `labels`       | `/etc/labels/monodepth.json`         | 颜色映射文件 |
+| `runtime`      | `dsp`                                | 推理硬件     |
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-monodepth --config-file=/etc/configs/config_monodepth.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Running app with model: /etc/models/midas_quantized.tflite and labels: /etc/labels/monodepth.json
+Using DSP Delegate
+VERBOSE: Replacing 140 out of 140 node(s) with delegate (TfLiteQnnDelegate) node, yielding 1 partitions for the whole graph.
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放测试视频，叠加深度热力图。暖色（红/橙）表示近处物体，冷色（蓝）表示远处背景。
+
+## 验证
+
+- `Using DSP Delegate`：推理在 NPU 上运行
+- `Replacing 140 out of 140 node(s)`：全部 140 个算子委派到 DSP
+- Pipeline 进入 `PLAYING` 状态
+- 显示器正确显示深度热力图
+
+## 工作原理
+
+MiDaS (Monocular Depth Estimation) 以单张 RGB 图像为输入，输出每个像素的相对深度值。GStreamer pipeline：
+
+```text
+filesrc → qtdemux → h264parse → v4l2h264dec
+                ↓                        ↓
+           (分流)               qtimlvconverter (预处理)
+                                        ↓
+                              qtimltflite (DSP 推理)
+                                        ↓
+                              后处理 (深度→热力图)
+                                        ↓
+                                  qtivcomposer
+                                        ↓
+                                   waylandsink
+```

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/multistream-inference.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/multistream-inference.md
@@ -1,0 +1,103 @@
+---
+sidebar_position: 12
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-25
+---
+
+# 多流推理
+
+`gst-ai-multistream-inference` 同时处理多路视频流，每路独立执行目标检测，适合安防监控、多路分析等场景。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 安装 ffmpeg 并转码视频
+
+默认视频格式与 Q900 的 GStreamer 渲染管线存在兼容性问题，需转码为 baseline H.264：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install -y ffmpeg
+sudo ffmpeg -y -i /etc/media/video.mp4 \
+    -c:v libx264 \
+    -profile:v baseline \
+    -level 3.1 \
+    -pix_fmt yuv420p \
+    -vf scale=640:480 \
+    -r 30 \
+    -g 30 \
+    -keyint_min 30 \
+    -bf 0 \
+    -an \
+    -movflags +faststart \
+    /etc/media/video_safe.mp4
+```
+
+</NewCodeBlock>
+
+关键参数说明：
+
+| 参数                   | 作用                                    |
+| ---------------------- | --------------------------------------- |
+| `-profile:v baseline`  | 禁用 B 帧，避免 qtdemux dmabuf 协商冲突 |
+| `-bf 0`                | 关闭 B 帧                               |
+| `-keyint_min 30 -g 30` | 关键帧间隔 1 秒，便于 seek              |
+| `-movflags +faststart` | moov 原子前置，加快解码器初始化         |
+| `-an`                  | 去除音频，减小文件体积                  |
+
+### 2. 创建配置文件
+
+配置中所有流指向同一个转码后的视频：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+python3 -c "
+import json
+with open('/etc/configs/config-multistream-inference.json') as f:
+    c = json.load(f)
+c['input-file-path'] = ['/etc/media/video_safe.mp4'] * 16
+json.dump(c, open('/tmp/cfg_multistream.json', 'w'), indent=2)
+print('config written')
+"
+```
+
+</NewCodeBlock>
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-multistream-inference --config-file=/tmp/cfg_multistream.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+HTP Core Count = 2
+Run app with model: /etc/models/yolox_quantized.tflite and labels: /etc/labels/yolox.json and use case: Detection
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+...
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上同时显示多路检测画面。
+
+## 验证
+
+- 每路视频 329 个算子全部委派到 DSP
+- Pipeline 进入 `PLAYING` 状态

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/object-detection.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/object-detection.md
@@ -1,0 +1,127 @@
+---
+sidebar_position: 2
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 目标检测
+
+`gst-ai-object-detection` 对视频流逐帧执行目标检测，在检测到的物体周围绘制边界框，标注类别名称和置信度。
+
+支持 YOLOX、YOLOv8、YOLO-NAS 模型。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型和标签
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/yolox_quantized.tflite
+ls -l /etc/labels/yolox.json
+```
+
+</NewCodeBlock>
+
+### 2. 查看配置
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config_detection.json
+```
+
+</NewCodeBlock>
+
+关键字段：
+
+| 字段              | 默认值                               | 说明                                                     |
+| ----------------- | ------------------------------------ | -------------------------------------------------------- |
+| `file-path`       | `/etc/media/video.mp4`               | 输入视频路径                                             |
+| `ml-framework`    | `tflite`                             | 推理框架                                                 |
+| `yolo-model-type` | `yolox`                              | YOLO 模型类型：`yolov5` / `yolov8` / `yolox` / `yolonas` |
+| `model`           | `/etc/models/yolox_quantized.tflite` | 模型文件                                                 |
+| `labels`          | `/etc/labels/yolox.json`             | 标签文件                                                 |
+| `threshold`       | `40`                                 | 置信度阈值 (1-100)                                       |
+| `runtime`         | `dsp`                                | 推理硬件                                                 |
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-object-detection --config-file=/etc/configs/config_detection.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Running app with model: /etc/models/yolox_quantized.tflite and labels: /etc/labels/yolox.json
+Using DSP Delegate
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放测试视频，检测到的物体周围显示彩色边界框，标注类别名称和置信度。
+
+## 验证
+
+- `Using DSP Delegate`：推理在 NPU 上运行
+- `Replacing 329 out of 329 node(s)`：全部 329 个算子委派到 DSP
+- Pipeline 进入 `PLAYING` 状态
+- 显示器正确显示边界框和标签
+
+## 调整检测灵敏度
+
+如果检测框太少（漏检），降低阈值：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+# 将 /etc/configs/config_detection.json 中 threshold 改为 20
+```
+
+</NewCodeBlock>
+
+如果误检太多，提高阈值（如 60）。
+
+## 切换 YOLO 模型
+
+修改配置文件中的模型类型和路径：
+
+```json
+{
+  "yolo-model-type": "yolov8",
+  "model": "/etc/models/yolov8_det_quantized.tflite",
+  "labels": "/etc/labels/yolov8.json"
+}
+```
+
+> YOLOv8 和 YOLO-NAS 模型需要通过 Qualcomm AI Hub 单独导出。
+
+## Pipeline 流程
+
+```text
+filesrc → qtdemux → h264parse → v4l2h264dec → qtimlvconverter
+                                                       ↓
+                                          qtimltflite (DSP 推理)
+                                                       ↓
+                                          qtimlvdetection (YOLO 后处理)
+                                                       ↓
+                                                qtivcomposer
+                                                       ↓
+                                                 waylandsink
+```

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/parallel-inference.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/parallel-inference.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 11
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 并行 AI 融合
+
+`gst-ai-parallel-inference` 在同一个视频流上**同时运行多个 AI 模型**，所有模型并行在 NPU 上推理，结果融合显示。
+
+默认配置同时运行 4 个模型：目标检测（YOLOX）、图像分类（InceptionV3）、姿态检测（HRNet）、图像分割（DeepLabV3+），全部在 DSP 上并行执行。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型文件
+
+所有模型均由 `download_artifacts.sh` 自动下载：
+
+```bash
+ls -l /etc/models/{yolox_quantized,inception_v3_quantized,hrnet_pose_quantized,deeplabv3_plus_mobilenet_quantized}.tflite
+```
+
+### 2. 查看配置
+
+```bash
+cat /etc/configs/config-parallel-inference.json
+```
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-parallel-inference --config-file=/etc/configs/config-parallel-inference.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+VERBOSE: Replacing 142 out of 142 node(s) with delegate (TfLiteQnnDelegate) node
+VERBOSE: Replacing 518 out of 518 node(s) with delegate (TfLiteQnnDelegate) node
+VERBOSE: Replacing 136 out of 136 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上同时显示边界框、分类标签、人体骨架和分割蒙版，四种 AI 结果叠加在同一个画面上。
+
+## 验证
+
+- 4 个模型（329 + 142 + 518 + 136 = 1125 个算子）全部在 DSP 上并行运行
+- Pipeline 进入 `PLAYING` 状态
+- 显示器同时显示四种推理结果
+
+## 工作原理
+
+Pipeline 使用 GStreamer 的 `tee` 元素将视频流分发给多个推理分支：
+
+```text
+                          ┌─→ qtimlvconverter → qtimltflite (检测, DSP) → qtimlvdetection ─┐
+                          │                                                                  │
+filesrc → qtdemux →       ├─→ qtimlvconverter → qtimltflite (分类, DSP) → qtimlvclassification ─┤
+h264parse → v4l2h264dec → tee                                                              qtivcomposer → waylandsink
+                          ├─→ qtimlvconverter → qtimltflite (姿态, DSP) → qtimlvpose ────────┤
+                          │                                                                  │
+                          └─→ qtimlvconverter → qtimltflite (分割, DSP) → qtimlvsegmentation ┘
+```
+
+四个推理分支共享输入视频流，各自独立在 DSP 上运行，最终由 `qtivcomposer` 将结果融合渲染到同一帧。这验证了 Q900 的 HTP V73 NPU 支持多模型并行处理。

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/pose-detection.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/pose-detection.md
@@ -1,0 +1,111 @@
+---
+sidebar_position: 3
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 姿态检测
+
+`gst-ai-pose-detection` 对视频流逐帧执行人体姿态检测，在人体关键点之间绘制骨架连线。
+
+使用 HRNet 模型。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认所需文件
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/hrnet_pose_quantized.tflite
+ls -l /etc/labels/hrnet_pose.json
+ls -l /etc/labels/hrnet_settings.json
+```
+
+</NewCodeBlock>
+
+> `hrnet_settings.json` 定义人体关节之间的连接关系。缺少该文件会导致 `Invalid pose settings path` 错误。
+
+### 2. 查看配置
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config_pose.json
+```
+
+</NewCodeBlock>
+
+关键字段：
+
+| 字段                 | 默认值                                    | 说明         |
+| -------------------- | ----------------------------------------- | ------------ |
+| `file-path`          | `/etc/media/video.mp4`                    | 输入视频路径 |
+| `ml-framework`       | `tflite`                                  | 推理框架     |
+| `model`              | `/etc/models/hrnet_pose_quantized.tflite` | 模型文件     |
+| `labels`             | `/etc/labels/hrnet_pose.json`             | 标签文件     |
+| `pose-settings-path` | `/etc/labels/hrnet_settings.json`         | 关节连接配置 |
+| `runtime`            | `dsp`                                     | 推理硬件     |
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-pose-detection --config-file=/etc/configs/config_pose.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Running app with model: /etc/models/hrnet_pose_quantized.tflite and labels: /etc/labels/hrnet_pose.json and settings /etc/labels/hrnet_settings.json
+Using DSP Delegate
+VERBOSE: Replacing 518 out of 518 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放测试视频，人体关键点之间绘制骨架连线。
+
+## 验证
+
+- `Using DSP Delegate`：推理在 NPU 上运行
+- `Replacing 518 out of 518 node(s)`：全部 518 个算子委派到 DSP
+- Pipeline 进入 `PLAYING` 状态
+- 显示器正确显示人体骨架
+
+## 排障
+
+### Invalid pose settings path
+
+确认 `hrnet_settings.json` 存在于 `/etc/labels/`：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/labels/hrnet_settings.json
+```
+
+</NewCodeBlock>
+
+如果缺失，重新运行下载脚本：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo ./download_artifacts.sh -v GA1.6-rel -c QCS9075
+```
+
+</NewCodeBlock>

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/python-apps.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/python-apps.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 15
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Python GStreamer 应用
+
+QIM SDK 提供 Python GStreamer 绑定示例，展示如何使用 Python 构建 AI/ML 和多媒体 pipeline。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装)
+
+Python 示例已通过 `gstreamer1.0-qcom-python-examples` 包安装。相关 Python 依赖（`python3-gst-1.0`、`python3-numpy`、`python3-opencv`）自动安装。
+
+## 可用示例
+
+| 应用                     | 说明                         |
+| ------------------------ | ---------------------------- |
+| 摄像头编码               | 从摄像头采集并编码为 H.264   |
+| OpenCV 摄像头流          | 使用 OpenCV 读取摄像头流     |
+| OpenCV 视频转换          | OpenCV 视频格式转换          |
+| 并发视频播放（视频墙）   | 多路视频同时播放             |
+| 多摄像头流               | Python 控制多路摄像头        |
+| 目标检测与显示           | 运行目标检测并在显示器上渲染 |
+| RTSP 流解码和目标检测    | 从 RTSP 流解码并检测         |
+| JPEG 图像解码            | 解码 JPEG 图像               |
+| 目标检测和分类           | 级联检测+分类                |
+| 转换和编码摄像头流       | 摄像头流转码                 |
+| 摄像头编码+目标检测+显示 | 端到端 pipeline              |
+| 目标检测+分类+分割       | 多任务 AI                    |
+| 并行推理                 | 多模型并行                   |
+| 菊花链检测和姿态检测     | 级联检测+姿态                |
+
+## 基本结构
+
+Python GStreamer 应用使用 PyGObject 绑定：
+
+```python
+import gi
+gi.require_version('Gst', '1.0')
+from gi.repository import Gst, GLib
+
+Gst.init(None)
+
+# 创建 pipeline
+pipeline = Gst.parse_launch(
+    "filesrc location=/etc/media/video.mp4 ! "
+    "qtdemux ! h264parse ! v4l2h264dec ! waylandsink"
+)
+
+# 启动
+pipeline.set_state(Gst.State.PLAYING)
+
+# 主循环
+loop = GLib.MainLoop()
+loop.run()
+```
+
+## 获取源代码
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+git clone https://github.com/quic/sample-apps-for-qualcomm-linux
+```
+
+</NewCodeBlock>
+
+## 参考
+
+- [源码编译](./build-from-source.md) — 在设备上编译自定义 C/C++ 应用

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/segmentation.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/segmentation.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 4
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 图像分割
+
+`gst-ai-segmentation` 对视频流逐帧执行语义分割，为每个像素分配类别标签，以半透明彩色蒙版叠加渲染。
+
+使用 DeepLabV3+ MobileNet 模型。
+
+与 [目标检测](./object-detection.md) 的区别：检测用边界框框出物体，分割对每个像素分类并着色。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型和标签
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/deeplabv3_plus_mobilenet_quantized.tflite
+ls -l /etc/labels/deeplabv3_resnet50.json
+```
+
+</NewCodeBlock>
+
+### 2. 查看配置
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config_segmentation.json
+```
+
+</NewCodeBlock>
+
+关键字段：
+
+| 字段                | 默认值                                                  | 说明         |
+| ------------------- | ------------------------------------------------------- | ------------ |
+| `file-path`         | `/etc/media/video.mp4`                                  | 输入视频路径 |
+| `ml-framework`      | `tflite`                                                | 推理框架     |
+| `model`             | `/etc/models/deeplabv3_plus_mobilenet_quantized.tflite` | 模型文件     |
+| `labels`            | `/etc/labels/deeplabv3_resnet50.json`                   | 颜色映射文件 |
+| `runtime`           | `dsp`                                                   | 推理硬件     |
+| `video-disposition` | `stretch`                                               | 视频布局方式 |
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-segmentation --config-file=/etc/configs/config_segmentation.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Running app with model: /etc/models/deeplabv3_plus_mobilenet_quantized.tflite and labels: /etc/labels/deeplabv3_resnet50.json
+Using DSP Delegate
+VERBOSE: Replacing 136 out of 136 node(s) with delegate (TfLiteQnnDelegate) node, yielding 1 partitions for the whole graph.
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器上播放测试视频，画面叠加半透明彩色分割蒙版。不同颜色对应不同类别（人、车、道路、建筑等）。
+
+## 验证
+
+- `Using DSP Delegate`：推理在 NPU 上运行
+- `Replacing 136 out of 136 node(s)`：全部 136 个算子委派到 DSP
+- Pipeline 进入 `PLAYING` 状态
+- 显示器正确显示分割蒙版
+
+## 排障
+
+### 分割蒙版不显示
+
+确认标签文件内容有效：
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+python3 -c "import json; json.load(open('/etc/labels/deeplabv3_resnet50.json'))" && echo "JSON 有效"
+```
+
+</NewCodeBlock>
+
+如果输出 `404: Not Found` 或其他非 JSON 内容，重新运行下载脚本。

--- a/docs/fogwise/airbox-q900/ai-dev/qim-sdk/superresolution.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qim-sdk/superresolution.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 6
+doc_kind: page
+locale: zh
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# 视频超分辨率
+
+`gst-ai-superresolution` 使用 AI 模型对低分辨率视频进行超分辨率重建，生成高分辨率输出帧。
+
+使用 QuickSRNet Small 模型（约 42 KB），适合实时推理。
+
+## 前提条件
+
+- 已完成 [QIM SDK 安装](./README.md#安装) 和 [模型下载](./README.md#下载模型和测试资源)
+
+## 步骤
+
+### 1. 确认模型
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/quicksrnetsmall_quantized.tflite
+```
+
+</NewCodeBlock>
+
+> 超分辨率应用不需要标签文件。
+
+### 2. 查看配置
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config-superresolution.json
+```
+
+</NewCodeBlock>
+
+关键字段：
+
+| 字段              | 默认值                 | 说明         |
+| ----------------- | ---------------------- | ------------ |
+| `input-file-path` | `/etc/media/video.mp4` | 输入视频路径 |
+
+> 注意：超分辨率配置使用 `input-file-path`（而非 `file-path`）。
+
+### 3. 运行
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-superresolution --config-file=/etc/configs/config-superresolution.json
+```
+
+</NewCodeBlock>
+
+按 `Ctrl + C` 停止。
+
+## 预期输出
+
+终端输出：
+
+```text
+Running app with model: /etc/models/quicksrnetsmall_quantized.tflite
+VERBOSE: Replacing 10 out of 13 node(s) with delegate (TfLiteQnnDelegate) node, yielding 3 partitions for the whole graph.
+Pipeline state changed from PAUSED to PLAYING
+```
+
+显示器显示超分辨率处理后的视频画面，细节比原始输入更清晰。
+
+## 验证
+
+- `Replacing 10 out of 13 node(s)`：10 个算子委派到 DSP，3 个回退 CPU
+- Pipeline 进入 `PLAYING` 状态
+- 显示器显示超分后画面
+
+> 部分算子（Reshape、Transpose）不支持 DSP，自动回退到 CPU 执行。不影响整体功能。
+
+## 工作原理
+
+QuickSRNet 是专为移动和嵌入式设备设计的超轻量级超分辨率网络。Pipeline 流程：
+
+```text
+filesrc → qtdemux → h264parse → v4l2h264dec
+                                       ↓
+                               qtimlvconverter
+                                       ↓
+                          qtimltflite (DSP + CPU)
+                                       ↓
+                                qtivcomposer
+                                       ↓
+                                 waylandsink
+```

--- a/docs/fogwise/airbox-q900/ai-dev/qnn_onnxrt_execution_provider.md
+++ b/docs/fogwise/airbox-q900/ai-dev/qnn_onnxrt_execution_provider.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 9
 
 doc_kind: wrapper
 source_of_truth: common

--- a/docs/fogwise/airbox-q900/ai-dev/tflite-delegate-demo.md
+++ b/docs/fogwise/airbox-q900/ai-dev/tflite-delegate-demo.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 10
 
 doc_kind: wrapper
 source_of_truth: common

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/README.md
@@ -1,0 +1,178 @@
+---
+sidebar_position: 101
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# QIM SDK Development Guide
+
+The Qualcomm Intelligent Multimedia SDK (IM SDK) is a GStreamer-based AI/ML application development framework. It provides ready-to-use CLI tools and hardware-accelerated plugins covering the complete pipeline from video capture, AI inference, to result rendering.
+
+## Relationship with QAIRT
+
+QIM SDK sits on top of QAIRT SDK:
+
+| Layer                   | Contents                                                                   | Status on Q900                   |
+| ----------------------- | -------------------------------------------------------------------------- | -------------------------------- |
+| **QAIRT Runtime**       | QNN / SNPE / LiteRT runtime libraries                                      | Installed via apt (`qairt-libs`) |
+| **QIM SDK Plugins**     | GStreamer ML plugins (capture, preprocess, inference, postprocess, render) | Installed via apt                |
+| **QIM SDK Sample Apps** | `gst-ai-*` CLI tools                                                       | Installed via apt                |
+
+Install QAIRT base libraries first (`sudo apt install -y qairt-libs`), see the installation steps below.
+
+## Prerequisites
+
+- Radxa AIRbox Q900 (QCS9075 / SA8775P, HTP V73 NPU)
+- Ubuntu 24.04, with network access
+- Display connected (Wayland)
+
+## Installation
+
+### Step 1: Install QAIRT Base Libraries
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install -y qairt-libs
+```
+
+</NewCodeBlock>
+
+### Step 2: Install QIM SDK
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install -y \
+    gstreamer1.0-tools \
+    tensorflow-lite-qcom-apps \
+    gstreamer1.0-qcom-sample-apps \
+    gstreamer1.0-qcom-python-examples
+```
+
+</NewCodeBlock>
+
+All ML inference plugins and video processing plugins are automatically installed as dependencies.
+
+### Step 3: Verify Installation
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls /usr/bin/gst-ai-*
+```
+
+</NewCodeBlock>
+
+Expected output: 20 `gst-ai-*` CLI tools.
+
+## Download Models and Test Resources
+
+Use the official script for one-click download:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install -y unzip
+curl -L -O https://raw.githubusercontent.com/quic/sample-apps-for-qualcomm-linux/refs/heads/main/download_artifacts.sh
+chmod +x download_artifacts.sh
+sudo ./download_artifacts.sh -v GA1.6-rel -c QCS9075
+```
+
+</NewCodeBlock>
+
+After download:
+
+| Directory       | Contents                                   |
+| --------------- | ------------------------------------------ |
+| `/etc/models/`  | 10 `.tflite` quantized models              |
+| `/etc/labels/`  | 16 label and config files                  |
+| `/etc/media/`   | 4 test videos                              |
+| `/etc/configs/` | 38 app config JSONs (from package install) |
+
+## Quick Verification
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-classification --config-file=/etc/configs/config_classification.json
+```
+
+</NewCodeBlock>
+
+On success, the display shows the test video with classification labels overlaid. The terminal output includes `Using DSP Delegate` and `Pipeline state changed to PLAYING`.
+
+Press `Ctrl + C` to stop.
+
+> Normally you do **not** need to manually set `XDG_RUNTIME_DIR` or `WAYLAND_DISPLAY` — these are configured automatically on SSH login.
+
+## Available Sample Applications
+
+The following apps have been verified on Q900 (QCS9075):
+
+| Application                                                                        | Description                         | Model                                    | NPU           |
+| ---------------------------------------------------------------------------------- | ----------------------------------- | ---------------------------------------- | ------------- |
+| [Image Classification](./classification.md)                                        | Identify subjects in images         | InceptionV3                              | DSP           |
+| [Object Detection](./object-detection.md)                                          | Detect and locate objects           | YOLOX                                    | DSP           |
+| [Pose Detection](./pose-detection.md)                                              | Human body keypoint detection       | HRNet                                    | DSP           |
+| [Image Segmentation](./segmentation.md)                                            | Per-pixel semantic segmentation     | DeepLabV3+                               | DSP           |
+| [Monocular Depth](./monodepth.md)                                                  | Depth heatmap estimation            | MiDaS V2                                 | DSP           |
+| [Super Resolution](./superresolution.md)                                           | Low-resolution upscaling            | QuickSRNet                               | DSP (partial) |
+| [Audio Classification](./audio-classification.md)                                  | Audio event classification          | YAMNet                                   | CPU           |
+| [Face Detection](./face-detection.md)                                              | Face landmark detection             | Lightweight Face Detection               | DSP           |
+| [Daisy-Chain Detection & Classification](./daisychain-detection-classification.md) | Cascaded detection + classification | YOLOX + InceptionV3                      | DSP           |
+| [Daisy-Chain Detection & Pose](./daisychain-detection-pose.md)                     | Cascaded detection + pose           | YOLOX + HRNet                            | DSP           |
+| [Parallel AI Fusion](./parallel-inference.md)                                      | 4-model simultaneous inference      | YOLOX + InceptionV3 + HRNet + DeepLabV3+ | DSP           |
+| [Multistream Inference](./multistream-inference.md)                                | Multi-stream concurrent detection   | YOLOX                                    | DSP           |
+| [Event Encoder](./event-encoder.md)                                                | Detection event encoding            | YOLOX                                    | DSP           |
+| [Metadata Parser](./metadata-parser.md)                                            | Detection metadata export           | YOLOX                                    | DSP           |
+
+> See the [IM SDK Reference Manual](https://docs.qualcomm.com/doc/80-70020-50SC/topic/download-model-and-label-files.html) Chapter 3 for the full list.
+
+## Reference
+
+- [Python GStreamer Apps](./python-apps.md) — Python binding examples
+- [Build from Source](./build-from-source.md) — Compile custom GStreamer apps on-device
+
+## Troubleshooting
+
+### No display output
+
+Check that the Wayland socket exists:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY
+```
+
+</NewCodeBlock>
+
+### DSP inference failure
+
+Verify FastRPC device nodes exist:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls /dev/fastrpc-cdsp*
+```
+
+</NewCodeBlock>
+
+If no output, see [Enable NPU](../fastrpc-setup.md).
+
+### Model files missing
+
+Re-run the download script:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo ./download_artifacts.sh -v GA1.6-rel -c QCS9075
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/audio-classification.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/audio-classification.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 7
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Audio Classification
+
+`gst-ai-audio-classification` performs audio event classification on an audio stream, identifying sound types (e.g., speech, music, ambient noise).
+
+Uses the YAMNet model, with the default configuration using CPU inference.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Model and Labels
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/yamnet.tflite
+ls -l /etc/labels/yamnet.json
+```
+
+</NewCodeBlock>
+
+### 2. View Configuration
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config-audio-classification.json
+```
+
+</NewCodeBlock>
+
+Key fields:
+
+| Field       | Default                     | Description                          |
+| ----------- | --------------------------- | ------------------------------------ |
+| `file-path` | `/etc/media/video-mp3.mp4`  | Input audio/video file (MP3 encoded) |
+| `model`     | `/etc/models/yamnet.tflite` | Model file                           |
+| `labels`    | `/etc/labels/yamnet.json`   | Label file                           |
+| `threshold` | `10`                        | Confidence threshold                 |
+| `codec`     | `mp3`                       | Audio encoding format                |
+| `runtime`   | `cpu`                       | Inference hardware                   |
+
+> Default uses CPU inference. For DSP inference, change `runtime` to `dsp` and add `ml-framework: "tflite"`.
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-audio-classification --config-file=/etc/configs/config-audio-classification.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+Terminal output:
+
+```text
+Running app with model: /etc/models/yamnet.tflite and labels: /etc/labels/yamnet.json
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the test video with audio classification results overlaid.
+
+## Validation
+
+- Pipeline reaches `PLAYING` state
+- Terminal continuously outputs audio classification results
+- Display shows classification labels
+
+## How It Works
+
+YAMNet is an audio event classification model based on the AudioSet dataset, supporting 521 audio categories. Pipeline flow:
+
+```text
+filesrc → qtdemux → (audio decode) → qtimlaudioconverter
+                                          ↓
+                                qtimltflite (inference)
+                                          ↓
+                               qtimlaclassification
+                                          ↓
+                               (classification label overlay)
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/build-from-source.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/build-from-source.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 16
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Build from Source
+
+All QIM SDK GStreamer plugins and sample applications are already available as pre-built packages via [apt installation](./README.md#installation). In most cases, source compilation is unnecessary.
+
+You can also compile from source directly on the device, which is useful for:
+
+- Modifying plugin source code to customize post-processing logic or add custom model support
+- Debugging plugin internals
+- Using build options that differ from the pre-built packages
+
+The build produces 34 GStreamer plugin shared libraries (`.so`), covering AI inference engines (`mltflite`, `mlqnn`, `mlsnpe`), preprocessing (`mlvconverter`), post-processing (`mlpostprocess` and others), and video processing (`vcomposer` and others). See the steps below.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation)
+
+## Install Build Dependencies
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt-add-repository -s ppa:ubuntu-qcom-iot/qcom-ppa
+sudo apt update
+sudo apt install -y \
+    qcom-adreno-dev \
+    libgstreamer1.0-qcom-sample-apps-utils-dev
+```
+
+</NewCodeBlock>
+
+## Build QIM Plugins from Source
+
+### Step 1: Download QIM Source
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cd ~
+apt source gst-plugins-qti-oss
+cd gst-plugins-qti-oss-*
+```
+
+</NewCodeBlock>
+
+### Step 2: CMake Build
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+mkdir build && cd build
+
+cmake \
+   -DCMAKE_INSTALL_PREFIX=/usr \
+   -DCMAKE_INSTALL_LIBDIR=lib/aarch64-linux-gnu \
+   -DCMAKE_INSTALL_BINDIR=bin \
+   -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+   -DGST_VERSION_REQUIRED=1.24.0 \
+   -DENABLE_GST_PLUGIN_BASE=ON \
+   -DENABLE_GST_ML_PLUGINS=ON \
+   -DENABLE_GST_VIDEOPROC_PLUGINS=ON \
+   -DENABLE_GST_SAMPLE_APPS=ON \
+   ..
+
+make -j$(nproc)
+```
+
+</NewCodeBlock>
+
+### Step 3: Install
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo make install
+```
+
+</NewCodeBlock>
+
+### Step 4: Verify
+
+```bash
+ls /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqti*.so | wc -l
+```
+
+Approximately 34 plugin shared libraries are installed, such as `libgstqtimltflite.so`, `libgstqtimlvclassification.so`, etc.
+
+## Troubleshooting
+
+### CMake cannot find GStreamer
+
+Verify GStreamer development packages are installed:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+pkg-config --modversion gstreamer-1.0
+```
+
+</NewCodeBlock>
+
+If not found, install:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install libgstreamer1.0-dev
+```
+
+</NewCodeBlock>
+
+## Reference
+
+- [Python GStreamer Apps](./python-apps.md) — Python development approach

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/classification.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/classification.md
@@ -1,0 +1,126 @@
+---
+sidebar_position: 1
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Image Classification
+
+`gst-ai-classification` performs image classification on each frame of a video stream, identifying the main subject and overlaying classification labels with confidence scores.
+
+Unlike [Object Detection](./object-detection.md), classification answers "what is this" (whole-image category), while detection answers "where is what" (bounding box per object).
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Model and Labels
+
+The `download_artifacts.sh` script has already downloaded the required files:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/inception_v3_quantized.tflite
+ls -l /etc/labels/classification.json
+```
+
+</NewCodeBlock>
+
+### 2. View Configuration
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config_classification.json
+```
+
+</NewCodeBlock>
+
+The default configuration uses InceptionV3 quantized model, LiteRT framework, and DSP inference. Key fields:
+
+| Field          | Default                                     | Description                                    |
+| -------------- | ------------------------------------------- | ---------------------------------------------- |
+| `file-path`    | `/etc/media/video.mp4`                      | Input video path                               |
+| `ml-framework` | `tflite`                                    | Inference framework: `tflite` / `snpe` / `qnn` |
+| `model`        | `/etc/models/inception_v3_quantized.tflite` | Model file                                     |
+| `labels`       | `/etc/labels/classification.json`           | Label file                                     |
+| `threshold`    | `40`                                        | Confidence threshold (1-100)                   |
+| `runtime`      | `dsp`                                       | Inference hardware: `cpu` / `gpu` / `dsp`      |
+| `output-type`  | `waylandsink`                               | Output method                                  |
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-classification --config-file=/etc/configs/config_classification.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+Terminal output:
+
+```text
+Running app with model: /etc/models/inception_v3_quantized.tflite and labels: /etc/labels/classification.json
+Using DSP Delegate
+VERBOSE: Replacing 142 out of 142 node(s) with delegate (TfLiteQnnDelegate) node, yielding 1 partitions for the whole graph.
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the test video with classification labels (e.g., "goldfish") and confidence scores overlaid.
+
+## Validation
+
+- `Using DSP Delegate`: Inference running on NPU
+- `Replacing 142 out of 142 node(s)`: All 142 operators delegated to DSP, no CPU fallback
+- Pipeline reaches `PLAYING` state
+- Display correctly shows classification labels
+
+## Switching Input Source
+
+Modify the input source fields in the config file:
+
+```json
+// Switch video file
+"file-path": "/etc/media/video1.mp4"
+
+// Or use RTSP stream
+"rtsp-ip-port": "rtsp://192.168.1.100:8554/live.mkv"
+```
+
+## Switching Inference Hardware
+
+Modify the `runtime` field:
+
+```json
+"runtime": "cpu"   // CPU inference
+"runtime": "gpu"   // GPU inference
+"runtime": "dsp"   // NPU inference (default, recommended)
+```
+
+## Pipeline Flow
+
+```text
+filesrc → qtdemux → h264parse → v4l2h264dec → qtimlvconverter
+                                                       ↓
+                                              (tensor preprocessing)
+                                                       ↓
+                                          qtimltflite (DSP inference)
+                                                       ↓
+                                          qtimlvclassification
+                                          (threshold/label mapping)
+                                                       ↓
+                                                qtivcomposer
+                                                       ↓
+                                                 waylandsink
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/daisychain-detection-classification.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/daisychain-detection-classification.md
@@ -1,0 +1,60 @@
+---
+sidebar_position: 9
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Daisy-Chain Detection & Classification
+
+`gst-ai-daisychain-detection-classification` performs cascaded inference: first [Object Detection](./object-detection.md) locates objects, then [Image Classification](./classification.md) identifies each detected object for finer-grained recognition.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Models
+
+```bash
+ls -l /etc/models/yolox_quantized.tflite /etc/models/inception_v3_quantized.tflite
+```
+
+### 2. View Configuration
+
+```bash
+cat /etc/configs/config_daisychain_detection_classification.json
+```
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-daisychain-detection-classification --config-file=/etc/configs/config_daisychain_detection_classification.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+```text
+Using DSP delegate with TFLITE for Classification
+Using DSP delegate with TFLITE for Detection
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+VERBOSE: Replacing 142 out of 142 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the test video with bounding boxes from detection and fine-grained classification labels for each detected object.
+
+## Validation
+
+- Detection (YOLOX, 329 ops) and classification (InceptionV3, 142 ops) running simultaneously on DSP
+- Pipeline reaches `PLAYING` state
+- Display shows both bounding boxes and classification labels

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/daisychain-detection-pose.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/daisychain-detection-pose.md
@@ -1,0 +1,60 @@
+---
+sidebar_position: 10
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Daisy-Chain Detection & Pose Estimation
+
+`gst-ai-daisychain-detection-pose` performs cascaded inference: first [Object Detection](./object-detection.md) locates human bodies, then [Pose Detection](./pose-detection.md) draws skeleton connections for each detected person.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Models
+
+```bash
+ls -l /etc/models/yolox_quantized.tflite /etc/models/hrnet_pose_quantized.tflite
+```
+
+### 2. View Configuration
+
+```bash
+cat /etc/configs/config-daisychain-detection-pose.json
+```
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-daisychain-detection-pose --config-file=/etc/configs/config-daisychain-detection-pose.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+```text
+Using DSP delegate with TFLITE for Pose
+Using DSP delegate with TFLITE for Detection
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+VERBOSE: Replacing 518 out of 518 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the test video with bounding boxes and skeleton overlays for detected people.
+
+## Validation
+
+- Detection (YOLOX, 329 ops) and pose (HRNet, 518 ops) running simultaneously on DSP
+- Pipeline reaches `PLAYING` state
+- Display shows both bounding boxes and human skeletons

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/event-encoder.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/event-encoder.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 13
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Event Encoder
+
+`gst-ai-event-encoder` performs object detection on a video stream and encodes detected events (object appearance/movement) into structured output, suitable for surveillance and video analytics.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Model
+
+```bash
+ls -l /etc/models/yolox_quantized.tflite
+```
+
+### 2. View Configuration
+
+```bash
+cat /etc/configs/config-event-encoder.json
+```
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-event-encoder --config-file=/etc/configs/config-event-encoder.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+```text
+Running app with model: /etc/models/yolox_quantized.tflite and labels: /etc/labels/yolox.json
+Using DSP delegate
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the detection view while the terminal streams structured event metadata.
+
+## Validation
+
+- YOLOX model (329 ops) running on DSP
+- Pipeline reaches `PLAYING` state
+- Terminal streams event encoding data continuously

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/face-detection.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/face-detection.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 8
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-25
+---
+
+# Face Detection
+
+`gst-ai-face-detection` performs face detection on each frame of a video stream, marking face locations and facial landmarks (eyes, nose, mouth, etc.).
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Install ffmpeg and Transcode Video
+
+The default video format has compatibility issues with Q900's GStreamer rendering pipeline. Transcode to baseline H.264:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install -y ffmpeg
+sudo ffmpeg -y -i /etc/media/video.mp4 \
+    -c:v libx264 \
+    -profile:v baseline \
+    -level 3.1 \
+    -pix_fmt yuv420p \
+    -vf scale=640:480 \
+    -r 30 \
+    -g 30 \
+    -keyint_min 30 \
+    -bf 0 \
+    -an \
+    -movflags +faststart \
+    /etc/media/video_safe.mp4
+```
+
+</NewCodeBlock>
+
+### 2. Create Config File
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+python3 -c "
+import json
+with open('/etc/configs/config_face_detection.json') as f:
+    c = json.load(f)
+c['file-path'] = '/etc/media/video_safe.mp4'
+json.dump(c, open('/tmp/cfg_face_detection.json', 'w'), indent=2)
+"
+```
+
+</NewCodeBlock>
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-face-detection --config-file=/tmp/cfg_face_detection.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+```text
+Running app with model: /etc/models/face_det_lite_quantized.tflite and labels: /etc/labels/face_detection.json
+VERBOSE: Replacing 90 out of 90 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the video with face bounding boxes and facial landmarks.
+
+## Validation
+
+- 90 ops all delegated to DSP
+- Pipeline reaches `PLAYING` state
+- Display correctly shows face bounding boxes and landmarks

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/metadata-parser.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/metadata-parser.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 14
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Metadata Parser
+
+`gst-ai-metadata-parser-example` performs object detection and parses the detection metadata (coordinates, class, confidence) into structured output, suitable for integration with external analytics systems or logging.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Model
+
+```bash
+ls -l /etc/models/yolox_quantized.tflite
+```
+
+### 2. View Configuration
+
+```bash
+cat /etc/configs/config-metadata-parser.json
+```
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-metadata-parser-example --config-file=/etc/configs/config-metadata-parser.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+```text
+Running app with model: /etc/models/yolox_quantized.tflite and labels: /etc/labels/yolox.json
+Using DSP delegate
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the detection view while the terminal streams structured detection metadata (JSON format).
+
+## Validation
+
+- YOLOX model (329 ops) running on DSP
+- Pipeline reaches `PLAYING` state
+- Terminal outputs valid metadata structures

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/monodepth.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/monodepth.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 5
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Monocular Depth Estimation
+
+`gst-ai-monodepth` performs monocular depth estimation on each frame of a video stream, generating a depth map rendered as a heatmap overlay. Warm colors (red/orange) indicate closer distances; cool colors (blue) indicate farther distances.
+
+Uses the MiDaS V2 model.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Model and Labels
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/midas_quantized.tflite
+ls -l /etc/labels/monodepth.json
+```
+
+</NewCodeBlock>
+
+### 2. View Configuration
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config_monodepth.json
+```
+
+</NewCodeBlock>
+
+Key fields:
+
+| Field          | Default                              | Description         |
+| -------------- | ------------------------------------ | ------------------- |
+| `file-path`    | `/etc/media/video.mp4`               | Input video path    |
+| `ml-framework` | `tflite`                             | Inference framework |
+| `model`        | `/etc/models/midas_quantized.tflite` | Model file          |
+| `labels`       | `/etc/labels/monodepth.json`         | Color mapping file  |
+| `runtime`      | `dsp`                                | Inference hardware  |
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-monodepth --config-file=/etc/configs/config_monodepth.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+Terminal output:
+
+```text
+Running app with model: /etc/models/midas_quantized.tflite and labels: /etc/labels/monodepth.json
+Using DSP Delegate
+VERBOSE: Replacing 140 out of 140 node(s) with delegate (TfLiteQnnDelegate) node, yielding 1 partitions for the whole graph.
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the test video overlaid with a depth heatmap. Warm colors indicate nearby objects; cool colors indicate distant background.
+
+## Validation
+
+- `Using DSP Delegate`: Inference running on NPU
+- `Replacing 140 out of 140 node(s)`: All 140 operators delegated to DSP
+- Pipeline reaches `PLAYING` state
+- Display correctly shows depth heatmap
+
+## How It Works
+
+MiDaS (Monocular Depth Estimation) takes a single RGB image as input and outputs relative depth values for each pixel. The GStreamer pipeline:
+
+```text
+filesrc → qtdemux → h264parse → v4l2h264dec
+                ↓                        ↓
+           (tee split)         qtimlvconverter (preprocess)
+                                        ↓
+                              qtimltflite (DSP inference)
+                                        ↓
+                              post-process (depth → heatmap)
+                                        ↓
+                                  qtivcomposer
+                                        ↓
+                                   waylandsink
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/multistream-inference.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/multistream-inference.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 12
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-25
+---
+
+# Multistream Inference
+
+`gst-ai-multistream-inference` processes multiple video streams simultaneously, with independent object detection per stream. Suitable for surveillance and multi-channel analytics.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Install ffmpeg and Transcode Video
+
+The default video format has compatibility issues with Q900's GStreamer rendering pipeline. Transcode to baseline H.264:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo apt install -y ffmpeg
+sudo ffmpeg -y -i /etc/media/video.mp4 \
+    -c:v libx264 \
+    -profile:v baseline \
+    -level 3.1 \
+    -pix_fmt yuv420p \
+    -vf scale=640:480 \
+    -r 30 \
+    -g 30 \
+    -keyint_min 30 \
+    -bf 0 \
+    -an \
+    -movflags +faststart \
+    /etc/media/video_safe.mp4
+```
+
+</NewCodeBlock>
+
+Key parameters:
+
+| Parameter              | Purpose                                                         |
+| ---------------------- | --------------------------------------------------------------- |
+| `-profile:v baseline`  | Disable B-frames, avoiding qtdemux dmabuf negotiation conflicts |
+| `-bf 0`                | Turn off B-frames                                               |
+| `-keyint_min 30 -g 30` | 1-second keyframe interval for reliable seeking                 |
+| `-movflags +faststart` | Moves moov atom to front, speeding up decoder init              |
+| `-an`                  | Remove audio to reduce file size                                |
+
+### 2. Create Config File
+
+All streams reference the same transcoded video:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+python3 -c "
+import json
+with open('/etc/configs/config-multistream-inference.json') as f:
+    c = json.load(f)
+c['input-file-path'] = ['/etc/media/video_safe.mp4'] * 16
+json.dump(c, open('/tmp/cfg_multistream.json', 'w'), indent=2)
+print('config written')
+"
+```
+
+</NewCodeBlock>
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-multistream-inference --config-file=/tmp/cfg_multistream.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+```text
+HTP Core Count = 2
+Run app with model: /etc/models/yolox_quantized.tflite and labels: /etc/labels/yolox.json and use case: Detection
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+...
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows multiple detection streams simultaneously.
+
+## Validation
+
+- 329 ops per stream, all delegated to DSP
+- Pipeline reaches `PLAYING` state
+- Q900 supports a maximum of **16 concurrent streams** with this configuration

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/object-detection.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/object-detection.md
@@ -1,0 +1,127 @@
+---
+sidebar_position: 2
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Object Detection
+
+`gst-ai-object-detection` performs object detection on each frame of a video stream, drawing bounding boxes around detected objects with class labels and confidence scores.
+
+Supports YOLOX, YOLOv8, and YOLO-NAS models.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Model and Labels
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/yolox_quantized.tflite
+ls -l /etc/labels/yolox.json
+```
+
+</NewCodeBlock>
+
+### 2. View Configuration
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config_detection.json
+```
+
+</NewCodeBlock>
+
+Key fields:
+
+| Field             | Default                              | Description                                          |
+| ----------------- | ------------------------------------ | ---------------------------------------------------- |
+| `file-path`       | `/etc/media/video.mp4`               | Input video path                                     |
+| `ml-framework`    | `tflite`                             | Inference framework                                  |
+| `yolo-model-type` | `yolox`                              | YOLO type: `yolov5` / `yolov8` / `yolox` / `yolonas` |
+| `model`           | `/etc/models/yolox_quantized.tflite` | Model file                                           |
+| `labels`          | `/etc/labels/yolox.json`             | Label file                                           |
+| `threshold`       | `40`                                 | Confidence threshold (1-100)                         |
+| `runtime`         | `dsp`                                | Inference hardware                                   |
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-object-detection --config-file=/etc/configs/config_detection.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+Terminal output:
+
+```text
+Running app with model: /etc/models/yolox_quantized.tflite and labels: /etc/labels/yolox.json
+Using DSP Delegate
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the test video with colored bounding boxes around detected objects, annotated with class names and confidence scores.
+
+## Validation
+
+- `Using DSP Delegate`: Inference running on NPU
+- `Replacing 329 out of 329 node(s)`: All 329 operators delegated to DSP
+- Pipeline reaches `PLAYING` state
+- Display correctly shows bounding boxes and labels
+
+## Adjusting Detection Sensitivity
+
+If too few objects are detected (missed detections), lower the threshold:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+# Change threshold to 20 in /etc/configs/config_detection.json
+```
+
+</NewCodeBlock>
+
+If there are too many false positives, increase the threshold (e.g., 60).
+
+## Switching YOLO Models
+
+Modify the model type and path in the config file:
+
+```json
+{
+  "yolo-model-type": "yolov8",
+  "model": "/etc/models/yolov8_det_quantized.tflite",
+  "labels": "/etc/labels/yolov8.json"
+}
+```
+
+> YOLOv8 and YOLO-NAS models require separate export via Qualcomm AI Hub.
+
+## Pipeline Flow
+
+```text
+filesrc → qtdemux → h264parse → v4l2h264dec → qtimlvconverter
+                                                       ↓
+                                          qtimltflite (DSP inference)
+                                                       ↓
+                                          qtimlvdetection (YOLO post-process)
+                                                       ↓
+                                                qtivcomposer
+                                                       ↓
+                                                 waylandsink
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/parallel-inference.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/parallel-inference.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 11
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Parallel AI Fusion
+
+`gst-ai-parallel-inference` runs **multiple AI models simultaneously** on a single video stream, with all models inferring in parallel on the NPU and results fused into a single display.
+
+The default configuration runs 4 models concurrently: object detection (YOLOX), classification (InceptionV3), pose detection (HRNet), and segmentation (DeepLabV3+), all executing in parallel on DSP.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Models
+
+```bash
+ls -l /etc/models/{yolox_quantized,inception_v3_quantized,hrnet_pose_quantized,deeplabv3_plus_mobilenet_quantized}.tflite
+```
+
+### 2. View Configuration
+
+```bash
+cat /etc/configs/config-parallel-inference.json
+```
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-parallel-inference --config-file=/etc/configs/config-parallel-inference.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+```text
+VERBOSE: Replacing 329 out of 329 node(s) with delegate (TfLiteQnnDelegate) node
+VERBOSE: Replacing 142 out of 142 node(s) with delegate (TfLiteQnnDelegate) node
+VERBOSE: Replacing 518 out of 518 node(s) with delegate (TfLiteQnnDelegate) node
+VERBOSE: Replacing 136 out of 136 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display simultaneously shows bounding boxes, classification labels, human skeletons, and segmentation masks — all four AI results overlaid on the same frame.
+
+## Validation
+
+- 4 models (329 + 142 + 518 + 136 = 1,125 operators) running in parallel on DSP
+- Pipeline reaches `PLAYING` state
+- Display shows all four inference results simultaneously
+
+This demonstrates that the Q900 HTP V73 NPU supports concurrent multi-model processing.

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/pose-detection.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/pose-detection.md
@@ -1,0 +1,111 @@
+---
+sidebar_position: 3
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Pose Detection
+
+`gst-ai-pose-detection` performs human pose detection on each frame of a video stream, drawing skeleton connections between body keypoints.
+
+Uses the HRNet model.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Required Files
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/hrnet_pose_quantized.tflite
+ls -l /etc/labels/hrnet_pose.json
+ls -l /etc/labels/hrnet_settings.json
+```
+
+</NewCodeBlock>
+
+> `hrnet_settings.json` defines the connections between body joints. Missing this file causes `Invalid pose settings path` error.
+
+### 2. View Configuration
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config_pose.json
+```
+
+</NewCodeBlock>
+
+Key fields:
+
+| Field                | Default                                   | Description             |
+| -------------------- | ----------------------------------------- | ----------------------- |
+| `file-path`          | `/etc/media/video.mp4`                    | Input video path        |
+| `ml-framework`       | `tflite`                                  | Inference framework     |
+| `model`              | `/etc/models/hrnet_pose_quantized.tflite` | Model file              |
+| `labels`             | `/etc/labels/hrnet_pose.json`             | Label file              |
+| `pose-settings-path` | `/etc/labels/hrnet_settings.json`         | Joint connection config |
+| `runtime`            | `dsp`                                     | Inference hardware      |
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-pose-detection --config-file=/etc/configs/config_pose.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+Terminal output:
+
+```text
+Running app with model: /etc/models/hrnet_pose_quantized.tflite and labels: /etc/labels/hrnet_pose.json and settings /etc/labels/hrnet_settings.json
+Using DSP Delegate
+VERBOSE: Replacing 518 out of 518 node(s) with delegate (TfLiteQnnDelegate) node
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the test video with skeleton connections drawn between body keypoints.
+
+## Validation
+
+- `Using DSP Delegate`: Inference running on NPU
+- `Replacing 518 out of 518 node(s)`: All 518 operators delegated to DSP
+- Pipeline reaches `PLAYING` state
+- Display correctly shows human skeleton overlay
+
+## Troubleshooting
+
+### Invalid pose settings path
+
+Verify `hrnet_settings.json` exists under `/etc/labels/`:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/labels/hrnet_settings.json
+```
+
+</NewCodeBlock>
+
+If missing, re-run the download script:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+sudo ./download_artifacts.sh -v GA1.6-rel -c QCS9075
+```
+
+</NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/python-apps.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/python-apps.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 15
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Python GStreamer Apps
+
+QIM SDK provides Python GStreamer binding examples, demonstrating how to build AI/ML and multimedia pipelines using Python.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation)
+
+Python examples are installed via the `gstreamer1.0-qcom-python-examples` package. Related Python dependencies (`python3-gst-1.0`, `python3-numpy`, `python3-opencv`) are installed automatically.
+
+## Available Examples
+
+| Application                               | Description                              |
+| ----------------------------------------- | ---------------------------------------- |
+| Camera Encode                             | Capture from camera and encode to H.264  |
+| OpenCV Camera Stream                      | Read camera stream via OpenCV            |
+| OpenCV Video Convert                      | OpenCV video format conversion           |
+| Concurrent Video Playback (Video Wall)    | Multi-stream simultaneous playback       |
+| Multi-Camera Stream                       | Python-controlled multi-camera           |
+| Object Detection & Display                | Run object detection and display results |
+| RTSP Stream Decode & Detection            | Decode from RTSP and detect              |
+| JPEG Image Decode                         | Decode JPEG images                       |
+| Object Detection & Classification         | Cascaded detection + classification      |
+| Convert & Encode Camera Stream            | Camera stream transcoding                |
+| Camera Encode + Detection + Display       | End-to-end pipeline                      |
+| Detection + Classification + Segmentation | Multi-task AI                            |
+| Parallel Inference                        | Multi-model parallel                     |
+| Daisy-Chain Detection & Pose              | Cascaded detection + pose                |
+
+## Basic Structure
+
+Python GStreamer apps use PyGObject bindings:
+
+```python
+import gi
+gi.require_version('Gst', '1.0')
+from gi.repository import Gst, GLib
+
+Gst.init(None)
+
+# Create pipeline
+pipeline = Gst.parse_launch(
+    "filesrc location=/etc/media/video.mp4 ! "
+    "qtdemux ! h264parse ! v4l2h264dec ! waylandsink"
+)
+
+# Start
+pipeline.set_state(Gst.State.PLAYING)
+
+# Main loop
+loop = GLib.MainLoop()
+loop.run()
+```
+
+## Get Source Code
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+git clone https://github.com/quic/sample-apps-for-qualcomm-linux
+```
+
+</NewCodeBlock>
+
+## Reference
+
+- [Build from Source](./build-from-source.md) — Compile custom C/C++ apps on-device

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/segmentation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/segmentation.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 4
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Image Segmentation
+
+`gst-ai-segmentation` performs semantic segmentation on each frame of a video stream, assigning a class label to each pixel and rendering results as a semi-transparent colored mask.
+
+Uses the DeepLabV3+ MobileNet model.
+
+Unlike [Object Detection](./object-detection.md), detection draws bounding boxes around objects; segmentation classifies and colors every pixel.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Model and Labels
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/deeplabv3_plus_mobilenet_quantized.tflite
+ls -l /etc/labels/deeplabv3_resnet50.json
+```
+
+</NewCodeBlock>
+
+### 2. View Configuration
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config_segmentation.json
+```
+
+</NewCodeBlock>
+
+Key fields:
+
+| Field               | Default                                                 | Description         |
+| ------------------- | ------------------------------------------------------- | ------------------- |
+| `file-path`         | `/etc/media/video.mp4`                                  | Input video path    |
+| `ml-framework`      | `tflite`                                                | Inference framework |
+| `model`             | `/etc/models/deeplabv3_plus_mobilenet_quantized.tflite` | Model file          |
+| `labels`            | `/etc/labels/deeplabv3_resnet50.json`                   | Color mapping file  |
+| `runtime`           | `dsp`                                                   | Inference hardware  |
+| `video-disposition` | `stretch`                                               | Video layout mode   |
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-segmentation --config-file=/etc/configs/config_segmentation.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+Terminal output:
+
+```text
+Running app with model: /etc/models/deeplabv3_plus_mobilenet_quantized.tflite and labels: /etc/labels/deeplabv3_resnet50.json
+Using DSP Delegate
+VERBOSE: Replacing 136 out of 136 node(s) with delegate (TfLiteQnnDelegate) node, yielding 1 partitions for the whole graph.
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the test video overlaid with a semi-transparent colored segmentation mask. Different colors represent different classes (person, car, road, building, etc.).
+
+## Validation
+
+- `Using DSP Delegate`: Inference running on NPU
+- `Replacing 136 out of 136 node(s)`: All 136 operators delegated to DSP
+- Pipeline reaches `PLAYING` state
+- Display correctly shows segmentation mask
+
+## Troubleshooting
+
+### Segmentation mask not displaying
+
+Verify the label file is valid JSON:
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+python3 -c "import json; json.load(open('/etc/labels/deeplabv3_resnet50.json'))" && echo "JSON valid"
+```
+
+</NewCodeBlock>
+
+If the output is `404: Not Found` or other non-JSON content, re-run the download script.

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/superresolution.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/superresolution.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 6
+doc_kind: page
+locale: en
+board: airbox-q900
+task_type: ai-dev
+last_verified: 2026-06-24
+---
+
+# Video Super Resolution
+
+`gst-ai-superresolution` uses an AI model to perform super-resolution reconstruction on low-resolution video, generating high-resolution output frames.
+
+Uses the QuickSRNet Small model (~42 KB), suitable for real-time inference.
+
+## Prerequisites
+
+- Completed [QIM SDK Installation](./README.md#installation) and [Model Download](./README.md#download-models-and-test-resources)
+
+## Steps
+
+### 1. Verify Model
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+ls -l /etc/models/quicksrnetsmall_quantized.tflite
+```
+
+</NewCodeBlock>
+
+> Super resolution does not require a label file.
+
+### 2. View Configuration
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+cat /etc/configs/config-superresolution.json
+```
+
+</NewCodeBlock>
+
+Key fields:
+
+| Field             | Default                | Description      |
+| ----------------- | ---------------------- | ---------------- |
+| `input-file-path` | `/etc/media/video.mp4` | Input video path |
+
+> Note: The super resolution config uses `input-file-path` (not `file-path`).
+
+### 3. Run
+
+<NewCodeBlock tip="radxa@airbox$" type="device">
+
+```bash
+gst-ai-superresolution --config-file=/etc/configs/config-superresolution.json
+```
+
+</NewCodeBlock>
+
+Press `Ctrl + C` to stop.
+
+## Expected Output
+
+Terminal output:
+
+```text
+Running app with model: /etc/models/quicksrnetsmall_quantized.tflite
+VERBOSE: Replacing 10 out of 13 node(s) with delegate (TfLiteQnnDelegate) node, yielding 3 partitions for the whole graph.
+Pipeline state changed from PAUSED to PLAYING
+```
+
+The display shows the super-resolved video output with clearer details compared to the original input.
+
+## Validation
+
+- `Replacing 10 out of 13 node(s)`: 10 operators delegated to DSP, 3 fall back to CPU
+- Pipeline reaches `PLAYING` state
+- Display shows super-resolved video
+
+> Some operators (Reshape, Transpose) are not supported on DSP and automatically fall back to CPU. This does not affect overall functionality.
+
+## How It Works
+
+QuickSRNet is an ultra-lightweight super-resolution network designed for mobile and embedded devices. Pipeline flow:
+
+```text
+filesrc → qtdemux → h264parse → v4l2h264dec
+                                       ↓
+                               qtimlvconverter
+                                       ↓
+                          qtimltflite (DSP + CPU)
+                                       ↓
+                                qtivcomposer
+                                       ↓
+                                 waylandsink
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qnn_onnxrt_execution_provider.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qnn_onnxrt_execution_provider.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 9
 
 doc_kind: wrapper
 source_of_truth: common

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/tflite-delegate-demo.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/tflite-delegate-demo.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 10
 
 doc_kind: wrapper
 source_of_truth: common


### PR DESCRIPTION
## Description of changes

- New qim-sdk/ section (16 pages ZH + EN) covering QAIRT setup, 4-package install, GA1.6 model download, and step-by-step demo instructions
- Fix ai-dev sidebar numbering (qnn_onnxrt 10→9, tflite-delegate 12→10)
- All demos verified on Q900 (QCS9075, Ubuntu 24.04)

## Agent-doc checklist

- [x] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [x] Changed page docs are not empty, include front matter, and have an H1 heading.
- [x] Code fences in changed docs include language labels.
- [x] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [x] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [x] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [x] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
