### PR TITLE
fix: airboox q900 format and deploy timeout

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -187,6 +187,7 @@ jobs:
           fi
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event_name != 'pull_request'
     permissions:
       contents: read

--- a/docs/fogwise/airbox-q900/hardware-design/nvme.md
+++ b/docs/fogwise/airbox-q900/hardware-design/nvme.md
@@ -61,7 +61,7 @@ sudo dd if=source_file/device of=target_file/device bs=block_size count=block_nu
 
 <details>
   <summary>演示示例：NVMe</summary>
-  <p>
+
 - 写入测试
 
 使用 `dd` 命令向 NVMe 设备写入 1G 的数据。
@@ -90,5 +90,4 @@ sudo dd if=/dev/nvme0n1 of=/dev/null bs=1M count=1024
 
 读取完成后，终端会显示读取的字节数、耗时以及传输速率。
 
- </p>
 </details>

--- a/docs/fogwise/airbox-q900/hardware-design/usb-a.md
+++ b/docs/fogwise/airbox-q900/hardware-design/usb-a.md
@@ -33,7 +33,7 @@ lsusb
 
 <details>
   <summary>演示示例：U 盘</summary>
-  <p>
+
 - 未接 U 盘
 
 使用 `lsusb` 命令查看当前系统的 USB 设备信息。
@@ -81,7 +81,6 @@ Bus 005 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
 
 其中 `Bus 002 Device 002: ID 3535:6300 aigo U330` 就是 U 盘的设备信息。
 
-  </p>
 </details>
 
 ### 读写测试
@@ -107,7 +106,6 @@ sudo dd if=source_file/device of=target_file/device bs=block_size count=block_nu
 
 <details>
   <summary>演示示例：U 盘</summary>
-  <p>
 
 提前将 U 盘连接到任意 1 个 USB Type-A 接口。
 
@@ -165,5 +163,4 @@ sudo dd if=/dev/sdi of=/dev/null bs=1M count=1024
 
 读取完成后，终端会显示读取的字节数、耗时以及传输速率。
 
- </p>
 </details>

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/hardware-design/nvme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/hardware-design/nvme.md
@@ -61,7 +61,7 @@ sudo dd if=source_file/device of=target_file/device bs=block_size count=block_nu
 
 <details>
   <summary>Demonstration: NVMe</summary>
-  <p>
+
 - Write Test
 
 Use the `dd` command to write 1GB of data to the NVMe device.
@@ -90,5 +90,4 @@ sudo dd if=/dev/nvme0n1 of=/dev/null bs=1M count=1024
 
 After completion, the terminal will display the number of bytes read, time taken, and transfer rate.
 
- </p>
 </details>

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/hardware-design/usb-a.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/hardware-design/usb-a.md
@@ -33,7 +33,7 @@ lsusb
 
 <details>
   <summary>Example: USB Flash Drive</summary>
-  <p>
+
 - Without USB flash drive connected
 
 Use the `lsusb` command to view the current system's USB device information.
@@ -81,7 +81,6 @@ Bus 005 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
 
 The line `Bus 002 Device 002: ID 3535:6300 aigo U330` shows the connected USB flash drive's device information.
 
-  </p>
 </details>
 
 ### Read/Write Testing
@@ -107,7 +106,6 @@ sudo dd if=source_file/device of=target_file/device bs=block_size count=block_nu
 
 <details>
   <summary>Example: USB Flash Drive</summary>
-  <p>
 
 First, connect a USB flash drive to any USB Type-A port.
 
@@ -165,5 +163,4 @@ sudo dd if=/dev/sdi of=/dev/null bs=1M count=1024
 
 After completion, the terminal will display the number of bytes read, time taken, and transfer rate.
 
- </p>
 </details>


### PR DESCRIPTION
## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
