### PR TITLE
revert: rollback today's build changes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -187,7 +187,6 @@ jobs:
           fi
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     if: github.event_name != 'pull_request'
     permissions:
       contents: read

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -216,31 +216,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
       - name: Build
-        shell: bash
-        env:
-          DOCUSAURUS_IGNORE_SSG_WARNINGS: true
         run: |
-          set -euo pipefail
           export NODE_OPTIONS="--max-old-space-size=8192"
-
-          (
-            while true
-            do
-              sleep 60
-              echo "[heartbeat] Still building at $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-            done
-          ) &
-          heartbeat_pid="$!"
-
-          set +e
           yarn build
-          status="$?"
-          set -e
-
-          kill "${heartbeat_pid}" 2>/dev/null || true
-          wait "${heartbeat_pid}" 2>/dev/null || true
-
-          exit "${status}"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
         stage: ["commit", "push"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Agent doc lint (changed files)
@@ -131,7 +131,7 @@ jobs:
         stage: ["manual"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: pre-commit check-external-links
@@ -192,12 +192,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout template
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           token: "${{ secrets.PRIVATE_REPO_TOKEN }}"
           repository: "radxa-docs/docs-template"
       - name: Checkout contents
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           path: "contents"
       - name: Install dependencies

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -219,11 +219,9 @@ jobs:
         shell: bash
         env:
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
-          DOCUSAURUS_PERF_LOGGER: true
-          DOCUSAURUS_SSG_WORKER_THREAD_COUNT: 1
         run: |
           set -euo pipefail
-          export NODE_OPTIONS="--max-old-space-size=6144"
+          export NODE_OPTIONS="--max-old-space-size=8192"
 
           (
             while true

--- a/docs/fogwise/airbox-q900/hardware-design/nvme.md
+++ b/docs/fogwise/airbox-q900/hardware-design/nvme.md
@@ -61,7 +61,7 @@ sudo dd if=source_file/device of=target_file/device bs=block_size count=block_nu
 
 <details>
   <summary>演示示例：NVMe</summary>
-
+  <p>
 - 写入测试
 
 使用 `dd` 命令向 NVMe 设备写入 1G 的数据。
@@ -90,4 +90,5 @@ sudo dd if=/dev/nvme0n1 of=/dev/null bs=1M count=1024
 
 读取完成后，终端会显示读取的字节数、耗时以及传输速率。
 
+ </p>
 </details>

--- a/docs/fogwise/airbox-q900/hardware-design/usb-a.md
+++ b/docs/fogwise/airbox-q900/hardware-design/usb-a.md
@@ -33,7 +33,7 @@ lsusb
 
 <details>
   <summary>演示示例：U 盘</summary>
-
+  <p>
 - 未接 U 盘
 
 使用 `lsusb` 命令查看当前系统的 USB 设备信息。
@@ -81,6 +81,7 @@ Bus 005 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
 
 其中 `Bus 002 Device 002: ID 3535:6300 aigo U330` 就是 U 盘的设备信息。
 
+  </p>
 </details>
 
 ### 读写测试
@@ -106,6 +107,7 @@ sudo dd if=source_file/device of=target_file/device bs=block_size count=block_nu
 
 <details>
   <summary>演示示例：U 盘</summary>
+  <p>
 
 提前将 U 盘连接到任意 1 个 USB Type-A 接口。
 
@@ -163,4 +165,5 @@ sudo dd if=/dev/sdi of=/dev/null bs=1M count=1024
 
 读取完成后，终端会显示读取的字节数、耗时以及传输速率。
 
+ </p>
 </details>

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/hardware-design/nvme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/hardware-design/nvme.md
@@ -61,7 +61,7 @@ sudo dd if=source_file/device of=target_file/device bs=block_size count=block_nu
 
 <details>
   <summary>Demonstration: NVMe</summary>
-
+  <p>
 - Write Test
 
 Use the `dd` command to write 1GB of data to the NVMe device.
@@ -90,4 +90,5 @@ sudo dd if=/dev/nvme0n1 of=/dev/null bs=1M count=1024
 
 After completion, the terminal will display the number of bytes read, time taken, and transfer rate.
 
+ </p>
 </details>

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/hardware-design/usb-a.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/hardware-design/usb-a.md
@@ -33,7 +33,7 @@ lsusb
 
 <details>
   <summary>Example: USB Flash Drive</summary>
-
+  <p>
 - Without USB flash drive connected
 
 Use the `lsusb` command to view the current system's USB device information.
@@ -81,6 +81,7 @@ Bus 005 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
 
 The line `Bus 002 Device 002: ID 3535:6300 aigo U330` shows the connected USB flash drive's device information.
 
+  </p>
 </details>
 
 ### Read/Write Testing
@@ -106,6 +107,7 @@ sudo dd if=source_file/device of=target_file/device bs=block_size count=block_nu
 
 <details>
   <summary>Example: USB Flash Drive</summary>
+  <p>
 
 First, connect a USB flash drive to any USB Type-A port.
 
@@ -163,4 +165,5 @@ sudo dd if=/dev/sdi of=/dev/null bs=1M count=1024
 
 After completion, the terminal will display the number of bytes read, time taken, and transfer rate.
 
+ </p>
 </details>


### PR DESCRIPTION
## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
