### PR TITLE
fix: deploy ram to 12gb

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -216,7 +216,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
       - name: Build
         run: |
-          export NODE_OPTIONS="--max-old-space-size=8192"
+          export NODE_OPTIONS="--max-old-space-size=12288"
           yarn build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
