### PR TITLE
fix(rock5/rock5t): repair broken ./3d-case link in accessories README (#1880)

### DIFF
--- a/docs/rock5/rock5t/accessories/README.md
+++ b/docs/rock5/rock5t/accessories/README.md
@@ -24,4 +24,4 @@ sidebar_position: 99
 
 ## 3D 打印外壳
 
-- [第三方 3D 打印外壳](./3d-case)：社区设计的 ROCK 5T 专用外壳
+- [第三方 3D 打印外壳](/rock5/rock5t/accessories/3d-case)：社区设计的 ROCK 5T 专用外壳

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/accessories/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/accessories/README.md
@@ -24,4 +24,4 @@ This page lists the official accessories compatible with ROCK 5T.
 
 ## 3D-Printed Cases
 
-- [Third-Party 3D-Printed Cases](./3d-case): Community-designed cases for ROCK 5T
+- [Third-Party 3D-Printed Cases](/rock5/rock5t/accessories/3d-case): Community-designed cases for ROCK 5T


### PR DESCRIPTION
## Summary

Fixes the broken "Third-Party 3D-Printed Cases" link on `/rock5/rock5t/accessories` reported in #1880.

## Root cause

In `docs/rock5/rock5t/accessories/README.md` (the category index page), Docusaurus resolves the relative autolink `[./3d-case]` to `/rock5/rock5t/3d-case` (the parent section URL) instead of `/rock5/rock5t/accessories/3d-case` (the actual docs route). The target file `3d-case.md` lives in the same `accessories/` subdirectory, but Docusaurus drops the `accessories/` segment when autolinking from a category README.

The user sees a 404 when clicking the link on https://docs.radxa.com/rock5/rock5t/accessories.

## Fix

Replace the relative autolink `[./3d-case]` with the absolute path `[/rock5/rock5t/accessories/3d-case]` in both Chinese and English versions, so the link is unambiguous regardless of Docusaurus autolink resolution rules.

| File | Before | After |
| --- | --- | --- |
| `docs/rock5/rock5t/accessories/README.md` | `[./3d-case]` | `[/rock5/rock5t/accessories/3d-case]` |
| `i18n/en/.../rock5/rock5t/accessories/README.md` | `[./3d-case]` | `[/rock5/rock5t/accessories/3d-case]` |

## Scope

This PR is intentionally limited to **rock5t only** (the product named in #1880). The same broken autolink pattern also affects `rock5/rock5b`, `rock4/rock4d`, and `cubie/a7a`, but those are out of scope here — they are covered separately under PR #41 (broader scope batch fix).

## Stats

- 1 commit
- 2 files (1 zh + 1 en)
- +2 / -2 lines
- Bilingual sync OK
- Fixes #1880

## Source

Triggered by user request from internal support group (售后技术支持).
