### PR TITLE
docs(fogwise/airbox-q900): update Qualcomm Linux Yocto link and drop Build Guide section

### DIFF
--- a/docs/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/docs/fogwise/airbox-q900/other-os/qualcomm.md
@@ -8,13 +8,9 @@ sidebar_position: 1
 
 请参考 [瑞莎 AIRbox Q900 Yocto 编译指南](https://github.com/radxa/meta-radxa-dragon/blob/scarthgap_qcom-6.6.116-QLI.1.7-Ver.1.1/README.md)
 
-## 高通 Linux 编译指南
-
-请参考 [高通 Linux 编译指南](https://docs.qualcomm.com/bundle/publicresource/topics/80-70020-254Y/build_from_source_qsc_gui_intro.html#build-from-source-qsc-gui-intro)
-
 ## 高通 Linux Yocto 指南
 
-请参考 [高通 Linux Yocto 指南](https://docs.qualcomm.com/bundle/publicresource/topics/80-70020-27/yocto_landing_page.html)
+请参考 [高通 Linux Yocto 指南](https://dragonwingdocs.qualcomm.com/qualcomm-linux-qli)
 
 ## 高通 Real-Time Subsystem 指南
 

--- a/docs/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/docs/fogwise/airbox-q900/other-os/qualcomm.md
@@ -14,4 +14,4 @@ sidebar_position: 1
 
 ## 高通 Real-Time Subsystem 指南
 
-请参考 [高通 Real-Time Subsystem 指南](https://docs.qualcomm.com/doc/80-70029-42/topic/rtss-guide.html)
+请参考 [高通 Real-Time Subsystem 指南](https://dragonwingdocs.qualcomm.com/System/Boot/rtss-addendum-overview)

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
@@ -14,4 +14,4 @@ Please refer to [Qualcomm Linux Yocto Guide](https://dragonwingdocs.qualcomm.com
 
 ## Qualcomm Real-Time Subsystem Guide
 
-Please refer to [Qualcomm Real-Time Subsystem Guide](https://docs.qualcomm.com/doc/80-70029-42/topic/rtss-guide.html)
+Please refer to [Qualcomm Real-Time Subsystem Guide](https://dragonwingdocs.qualcomm.com/System/Boot/rtss-addendum-overview)

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
@@ -8,13 +8,9 @@ sidebar_position: 1
 
 Please refer to [Radxa AIRbox Q900 Yocto Build Guide](https://github.com/radxa/meta-radxa-dragon/blob/scarthgap_qcom-6.6.116-QLI.1.7-Ver.1.1/README.md)
 
-## Qualcomm Linux Build Guide
-
-Please refer to [Qualcomm Linux Build Guide](https://docs.qualcomm.com/bundle/publicresource/topics/80-70020-254Y/build_from_source_qsc_gui_intro.html#build-from-source-qsc-gui-intro)
-
 ## Qualcomm Linux Yocto Guide
 
-Please refer to [Qualcomm Linux Yocto Guide](https://docs.qualcomm.com/bundle/publicresource/topics/80-70020-27/yocto_landing_page.html)
+Please refer to [Qualcomm Linux Yocto Guide](https://dragonwingdocs.qualcomm.com/qualcomm-linux-qli)
 
 ## Qualcomm Real-Time Subsystem Guide
 


### PR DESCRIPTION
## Summary

Update the AIRbox Q900 Qualcomm Linux guide page (Chinese source + English
translation) to:

1. Replace the obsolete Qualcomm docs Yocto landing page link
   (`https://docs.qualcomm.com/bundle/publicresource/topics/80-70020-27/yocto_landing_page.html`)
   with the new URL
   `https://dragonwingdocs.qualcomm.com/qualcomm-linux-qli`.
2. Remove the entire "Qualcomm Linux Build Guide" / "高通 Linux 编译指南"
   section, which pointed at a build-from-source page that is no longer
   surfaced alongside the Yocto and Real-Time Subsystem guides.

Both the Chinese source at `docs/fogwise/airbox-q900/other-os/qualcomm.md`
and the English translation at
`i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md`
are updated in the same commit so the two languages stay in sync.

## Context

The Qualcomm Linux documentation hub has moved from the
`docs.qualcomm.com` Yocto landing page to the new
`dragonwingdocs.qualcomm.com` site. The previous Yocto link in this page
no longer points at the right resource, and the previously referenced
"Build Guide" section is being retired. The Radxa-specific "AIRbox Q900
Yocto Build Guide" and "Real-Time Subsystem Guide" sections are kept
unchanged.

## Files changed

- `docs/fogwise/airbox-q900/other-os/qualcomm.md`
- `i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md`

## Risk

Low. Only two link/paragraph edits in a single navigation/index page.
No other pages reference the removed "Qualcomm Linux Build Guide"
section.
