### PR TITLE
docs(dx-m1): add dx_rt_windows clone step in Windows driver install

### DIFF
--- a/docs/aicore/dx-m1/windows/README.md
+++ b/docs/aicore/dx-m1/windows/README.md
@@ -22,7 +22,14 @@ last_verified: 2026-06-30
 
 智核 DX-M1 / DX-M1M 在 Windows 上通过 PCIe 接口通信，需安装配套驱动。
 
-1. 解压 `dx_rt_windows` 软件包，进入 `m1/v3.2.0/dxm1drv/` 目录
+首先克隆 `dx_rt_windows` 仓库，后续步骤中的相对路径（如 `m1\v3.2.0\...`）均基于该仓库根目录：
+
+```bash
+git clone https://github.com/DEEPX-AI/dx_rt_windows.git
+cd dx_rt_windows
+```
+
+1. 进入 `m1/v3.2.0/dxm1drv/` 目录
 2. 解压 `dxm1drv.zip`，得到 `dxm1drv.inf`、`dxm1drv.sys`、`dxm1drv.cat`
 3. 右键点击 `dxm1drv.inf`，选择 **安装**
 4. 安装完成后，打开设备管理器，在 **处理加速器 (Processing accelerators)** 下应能看到 **DEEPX DEVICE - M1 PCI CONTROLLER**

--- a/i18n/en/docusaurus-plugin-content-docs/current/aicore/dx-m1/windows/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/aicore/dx-m1/windows/README.md
@@ -22,7 +22,14 @@ The DX-M1 / DX-M1M AI accelerator supports Windows 10 / 11 x64. This guide cover
 
 The DX-M1 / DX-M1M communicates over PCIe on Windows and requires a companion driver.
 
-1. Extract the `dx_rt_windows` package and navigate to `m1/v3.2.0/dxm1drv/`
+First, clone the `dx_rt_windows` repository. All relative paths in the following steps (such as `m1\v3.2.0\...`) are relative to the root of this repository:
+
+```bash
+git clone https://github.com/DEEPX-AI/dx_rt_windows.git
+cd dx_rt_windows
+```
+
+1. Navigate to `m1/v3.2.0/dxm1drv/`
 2. Extract `dxm1drv.zip` to obtain `dxm1drv.inf`, `dxm1drv.sys`, and `dxm1drv.cat`
 3. Right-click `dxm1drv.inf` and select **Install**
 4. After installation, open Device Manager. Under **Processing accelerators**, you should see **DEEPX DEVICE - M1 PCI CONTROLLER**


### PR DESCRIPTION
## Summary

- 在 `docs/aicore/dx-m1/windows/README.md` "驱动安装" 章节开头加入 `dx_rt_windows` 仓库克隆步骤，让后续 `cd m1\v3.2.0\...` 等相对路径有明确起点。
- 同步更新英文版 `i18n/en/docusaurus-plugin-content-docs/current/aicore/dx-m1/windows/README.md` 同一章节。
- 起源：内部协同群里 邓洛宁 指出 Windows 文档漏掉了克隆仓库这一步，初始步骤依赖一个不存在的 "解压"前提；补上 clone 步骤后，第 1 步的相对路径才真正可用。
- 风险评估：docs-only 修改，未触碰 `products/` / `datasheets/` / `blog/`，只动 driver install 章节里的一段说明 + 一步编号，范围小、可独立回滚。

## Test plan

- [x] `python3 scripts/agent-doc-lint.sh <两个文件>` 通过
- [x] `python3 scripts/agent-doc-translation-guard.sh <两个文件>` 通过
- [x] `python3 scripts/github_pr_guard.py check --repo-path . --fetch` 通过（1 commit / 2 files / 1 scope, no reasons）
- [ ] 等 review 后合入
