### PR TITLE
fix: airbox q900 en docs code format

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/multi-input-output.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/ai-dev/qim-sdk/multi-input-output.md
@@ -89,6 +89,8 @@ print('config written')
 "
 ```
 
+</NewCodeBlock>
+
 ### 4. Run
 
 <NewCodeBlock tip="radxa@airbox$" type="device">


### PR DESCRIPTION
## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
