### PR TITLE
docs(kernel): add FAQ for incremental compilation in common radxa-os kernel tutorial

### DIFF
--- a/docs/common/radxa-os/build-system/_kernel.mdx
+++ b/docs/common/radxa-os/build-system/_kernel.mdx
@@ -55,3 +55,15 @@ make deb
 ```
 
 </NewCodeBlock>
+
+## 常见问题 (FAQ)
+
+### 如何使用增量编译模式？
+
+为了加速验证改动的代码，不做全量编译，只进行增量编译，可以在 Makefile 文件的 debuild 指令增加 `-nc` 参数。
+
+```
+$(CUSTOM_DEBUILD_ENV) debuild --no-lintian --lintian-hook "lintian --fail-on error,warning --suppress-tags-from-file $(PWD)/debian/common-lintian-overrides -- %p_%v_*.changes" --no-sign -b $(CUSTOM_DEBUILD_ARG) -nc
+```
+
+修改并保存文件后，重新运行 `make deb` 编译。

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_kernel.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_kernel.mdx
@@ -54,3 +54,15 @@ make deb
 ```
 
 </NewCodeBlock>
+
+## FAQ
+
+### How to use incremental compilation mode?
+
+To speed up validating code changes without doing a full build, you can enable incremental compilation by adding the `-nc` flag to the `debuild` command in the Makefile.
+
+```
+$(CUSTOM_DEBUILD_ENV) debuild --no-lintian --lintian-hook "lintian --fail-on error,warning --suppress-tags-from-file $(PWD)/debian/common-lintian-overrides -- %p_%v_*.changes" --no-sign -b $(CUSTOM_DEBUILD_ARG) -nc
+```
+
+After modifying and saving the file, re-run `make deb` to start the build.


### PR DESCRIPTION
## Summary

Move the FAQ section for incremental kernel compilation into the common `radxa-os` kernel build tutorial, instead of being q6a-only.

This makes the FAQ available to **all products that import the common tutorial**:
- Cubie A5E / A7A / A7S / A7Z
- Dragon Q6A / Q8B
- Fogwise AIRBox Q900
- Orion O6 / O6N

The `-nc` flag and the `debuild` Makefile snippet are generic to the radxa-pkg kernel build system, so it makes sense to keep this in the shared template rather than duplicating it per-product.

## Changed files

- `docs/common/radxa-os/build-system/_kernel.mdx` (中文)
- `i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_kernel.mdx` (English)

## Verification

- `python3 ../scripts/github_pr_guard.py check --repo-path . --fetch` → `ok: true`
- `python3 ../scripts/github_pr_guard.py pr 1904 --repo radxa-docs/docs` → `ok: true`
- Bilingual check passed (`missing_en: []`, `missing_zh: []`)
- Scope: `docs/common/radxa-os` (single scope, 2 files)

## Source

Internal support team request in Feishu 售后技术支持群 (topic `omt_192385cf9d8e5c9c`), 2026-07-02.
