### PR TITLE
docs(aicore/ax-m1): align env_install with new axclhost packages

### DIFF
--- a/docs/aicore/ax-m1/getting-started/env_install.md
+++ b/docs/aicore/ax-m1/getting-started/env_install.md
@@ -43,7 +43,10 @@ sudo apt install gcc linux-headers-$(uname -r) make
 <NewCodeBlock tip="Host" type="device">
 
 ```bash
-sudo dpkg -i ./axcl_host_aarch64_V3.6.5_20250908154509_NO4973.deb
+sudo dpkg -i axclhost-firmware_3.6.5-1_all.deb
+sudo dpkg -i task-axclhost_3.6.5-1_all.deb
+sudo dpkg -i axclhost-dkms_3.6.5-1_all.deb
+sudo systemctl restart systemd-modules-load
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/aicore/ax-m1/getting-started/env_install.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/aicore/ax-m1/getting-started/env_install.md
@@ -43,7 +43,10 @@ Download the driver package from the resources section on the left panel.
 <NewCodeBlock tip="Host" type="device">
 
 ```bash
-sudo dpkg -i ./axcl_host_aarch64_V3.6.5_20250908154509_NO4973.deb
+sudo dpkg -i axclhost-firmware_3.6.5-1_all.deb
+sudo dpkg -i task-axclhost_3.6.5-1_all.deb
+sudo dpkg -i axclhost-dkms_3.6.5-1_all.deb
+sudo systemctl restart systemd-modules-load
 ```
 
 </NewCodeBlock>


### PR DESCRIPTION
## Summary

把 `docs/aicore/ax-m1/getting-started/env_install` 里安装 AXCL 驱动这一步从单一的 `axcl_host_aarch64_V3.6.5_20250908154509_NO4973.deb` 改为三个新的 deb 包，并补上 `systemd-modules-load` 重启，与 `spi-flash.md` 里的安装流程保持一致。

- `axclhost-firmware_3.6.5-1_all.deb`
- `task-axclhost_3.6.5-1_all.deb`
- `axclhost-dkms_3.6.5-1_all.deb`

## Why

原先教程里的 `axcl_host_aarch64_V3.6.5...deb` 与 `spi-flash.md` 已采用的 `axclhost-firmware / task-axclhost / axclhost-dkms` 三包方式不一致，新用户按 `env_install` 走完后仍会缺少对应的 systemd 模块加载步骤。统一成同一套安装流程可以减少入门阶段的踩坑。

## Changes

- 中文：`docs/aicore/ax-m1/getting-started/env_install.md`
- 英文：`i18n/en/docusaurus-plugin-content-docs/current/aicore/ax-m1/getting-started/env_install.md`

两个版本同步更新，替换单包安装命令，并补上 `sudo systemctl restart systemd-modules-load`。

## Reference

- https://docs.radxa.com/aicore/ax-m1/getting-started/spi-flash（安装软件章节）
- https://docs.radxa.com/aicore/ax-m1/getting-started/env_install（本次修改）
