### PR TITLE
docs(fogwise/airbox-q900): re-point Yocto Build Guide to meta-qcom-qli-2.0 branch

### DIFF
--- a/docs/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/docs/fogwise/airbox-q900/other-os/qualcomm.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## 瑞莎 AIRbox Q900 Yocto 编译指南
 
-请参考 [瑞莎 AIRbox Q900 Yocto 编译指南](https://github.com/radxa/meta-radxa-dragon/blob/scarthgap_qcom-6.6.116-QLI.1.7-Ver.1.1/README.md)
+请参考 [瑞莎 AIRbox Q900 Yocto 编译指南](https://github.com/radxa/meta-radxa-dragon/blob/meta-qcom-qli-2.0/README-Radxa-AIRbox-Q900.md)
 
 ## 高通 Linux Yocto 指南
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## Radxa AIRbox Q900 Yocto Build Guide
 
-Please refer to [Radxa AIRbox Q900 Yocto Build Guide](https://github.com/radxa/meta-radxa-dragon/blob/scarthgap_qcom-6.6.116-QLI.1.7-Ver.1.1/README.md)
+Please refer to [Radxa AIRbox Q900 Yocto Build Guide](https://github.com/radxa/meta-radxa-dragon/blob/meta-qcom-qli-2.0/README-Radxa-AIRbox-Q900.md)
 
 ## Qualcomm Linux Yocto Guide
 


### PR DESCRIPTION
## Summary

Update the AIRbox Q900 Qualcomm Linux guide page (Chinese source + English
translation) to re-point the Radxa-specific "AIRbox Q900 Yocto Build Guide"
link from the obsolete `scarthgap_qcom-6.6.116-QLI.1.7-Ver.1.1` branch to
the current `meta-qcom-qli-2.0` branch, where the README has been renamed
to `README-Radxa-AIRbox-Q900.md`.

## Change

- Old link:
  `https://github.com/radxa/meta-radxa-dragon/blob/scarthgap_qcom-6.6.116-QLI.1.7-Ver.1.1/README.md`
- New link:
  `https://github.com/radxa/meta-radxa-dragon/blob/meta-qcom-qli-2.0/README-Radxa-AIRbox-Q900.md`

## Context

PR #1900 (`docs/airbox-q900-qualcomm-link-and-section-20260702`,
merged 2026-07-02) intentionally kept the Radxa-specific Yocto Build
Guide and Real-Time Subsystem sections unchanged — it only refreshed
the upstream Qualcomm docs (Yocto landing page + Real-Time Subsystem
guide) and dropped the retired "Build from source" section.

This PR closes that follow-up gap by re-pointing the AIRbox Q900 Yocto
Build Guide to the actively maintained branch, so the docs no longer
link to a frozen QLI 1.7 / Ver. 1.1 README.

## Files changed

- `docs/fogwise/airbox-q900/other-os/qualcomm.md` (Chinese source)
- `i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md` (English translation)

Both files updated in the same commit so the two languages stay in sync.

## Risk

Low. One link swap on a single index page, in both languages. The
section title ("瑞莎 AIRbox Q900 Yocto 编译指南" / "Radxa AIRbox Q900
Yocto Build Guide") and surrounding sections (Qualcomm Linux Yocto
Guide, Real-Time Subsystem Guide) are unchanged.

## Follow-up

None required. No other page in `docs/` references the old
`scarthgap_qcom-6.6.116-QLI.1.7-Ver.1.1/README.md` URL.