### PR TITLE
docs(common): add FAQ for modifying locally built Debian package version

### DIFF
--- a/docs/common/radxa-os/build-system/_kernel.mdx
+++ b/docs/common/radxa-os/build-system/_kernel.mdx
@@ -67,3 +67,31 @@ $(CUSTOM_DEBUILD_ENV) debuild --no-lintian --lintian-hook "lintian --fail-on err
 ```
 
 修改并保存文件后，重新运行 `make deb` 编译。
+
+### 如何修改本地构建出的 Debian 包的版本？
+
+以 [linux-qcom 仓库](https://github.com/radxa-pkg/linux-qcom) 为例，打开 `debian/changelog` 文件，修改第一行括号里的版本号。
+
+例如：原来文件内容是：
+
+```text
+linux-qcom (7.0.11-2) unstable; urgency=medium
+```
+
+把括号里的 `7.0.11-2` 改成你想要的版本号，比如：
+
+```text
+linux-qcom (7.0.11-99) unstable; urgency=medium
+```
+
+然后执行：
+
+<NewCodeBlock tip="PC@host$" type="host">
+
+```bash
+make deb
+```
+
+</NewCodeBlock>
+
+构建出来的 Debian 包版本就是 `7.0.11-99`。

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_kernel.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/build-system/_kernel.mdx
@@ -66,3 +66,31 @@ $(CUSTOM_DEBUILD_ENV) debuild --no-lintian --lintian-hook "lintian --fail-on err
 ```
 
 After modifying and saving the file, re-run `make deb` to start the build.
+
+### How to modify the version of a locally built Debian package?
+
+Take the [linux-qcom repository](https://github.com/radxa-pkg/linux-qcom) as an example. Open the `debian/changelog` file and modify the version number inside the parentheses on the first line.
+
+For example, the original file content is:
+
+```text
+linux-qcom (7.0.11-2) unstable; urgency=medium
+```
+
+Change the `7.0.11-2` inside the parentheses to the version number you want, for example:
+
+```text
+linux-qcom (7.0.11-99) unstable; urgency=medium
+```
+
+Then run:
+
+<NewCodeBlock tip="PC@host$" type="host">
+
+```bash
+make deb
+```
+
+</NewCodeBlock>
+
+The resulting Debian package version will be `7.0.11-99`.


### PR DESCRIPTION
## 背景

Dragon Q6A 客户在本地编译 Kernel Debian 包时，常常希望把版本号改高，避免与官方发布包混淆（也方便在 OTA/批量升级场景里区分自己编译的版本）。

当前 `docs/dragon/q6a/low-level-dev/build-system/kernel` 公共模版 FAQ 里只覆盖了「如何使用增量编译模式」，没有覆盖「如何改版本号」。这次在公共模版（`common/radxa-os/build-system/_kernel.mdx`）FAQ 末尾追加一条 FAQ，复用 `linux-qcom` 作为示例仓库，与 Q6A 默认仓库一致。

## 改动

在 `common/radxa-os/build-system/_kernel.mdx`（中文 + 英文）的 FAQ 末尾追加：

### 如何修改本地构建出的 Debian 包的版本？

以 [linux-qcom 仓库](https://github.com/radxa-pkg/linux-qcom) 为例，打开 `debian/changelog` 文件，修改第一行括号里的版本号。例如：

```text
linux-qcom (7.0.11-2) unstable; urgency=medium
```

把括号里的 `7.0.11-2` 改成你想要的版本号，比如 `7.0.11-99`，再执行 `make deb`，最终产出的 Debian 包版本就是 `7.0.11-99`。

## 影响范围

- 文档：仅 FAQ 新增
- 公共模版：`common/radxa-os/build-system/_kernel.mdx`（同时影响所有 import 该模版的页面）
- 产品范围：Dragon Q6A（`docs/dragon/q6a/low-level-dev/build-system/kernel`），以及未来使用同一模版的其他产品
- 中英文同步：已同步更新

## 检查

- `scripts/github_pr_guard.py check` → `ok=true`
- `agent-doc-translation-guard` → passed
- `agent-doc-drift-guard --warn-only` → passed

## 备注

仓库既有的「`debuild` 命令片段」是 unlabeled code fence 风格，本次 FAQ 为保持同一风格也使用裸 `text` fence；如后续希望统一改用 `<NewCodeBlock>`，建议另开一个 cleanup PR 处理。
