### PR TITLE
docs(orion/o6): point cix-sdk tutorial to official CIX wiki

### DIFF
--- a/docs/orion/o6/low-level-dev/cix-sdk/README.md
+++ b/docs/orion/o6/low-level-dev/cix-sdk/README.md
@@ -3,4 +3,11 @@ sidebar_position: 10
 title: 此芯 SDK
 ---
 
+:::info
+此芯 SDK 的系统编译流程已迁移到此芯官方文档维护，本页不再维护具体步骤。请参考：
+
+- 中文：[https://github.com/cixtech/cix-manifest/wiki/guide_zh](https://github.com/cixtech/cix-manifest/wiki/guide_zh)
+- English: [https://github.com/cixtech/cix-manifest/wiki](https://github.com/cixtech/cix-manifest/wiki)
+:::
+
 <DocCardList />

--- a/docs/orion/o6/low-level-dev/cix-sdk/build.md
+++ b/docs/orion/o6/low-level-dev/cix-sdk/build.md
@@ -1,12 +1,11 @@
 ---
 title: 软件编译
-
-doc_kind: wrapper
-source_of_truth: common
-imports_resolve_to:
-  - docs/common/orion-common/low-level-dev/cix-sdk/_build.mdx
+sidebar_position: 1
+doc_kind: page
 ---
 
-import CIX_SDK_Build from '../../../../common/orion-common/low-level-dev/cix-sdk/\_build.mdx';
+:::info
+此芯 SDK 的系统编译流程已迁移到此芯官方文档维护。请参考：
 
-<CIX_SDK_Build />
+[https://github.com/cixtech/cix-manifest/wiki/guide_zh](https://github.com/cixtech/cix-manifest/wiki/guide_zh)
+:::

--- a/docs/orion/o6/low-level-dev/cix-sdk/get-source.md
+++ b/docs/orion/o6/low-level-dev/cix-sdk/get-source.md
@@ -1,13 +1,11 @@
 ---
 title: 获取源代码
 sidebar_position: 0
-
-doc_kind: wrapper
-source_of_truth: common
-imports_resolve_to:
-  - docs/common/orion-common/low-level-dev/cix-sdk/_get-source.mdx
+doc_kind: page
 ---
 
-import CIX_SDK_GetSource from '../../../../common/orion-common/low-level-dev/cix-sdk/\_get-source.mdx';
+:::info
+此芯 SDK 的代码获取与环境准备流程已迁移到此芯官方文档维护。请参考：
 
-<CIX_SDK_GetSource />
+[https://github.com/cixtech/cix-manifest/wiki/guide_zh](https://github.com/cixtech/cix-manifest/wiki/guide_zh)
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/low-level-dev/cix-sdk/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/low-level-dev/cix-sdk/README.md
@@ -3,4 +3,11 @@ sidebar_position: 10
 title: CIX SDK
 ---
 
+:::info
+The CIX SDK system compilation flow is now maintained in the official CIX documentation. This page is no longer maintained with detailed steps. Please refer to:
+
+- English: [https://github.com/cixtech/cix-manifest/wiki](https://github.com/cixtech/cix-manifest/wiki)
+- 中文：[https://github.com/cixtech/cix-manifest/wiki/guide_zh](https://github.com/cixtech/cix-manifest/wiki/guide_zh)
+:::
+
 <DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/low-level-dev/cix-sdk/build.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/low-level-dev/cix-sdk/build.md
@@ -1,12 +1,11 @@
 ---
 title: Software Compilation
-
-doc_kind: wrapper
-source_of_truth: common
-imports_resolve_to:
-  - i18n/en/docusaurus-plugin-content-docs/current/common/orion-common/low-level-dev/cix-sdk/_build.mdx
+sidebar_position: 1
+doc_kind: page
 ---
 
-import CIX_SDK_Build from '../../../../common/orion-common/low-level-dev/cix-sdk/\_build.mdx';
+:::info
+The CIX SDK system compilation flow is now maintained in the official CIX documentation. Please refer to:
 
-<CIX_SDK_Build />
+[https://github.com/cixtech/cix-manifest/wiki](https://github.com/cixtech/cix-manifest/wiki)
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/low-level-dev/cix-sdk/get-source.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/o6/low-level-dev/cix-sdk/get-source.md
@@ -1,13 +1,11 @@
 ---
 title: Source Code Acquisition
 sidebar_position: 0
-
-doc_kind: wrapper
-source_of_truth: common
-imports_resolve_to:
-  - i18n/en/docusaurus-plugin-content-docs/current/common/orion-common/low-level-dev/cix-sdk/_get-source.mdx
+doc_kind: page
 ---
 
-import CIX_SDK_GetSource from '../../../../common/orion-common/low-level-dev/cix-sdk/\_get-source.mdx';
+:::info
+The CIX SDK source acquisition and environment setup flow is now maintained in the official CIX documentation. Please refer to:
 
-<CIX_SDK_GetSource />
+[https://github.com/cixtech/cix-manifest/wiki](https://github.com/cixtech/cix-manifest/wiki)
+:::


### PR DESCRIPTION
## Summary

Replace the locally-maintained CIX SDK build / source-acquisition tutorials under `orion/o6` with a pointer to the official CIX documentation, since the build flow is now maintained upstream at https://github.com/cixtech/cix-manifest/wiki.

## Changes

- `docs/orion/o6/low-level-dev/cix-sdk/build.md` (zh)
- `docs/orion/o6/low-level-dev/cix-sdk/get-source.md` (zh)
- `docs/orion/o6/low-level-dev/cix-sdk/README.md` (zh)
- `i18n/en/.../orion/o6/low-level-dev/cix-sdk/build.md`
- `i18n/en/.../orion/o6/low-level-dev/cix-sdk/get-source.md`
- `i18n/en/.../orion/o6/low-level-dev/cix-sdk/README.md`

Both `build.md` and `get-source.md` are converted from `doc_kind: wrapper` (importing from the shared `orion-common` partial) to `doc_kind: page` with a single info callout pointing to the CIX wiki:

- 中文：https://github.com/cixtech/cix-manifest/wiki/guide_zh
- English: https://github.com/cixtech/cix-manifest/wiki

The `README.md` index adds the same pointer at the top, and still renders `<DocCardList />` so the existing sub-pages remain reachable.

## Scope notes

- The shared `docs/common/orion-common/low-level-dev/cix-sdk/_build.mdx` and `_get-source.mdx` are intentionally **not** modified in this commit. `orion/o6n` still imports from them, so O6N continues to render the old tutorial. If O6N should be redirected too, please comment and I'll send a follow-up commit on the same branch.
- The O6N sync is intentionally deferred so that this PR is scoped to the explicit ask (O6 only) and avoids a stealth change to O6N.

## Verification

- `scripts/agent-doc-lint.sh` → passed
- `scripts/agent-doc-translation-guard.sh` → passed
- `github_pr_guard.py check` → ok (1 commit, 6 files, bilingual complete)
