### PR TITLE
docs(rock3b): link boot-from-sd-card image download to the consolidated download page

### DIFF
--- a/docs/rock3/rock3b/getting-started/install-system/boot-from-emmc.md
+++ b/docs/rock3/rock3b/getting-started/install-system/boot-from-emmc.md
@@ -2,24 +2,24 @@
 sidebar_position: 1
 
 doc_kind: wrapper
-source_of_truth: local
+source_of_truth: common
 imports_resolve_to:
-  - docs/rock3/rock3b/_image.mdx
   - docs/common/general/_etcherV2.mdx
 ---
 
-import Images from "../../\_image.mdx"
 import Etcher from '../../../../common/general/\_etcherV2.mdx';
 
-# 安装系统到 EMMC Module
+# 安装系统到 eMMC Module
+
+本文介绍如何在 ROCK 3B 上将系统安装到 eMMC Module 中，并通过 eMMC Module 启动系统。
 
 ## 文件下载
 
-<Images loader={false} system_img={true} spi_img={false} />
+到资源下载汇总页面下载 [ROCK 3B 系统镜像](../../download)
 
-## EMMC Module 准备
+## eMMC Module 准备
 
-将 [EMMC Module](../../../../accessories/emmc_module) 插入到 [EMMC Reader](../../../../accessories/emmc_reader) 中，然后将 Reader 插入到 PC 的 USB 端口上
+将 [eMMC Module](../../../../accessories/emmc_module) 插入到 [eMMC Reader](../../../../accessories/emmc_reader) 中，然后将 Reader 插入到 PC 的 USB 端口上
 
 ## 镜像烧录
 
@@ -27,7 +27,7 @@ import Etcher from '../../../../common/general/\_etcherV2.mdx';
 
 ## 启动系统
 
-按照上述步骤成功烧录 EMMC Module 后， 将 EMMC Module 插入到 EMMC Module 插槽内（如下图所示），然后上电，系统开始启动，HDMI显示桌面。
+按照上述步骤成功烧录 eMMC Module 后， 将 eMMC Module 插入到 eMMC Module 插槽内（如下图所示），然后上电，系统开始启动，HDMI显示桌面。
 
 <img
 src="/img/rock3/3b/rock3b_with_emmc_module.webp"

--- a/docs/rock3/rock3b/getting-started/install-system/boot-from-sd-card.md
+++ b/docs/rock3/rock3b/getting-started/install-system/boot-from-sd-card.md
@@ -2,20 +2,20 @@
 sidebar_position: 1
 
 doc_kind: wrapper
-source_of_truth: local
+source_of_truth: common
 imports_resolve_to:
-  - docs/rock3/rock3b/_image.mdx
   - docs/common/general/_etcherV2.mdx
 ---
 
-import Images from "../../\_image.mdx"
 import Etcher from '../../../../common/general/\_etcherV2.mdx';
 
 # 安装系统到 microSD 卡
 
+本文介绍如何在 ROCK 3B 上将系统安装到 microSD 卡 中，并通过 microSD 卡 启动系统。
+
 ## 文件下载
 
-<Images loader={false} system_img={true} spi_img={false} />
+到资源下载汇总页面下载 [ROCK 3B 系统镜像](../../download)
 
 ## microSD 卡准备
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/getting-started/install-system/boot-from-emmc.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/getting-started/install-system/boot-from-emmc.md
@@ -2,24 +2,24 @@
 sidebar_position: 1
 
 doc_kind: wrapper
-source_of_truth: local
+source_of_truth: common
 imports_resolve_to:
-  - i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/_image.mdx
   - i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcherV2.mdx
 ---
 
-import Images from "../../\_image.mdx"
 import Etcher from '../../../../common/general/\_etcherV2.mdx';
 
-# Install the system to the EMMC Module
+# Install OS to eMMC Module
+
+This article explains how to install the operating system to an eMMC Module and boot the system from it on ROCK 3B.
 
 ## File Download
 
-<Images loader={false} system_img={true} spi_img={false} />
+Download the [ROCK 3B system image](../../download) from the resource download page.
 
-## EMMC Module preparation
+## eMMC Module preparation
 
-Insert [EMMC Module](../../../../accessories/emmc_module) into [EMMC Reader](accessories/emmc_reader), and then insert the reader into the USB port of your PC.
+Insert the [eMMC Module](../../../../accessories/emmc_module) into the [eMMC Reader](accessories/emmc_reader), and then insert the reader into the USB port of your PC.
 
 ## Image burning
 
@@ -27,7 +27,7 @@ Insert [EMMC Module](../../../../accessories/emmc_module) into [EMMC Reader](acc
 
 ## Boot the system
 
-After successfully burning the EMMC Module according to the above steps, insert the EMMC Module into the EMMC Module slot (as shown in the picture below), then power on the system, the system will start booting and HDMI will display the desktop.
+After successfully burning the eMMC Module according to the above steps, insert the eMMC Module into the eMMC Module slot (as shown in the picture below), then power on the system, the system will start booting and HDMI will display the desktop.
 
 <img
 src="/img/rock3/3b/rock3b_with_emmc_module.webp"

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/getting-started/install-system/boot-from-sd-card.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/getting-started/install-system/boot-from-sd-card.md
@@ -2,20 +2,20 @@
 sidebar_position: 1
 
 doc_kind: wrapper
-source_of_truth: local
+source_of_truth: common
 imports_resolve_to:
-  - i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/_image.mdx
   - i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcherV2.mdx
 ---
 
-import Images from "../../\_image.mdx"
 import Etcher from '../../../../common/general/\_etcherV2.mdx';
 
-# Install the system on the microSD card
+# Install OS to microSD Card
 
-## File download
+This article explains how to install the operating system to a microSD card and boot the system from it on ROCK 3B.
 
-<Images loader={false} system_img={true} spi_img={false} />
+## File Download
+
+Download the [ROCK 3B system image](../../download) from the resource download page.
 
 ## microSD card preparation
 


### PR DESCRIPTION
## Summary

把 ROCK 3B 「安装系统到 microSD 卡」和「安装系统到 eMMC Module」两页里通过 `_image.mdx` 组件嵌入的镜像下载段落，统一改为直接指向 `../../download` 资源下载汇总页面，与 ROCK 4A/B 同类页面的现行写法保持一致。

## Why

- 两页原先通过 `import Images from "../../_image.mdx"` 渲染系统镜像链接，但 `_image.mdx` 里写死的 URL（`b18`）和 `/rock3/rock3b/download` 维护的最新镜像列表（已包含 `rsdk-r1`）会逐步脱节，容易把客户引到过期镜像。
- 售后技术支持群收到反馈：镜像下载部分已过时，需要按同类页面的写法收敛到 download 页面。

## Changes

- `docs/rock3/rock3b/getting-started/install-system/boot-from-sd-card.md` (commit 1)
  - 删除 `_image.mdx` 的 `import` 和 `imports_resolve_to` 条目
  - `source_of_truth` 从 `local` 改为 `common`
  - 「文件下载」段落改为「到资源下载汇总页面下载 [ROCK 3B 系统镜像](../../download)」
  - 新增一句话简介，与 ROCK 4A/B 同类页面风格对齐
- `i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/getting-started/install-system/boot-from-sd-card.md` (commit 1)
  - 同步去掉 `_image.mdx` import、`source_of_truth` 改为 `common`
  - 「File Download」段落改为「Download the [ROCK 3B system image](../../download) from the resource download page.」
  - 标题与简介同步对齐英文版本风格
- `docs/rock3/rock3b/getting-started/install-system/boot-from-emmc.md` (commit 2)
  - 与 sd-card 完全一致的处理方式（去掉 `_image.mdx`，改为 download 链接）
  - 顺手把全文大小写不统一的 `EMMC Module` / `EMMC Reader` 归一为 `eMMC`，与 ROCK 4A/B 参考页对齐
- `i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/getting-started/install-system/boot-from-emmc.md` (commit 2)
  - 同步上面三处处理

## 参考

- `docs/rock4/rock4ab-se/getting-started/install-os/boot-from-sd-card.md`（同类页面目标格式）
- `docs/rock4/rock4ab-se/getting-started/install-os/boot-from-emmc.md`（同类页面目标格式）
- `docs/rock3/rock3b/download.md`（新的镜像下载地址）

## 影响范围

- 仅 ROCK 3B：microSD 卡 / eMMC Module 两套安装引导页面（共 4 个文件：中英文各 2）
- maskrom 三页（windows/linux/mac-os）也引用 `_image.mdx`，但本次按内部沟通结果暂不动，单独跟进

## Verification

- `python3 /Users/tomclawz/.openclaw/workspaces/support/scripts/github_pr_guard.py check --repo-path ~/radxa-docs/docs --fetch`
  - `ok: true`，`reasons: []`
  - bilingual 同步：中文 / 英文都齐全
  - scope 仅 `docs/rock3/rock3b`，文件数 4，commit 数 2