### PR TITLE
docs: update Orion O6N BIOS links

### DIFF
--- a/docs/orion/download.md
+++ b/docs/orion/download.md
@@ -32,8 +32,8 @@ sidebar_position: 150
 #### 瑞莎星睿 O6N
         | 下载平台                                                             | 版本       | 文件格式 | 获取方式                                                                                            |
         | :------------------------------------------------------------------- | :--------- | :------- | :-------------------------------------------------------------------------------------------------- |
-        | [**Radxa DL**](https://dl.radxa.com/orion/o6n/images/bios/orion-o6n-bios-1.1.0-2.zip)                      | `1.1.0-2` | `.zip`   | 固件位于压缩包内                                                                                                  |
-        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-2) | `1.1.0-2` | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6n` 目录下 |
+        | [**Radxa DL**](https://dl.radxa.com/orion/o6n/images/bios/orion-o6n-bios-1.2.4.zip)                      | `1.2.4` | `.zip`   | 固件位于压缩包内                                                                                                  |
+        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.2.4) | `1.2.4` | `.deb`   | 固件位于 `edk2-cix_***_all.deb` 包中的 `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6n` 目录下 |
     </TabItem>
 </Tabs>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/orion/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/orion/download.md
@@ -32,8 +32,8 @@ Radxa Orion O6 and O6N use different BIOS firmware.
 #### Radxa Orion O6N
         | Download Platform                                                             | Version   | Format | How to Access                                                                                            |
         | :------------------------------------------------------------------- | :-------- | :------- | :-------------------------------------------------------------------------------------------------- |
-        | [**Radxa DL**](https://dl.radxa.com/orion/o6n/images/bios/orion-o6n-bios-1.1.0-2.zip)                      | `1.1.0-2` | `.zip`   | Firmware is inside the zip file                                                                                    |
-        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.1.0-2) | `1.1.0-2` | `.deb`   | Firmware is located in `edk2-cix_***_all.deb` package under `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6n` directory |
+        | [**Radxa DL**](https://dl.radxa.com/orion/o6n/images/bios/orion-o6n-bios-1.2.4.zip)                      | `1.2.4` | `.zip`   | Firmware is inside the zip file                                                                                    |
+        | [**GitHub Release**](https://github.com/radxa-pkg/edk2-cix/releases/tag/1.2.4) | `1.2.4` | `.deb`   | Firmware is located in `edk2-cix_***_all.deb` package under `edk2-cix_***_all\data.tar\data\usr\share\edk2\radxa\orion-o6n` directory |
     </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## Summary
- Update Orion O6N BIOS download URL from `orion-o6n-bios-1.1.0-2.zip` to `orion-o6n-bios-1.2.4.zip`
- Update the related `edk2-cix` GitHub release tag from `1.1.0-2` to `1.2.4`
- Update the displayed BIOS version to `1.2.4`
- Apply the same change to the Chinese and English docs pages

## Verification
- Confirmed the old O6N BIOS URL/tag no longer appears in the edited files
- Confirmed the new Radxa DL URL returns HTTP 200
- Confirmed the new GitHub release tag URL returns HTTP 200
- Ran `python3 scripts/github_pr_guard.py check --repo-path <worktree> --fetch`
