### PR TITLE
docs(rock5b+): list Quectel LTE EC25 as a supported accessory

### DIFF
--- a/docs/rock5/rock5b/accessories/README.md
+++ b/docs/rock5/rock5b/accessories/README.md
@@ -16,6 +16,7 @@ sidebar_position: 99
 | 摄像头   | Camera 4K              | 4K 分辨率摄像头模块，支持通过 MIPI CSI 接口连接          | [查看详情](https://radxa.com/products/accessories/camera4k)           |
 | 摄像头   | Camera 8M 219          | 8MP IMX219 摄像头模块，广泛兼容的摄像头选择              | [查看详情](https://radxa.com/products/accessories/camera-8m-219)      |
 | 无线模块 | Wireless Module A8     | 支持 Wi-Fi 6 和蓝牙 5.2 的无线网卡模块                   | [查看详情](https://radxa.com/products/accessories/wireless-module-a8) |
+| 无线模块 | LTE EC25 4G 模组       | 移远 Quectel LTE EC25-AU 4G 模组，M.2 B Key 接口连接 | [查看详情](https://docs.radxa.com/rock5/rock5b/getting-started/interface-usage/pcie-b-key) |
 | PoE 扩展 | 25W PoE+ HAT           | 通过以太网供电的扩展板，支持 IEEE 802.3at 标准           | [查看详情](https://radxa.com/products/accessories/25w-poe-plus-hat)   |
 | 存储扩展 | eMMC Module            | 高速 eMMC 存储模块，提供 16GB/32GB/64GB/128GB 容量选择   | [查看详情](https://radxa.com/products/accessories/emmc-module)        |
 | 存储扩展 | eMMC to uSD            | eMMC 转 microSD 卡适配器                                 | [查看详情](https://radxa.com/products/accessories/emmc-to-usd)        |

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/accessories/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/accessories/README.md
@@ -16,6 +16,7 @@ This page lists the official accessories compatible with ROCK 5B.
 | Camera   | Camera 4K              | 4K resolution camera module that connects over MIPI CSI                  | [Learn more](https://radxa.com/products/accessories/camera4k)           |
 | Camera   | Camera 8M 219          | 8 MP IMX219 camera module, a widely compatible option                    | [Learn more](https://radxa.com/products/accessories/camera-8m-219)      |
 | Wireless | Wireless Module A8     | Wi-Fi 6 and Bluetooth 5.2 wireless card module                           | [Learn more](https://radxa.com/products/accessories/wireless-module-a8) |
+| Wireless | LTE EC25 4G Module     | Quectel LTE EC25-AU 4G cellular module, connects via M.2 B Key            | [Learn more](https://docs.radxa.com/rock5/rock5b/getting-started/interface-usage/pcie-b-key) |
 | PoE      | 25W PoE+ HAT           | Power-over-Ethernet expansion board supporting IEEE 802.3at              | [Learn more](https://radxa.com/products/accessories/25w-poe-plus-hat)   |
 | Storage  | eMMC Module            | High-speed eMMC storage modules in 16/32/64/128 GB capacities            | [Learn more](https://radxa.com/products/accessories/emmc-module)        |
 | Storage  | eMMC to uSD            | eMMC to microSD card adapter                                             | [Learn more](https://radxa.com/products/accessories/emmc-to-usd)        |


### PR DESCRIPTION
## 背景
客户在 support 邮件里问"ROCK 5B+ 支持什么 4G 模块"。我们 docs 里其实已经有 Quectel EC25-AU 的完整配置指南（`docs/rock5/rock5b/getting-started/interface-usage/pcie-b-key.md`），但只挂在「配件 / 外设」系列 (`docs.radxa.com/accessories/peripherals/quectel-lte-ec25`)，没有出现在 ROCK 5B+ 自己的配件列表页 (`docs.radxa.com/rock5/rock5b/accessories`)。结果就是客户/同事打开 5B+ 配件页时根本看不到这个选项。

## 改动
在 `docs/rock5/rock5b/accessories/README.md` 的配件表格里「无线模块」分类下增加一行：

- 配件名称：LTE EC25 4G 模组
- 描述：移远 Quectel LTE EC25-AU 4G 模组，M.2 B Key 接口连接
- 查看详情：跳转到 https://docs.radxa.com/rock5/rock5b/getting-started/interface-usage/pcie-b-key （即 M.2 B Key 配置指南）

`查看详情` 暂时跳 docs guide 而非 `radxa.com/products/...`，原因是 radxa.com 主站目前没有 EC25 配件的产品页，等主站补上产品页之后可以再单独把链接换回去。

## 影响范围
- 文件：
  - `docs/rock5/rock5b/accessories/README.md`（中文）
  - `i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/accessories/README.md`（英文同步）
- 仅 ROCK 5B+ 配件列表页
- 不改其它产品
- 不改 EC25 本身的配置文档

## 验证
- `python3 scripts/github_pr_guard.py check --repo-path ~/radxa-docs/contents --fetch` → ok: true
  - 1 commit, 2 files, scope `docs/rock5/rock5b`
  - 中英双语都已更新
- 渲染后表格新增 1 行，不会影响其他行