### PR TITLE
docs(cubie/a5e): remove Tina Linux XFCE link from GPT system images

### DIFF
--- a/docs/cubie/a5e/download.md
+++ b/docs/cubie/a5e/download.md
@@ -44,7 +44,6 @@ sidebar_position: 150
 - [Radxa OS - Debian 11 Bullseye KDE R7（最新）](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz)
 - [Radxa OS - Debian 11 Bullseye CLI R7（最新）](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_cli_r7.output_512.img.xz)
 - [Radxa OS - Debian 11 Bullseye KDE](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-b1/radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz)
-- [Tina Linux - Debian 11 Bullseye XFCE](https://mega.nz/file/g7AWVBZJ#xkDOIJYHvgUngdKUgW7D_aSaVPifyYZDOG0fUOtgAMk) ⚠️ *MEGA 链接，部分地区可能无法访问*
 
 #### FEL 系统镜像
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/download.md
@@ -33,7 +33,6 @@ We strongly recommend that beginners download GPT format Radxa OS official image
 - [Radxa OS - Debian 11 Bullseye KDE R7 (Latest)](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz)
 - [Radxa OS - Debian 11 Bullseye CLI R7 (Latest)](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_cli_r7.output_512.img.xz)
 - [Radxa OS - Debian 11 Bullseye KDE](https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-b1/radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz)
-- [Tina Linux - Debian 11 Bullseye XFCE](https://mega.nz/file/g7AWVBZJ#xkDOIJYHvgUngdKUgW7D_aSaVPifyYZDOG0fUOtgAMk)
 
 #### FEL System Images
 


### PR DESCRIPTION
The Tina Linux - Debian 11 Bullseye XFCE entry was listed under 'GPT 系统镜像 (推荐)' / 'GPT System Images (Recommended)' alongside the Radxa OS releases, which made it appear to be an officially recommended GPT-format image. Move it out of that section to avoid confusing it with Radxa OS as the beginner-friendly default.

The FEL section link is kept unchanged.

## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
