### PR TITLE
docs(dragon/q8b npu-dev): split quick-example download commands by Ubuntu version

### DIFF
--- a/docs/common/ai/qualcomm/_qairt-quick-example.mdx
+++ b/docs/common/ai/qualcomm/_qairt-quick-example.mdx
@@ -7,6 +7,9 @@
 
 ## 下载示例
 
+<Tabs queryString="ubuntu">
+    <TabItem value="Ubuntu 24.04">
+
 <NewCodeBlock tip="Device" type="device">
 
 ```bash
@@ -15,6 +18,23 @@ modelscope download --model radxa/resnet50_qairt --local ./resnet50_qairt
 ```
 
 </NewCodeBlock>
+
+    </TabItem>
+
+    <TabItem value="Ubuntu 26.04">
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+pip3 install modelscope
+modelscope download --model radxa/resnet50_qairt --local-dir ./resnet50_qairt
+```
+
+</NewCodeBlock>
+
+    </TabItem>
+
+</Tabs>
 
 ## 运行示例
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/qualcomm/_qairt-quick-example.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/qualcomm/_qairt-quick-example.mdx
@@ -8,6 +8,9 @@ to make sure the NPU is enabled.
 
 ## Download Example
 
+<Tabs queryString="ubuntu">
+    <TabItem value="Ubuntu 24.04">
+
 <NewCodeBlock tip="Device" type="device">
 
 ```bash
@@ -16,6 +19,23 @@ modelscope download --model radxa/resnet50_qairt --local ./resnet50_qairt
 ```
 
 </NewCodeBlock>
+
+    </TabItem>
+
+    <TabItem value="Ubuntu 26.04">
+
+<NewCodeBlock tip="Device" type="device">
+
+```bash
+pip3 install modelscope
+modelscope download --model radxa/resnet50_qairt --local-dir ./resnet50_qairt
+```
+
+</NewCodeBlock>
+
+    </TabItem>
+
+</Tabs>
 
 ## Run Example
 


### PR DESCRIPTION
## Summary

- 在 Dragon Q8B NPU 快速验证教程 (`docs/dragon/q8b/app-dev/npu-dev/quick-example`) 的 **下载示例** 段落，把原本单一的 modelscope 下载命令拆成 Tabs，按 Ubuntu 版本区分
- Ubuntu 24.04：保留原命令 `modelscope download --model radxa/resnet50_qairt --local ./resnet50_qairt`
- Ubuntu 26.04：使用新参数 `modelscope download --model radxa/resnet50_qairt --local-dir ./resnet50_qairt`
- 中英文同步修改：CN 文档与 `i18n/en/.../current/` 下英文版同时更新

## Context

来自内部技术支持工单：Dragon Q8B 上跑 QAIRT 快速验证时，Ubuntu 26.04 的 modelscope 已不支持旧的 `--local` 参数，必须改用 `--local-dir`，但当前教程仍只展示 24.04 写法，会让 26.04 用户首次下载就报错。

通过 Tabs 让教程同时支持两个版本，避免一刀切替换 24.04 命令（24.04 用户仍在用）。

## Changed files

- `docs/common/ai/qualcomm/_qairt-quick-example.mdx`
- `i18n/en/docusaurus-plugin-content-docs/current/common/ai/qualcomm/_qairt-quick-example.mdx`

## Validation

- `python3 scripts/github_pr_guard.py check --repo-path ...` → ok
- bilingual check passed（中英文均已同步）
- 仅修改 `docs/common/ai` 范围，单 commit，2 个文件

/cc @tangzz-radxa
