### PR TITLE
docs(rock 5 itx): clarify that SATA interfaces are SATA 3.0

### DIFF
--- a/docs/rock5/rock5itx/getting-started/assembly-guide.md
+++ b/docs/rock5/rock5itx/getting-started/assembly-guide.md
@@ -48,7 +48,7 @@ sidebar_position: 7
 
 ### 安装 SATA 硬盘
 
-如果主板带有 SATA 接口，则请按以下方式接线。
+如果主板带有 SATA 3.0 接口，则请按以下方式接线。
 
 以下图片中偏上的那条为数据线，将该数据线插入[接口说明](../getting-started/introduction#主板概览)中标号 20 中的其中一个。
 

--- a/docs/rock5/rock5itx/getting-started/interface-usage/sata.md
+++ b/docs/rock5/rock5itx/getting-started/interface-usage/sata.md
@@ -2,9 +2,11 @@
 sidebar_position: 14
 ---
 
-# Sata
+# SATA 3.0
 
 SATA 是一种计算机总线接口，用于将主机总线适配器连接到硬盘驱动器、光驱和固态驱动器等大容量存储设备。串行 ATA 取代了早期的并行 ATA（PATA）标准，成为存储设备的主要接口。
+
+ROCK 5 ITX 板载 4 个 SATA 3.0 接口，单口最高速率 6 Gbps。
 
 ## 接口测试方法
 
@@ -30,7 +32,7 @@ sudo hdparm -tT --direct /dev/sdX
 
 ### 组 raid 5 阵列
 
-- 将 4 块 sata 硬盘插入 ROCK 5 ITX sata 接口
+- 将 4 块 sata 硬盘插入 ROCK 5 ITX SATA 3.0 接口
 
 - 安装 mdadm
 

--- a/docs/rock5/rock5itx/getting-started/introduction.md
+++ b/docs/rock5/rock5itx/getting-started/introduction.md
@@ -92,8 +92,8 @@ ROCK 5 ITX 不仅是一款高性能的ARM基础PC板，更是一个多功能、�
     <th>2 个摄像头端口（2 个四通道 MIPI CSI 或 2 个双通道 MIPI CSI）</th>
   </tr>
   <tr>
-    <th>SATA</th>
-    <th>4x SATA 接口，带电源接头</th>
+    <th>SATA 3.0</th>
+    <th>4x SATA 3.0 接口，带电源接头</th>
   </tr>
   <tr>
     <th>供电</th>
@@ -178,7 +178,7 @@ ROCK 5 ITX 不仅是一款高性能的ARM基础PC板，更是一个多功能、�
         <th>12</th>
         <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
         <th>20</th>
-        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4个带供电的 SATA 接口</a></th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4个带供电的 SATA 3.0 接口</a></th>
         <th>28</th>
         <th>Rockchip RK3588</th>
       </tr>
@@ -276,7 +276,7 @@ ROCK 5 ITX 不仅是一款高性能的ARM基础PC板，更是一个多功能、�
         <th>12</th>
         <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
         <th>20</th>
-        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4个带供电的 SATA 接口</a></th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4个带供电的 SATA 3.0 接口</a></th>
         <th>28</th>
         <th>Rockchip RK3588</th>
       </tr>

--- a/docs/rock5/rock5itx/hardware-design/hardware-interface.md
+++ b/docs/rock5/rock5itx/hardware-design/hardware-interface.md
@@ -85,7 +85,7 @@ sidebar_position: 4
         <th>12</th>
         <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
         <th>20</th>
-        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4个带供电的 SATA 接口</a></th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4个带供电的 SATA 3.0 接口</a></th>
         <th>28</th>
         <th>Rockchip RK3588</th>
       </tr>
@@ -183,7 +183,7 @@ sidebar_position: 4
         <th>12</th>
         <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
         <th>20</th>
-        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4个带供电的 SATA 接口</a></th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4个带供电的 SATA 3.0 接口</a></th>
         <th>28</th>
         <th>Rockchip RK3588</th>
       </tr>
@@ -702,7 +702,7 @@ LCD 座子采用的是 FH35C-39S-0.3SHW（50），间距 0.3 mm。
 
 RTC 采取 Lithium 纽扣电池 CR1220-3V。
 
-## SATA
+## SATA 3.0 {#sata}
 
 ### SATA PORT
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/assembly-guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/assembly-guide.md
@@ -48,7 +48,7 @@ Insert the SSD into the [Interface Description](../getting-started/introduction#
 
 ### Install the SATA Hard Drive
 
-If the motherboard has a SATA interface, wire it as follows.
+If the motherboard has a SATA 3.0 interface, wire it as follows.
 
 The upper one in the picture below is the data cable. Plug this cable into one of the cables labelled 20 in [Interface Description](../getting-started/introduction#motherboard-overview).
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/interface-usage/sata.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/interface-usage/sata.md
@@ -2,9 +2,11 @@
 sidebar_position: 14
 ---
 
-# Sata
+# SATA 3.0
 
 SATA is a computer bus interface that connects host bus adapters to mass storage devices such as hard disk drives, optical drives, and solid-state drives. Serial ATA succeeded the earlier Parallel ATA (PATA) standard to become the predominant interface for storage devices.
+
+ROCK 5 ITX provides 4 onboard SATA 3.0 interfaces, each supporting up to 6 Gbps.
 
 ## Interface test methods
 
@@ -30,7 +32,7 @@ sudo hdparm -tT --direct /dev/sdX
 
 ### Group raid 5 array
 
-- Inserting 4 sata drives into the ROCK 5 ITX sata interface
+- Inserting 4 sata drives into the ROCK 5 ITX SATA 3.0 interface
 
 - Install mdadm
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/introduction.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/introduction.md
@@ -92,8 +92,8 @@ The ROCK 5 ITX is not only a high-performance ARM-based PC board but also a vers
     <th>2x camera ports (2x four-channel MIPI CSI or 2x dual-channel MIPI CSI)</th>
   </tr>
   <tr>
-    <th>SATA</th>
-    <th>4x SATA interfaces with power connectors</th>
+    <th>SATA 3.0</th>
+    <th>4x SATA 3.0 interfaces with power connectors</th>
   </tr>
   <tr>
     <th>Power</th>
@@ -178,7 +178,7 @@ The ROCK 5 ITX is not only a high-performance ARM-based PC board but also a vers
         <th>12</th>
         <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
         <th>20</th>
-        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4 Powered SATA Interfaces</a></th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4 Powered SATA 3.0 Interfaces</a></th>
         <th>28</th>
         <th>Rockchip RK3588</th>
       </tr>
@@ -276,7 +276,7 @@ The ROCK 5 ITX is not only a high-performance ARM-based PC board but also a vers
         <th>12</th>
         <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
         <th>20</th>
-        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4 Powered SATA Interfaces</a></th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4 Powered SATA 3.0 Interfaces</a></th>
         <th>28</th>
         <th>Rockchip RK3588</th>
       </tr>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/hardware-design/hardware-interface.md
@@ -85,7 +85,7 @@ sidebar_position: 4
         <th>12</th>
         <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
         <th>20</th>
-        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4 Powered SATA Interfaces</a></th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4 Powered SATA 3.0 Interfaces</a></th>
         <th>28</th>
         <th>Rockchip RK3588</th>
       </tr>
@@ -183,7 +183,7 @@ sidebar_position: 4
         <th>12</th>
         <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#usb-30--hdmi-11">USB 3.0 + HDMI</a></th>
         <th>20</th>
-        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4 Powered SATA Interfaces</a></th>
+        <th><a href="/rock5/rock5itx/hardware-design/hardware-interface#sata">4 Powered SATA 3.0 Interfaces</a></th>
         <th>28</th>
         <th>Rockchip RK3588</th>
       </tr>
@@ -702,7 +702,7 @@ Spacing 2.54 mm
 
 RTC takes Lithium coin cell CR1220-3V.
 
-## SATA
+## SATA 3.0 {#sata}
 
 ### SATA PORT
 


### PR DESCRIPTION
## Summary

ROCK 5 ITX 提供 4 个板载 SATA 接口（每个最高 6 Gbps），但当前文档只把它们写成 "SATA"，没有标明是 SATA 3.0。把所有提到这块板 SATA 接口的地方统一改成 "SATA 3.0"，让用户在阅读规格、接口说明和装机步骤时能直接看出接口代数。

## 改动范围

只针对 ROCK 5 ITX（`rock5/rock5itx/`）的 SATA 接口相关描述。中英文同步。

- `docs/rock5/rock5itx/getting-started/introduction.md`
  - 参数表：`<th>SATA</th>` / `4x SATA 接口，带电源接头` → SATA 3.0
  - 主板概览（v1.11 / v1.12 两块板的表）："4个带供电的 SATA 接口" → "4个带供电的 SATA 3.0 接口"
- `docs/rock5/rock5itx/hardware-design/hardware-interface.md`
  - 主板概览（同上两处）：SATA 接口描述同步
  - 章节标题：`## SATA` → `## SATA 3.0 {#sata}`，**用 `{#sata}` 显式保留锚点**，避免 overview 表里 `#sata` 链接失效
- `docs/rock5/rock5itx/getting-started/interface-usage/sata.md`
  - 页面标题：`# Sata` → `# SATA 3.0`
  - 文首补充："ROCK 5 ITX 板载 4 个 SATA 3.0 接口，单口最高速率 6 Gbps。"
  - RAID 步骤中的 "ROCK 5 ITX sata 接口" → "ROCK 5 ITX SATA 3.0 接口"
- `docs/rock5/rock5itx/getting-started/assembly-guide.md`
  - "如果主板带有 SATA 接口" → "如果主板带有 SATA 3.0 接口"

英文版（`i18n/en/...`）做对应修改。

## 未改动

- 配件名 "SATA Power Cable" / "M.2 to Hexa SATA Adapter"：属于商品 SKU 名，不改
- `maskrom/windows.md` 里 `sata={false}`：是 rkdevtool React 组件 prop，不属于文档描述
- 引脚定义里的 `STXP0_64` / `VCC5V0_SATA` / `SATA30_1_TXP` 等：属于硬件信号名 / 电源轨名，改动风险大于收益
- `assembly-guide.md` 里的 `SATA 硬盘` / `SATA 电源线`：描述的是硬盘/线缆类型，与接口版本无关

## 验证

- `python3 scripts/github_pr_guard.py check --repo-path . --fetch`：通过（8 个文件，1 commit，scope 限定在 `docs/rock5/rock5itx`，bilingual OK）
- 锚点 `#sata` 保留（`## SATA 3.0 {#sata}`），主板概览里到 `hardware-interface.md#sata` 的链接不会失效
