### PR TITLE
docs(dragon/q6a,q8b): add reboot-after-SPI-flash warning

### DIFF
--- a/docs/dragon/q6a/low-level-dev/spi-fw.md
+++ b/docs/dragon/q6a/low-level-dev/spi-fw.md
@@ -103,6 +103,13 @@ sudo edl-ng --memory=spinor rawprogram rawprogram0.xml patch0.xml --loader=prog_
   </TabItem>
 </Tabs>
 
+:::warning 烧录完成后请重启设备
+SPI 启动固件烧录成功后，请按以下任一方式重启设备：
+
+- 重新插拔设备电源
+- 在终端执行 `edl-ng reset` 命令
+:::
+
 ## 擦除 SPI 启动固件
 
 擦除 SPI 启动固件将导致设备无法启动，需要重新烧录 SPI 启动固件才可正常启动，若非必要，请勿擦除 SPI 启动固件。

--- a/docs/dragon/q8b/low-level-dev/spi-fw.md
+++ b/docs/dragon/q8b/low-level-dev/spi-fw.md
@@ -103,6 +103,13 @@ sudo edl-ng --memory=spinor rawprogram rawprogram0.xml patch0.xml --loader=prog_
   </TabItem>
 </Tabs>
 
+:::warning 烧录完成后请重启设备
+SPI 启动固件烧录成功后，请按以下任一方式重启设备：
+
+- 重新插拔设备电源
+- 在终端执行 `edl-ng reset` 命令
+:::
+
 ## 擦除 SPI 启动固件
 
 擦除 SPI 启动固件将导致设备无法启动，需要重新烧录 SPI 启动固件才可正常启动，若非必要，请勿擦除 SPI 启动固件。

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/low-level-dev/spi-fw.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/low-level-dev/spi-fw.md
@@ -103,6 +103,13 @@ sudo edl-ng --memory=spinor rawprogram rawprogram0.xml patch0.xml --loader=prog_
   </TabItem>
 </Tabs>
 
+:::warning Restart the device after flashing
+After the SPI boot firmware is successfully flashed, please restart the device using either of the following methods:
+
+- Re-plug the device power
+- Run the `edl-ng reset` command in the terminal
+:::
+
 ## Erase SPI Boot Firmware
 
 Erasing the SPI boot firmware will prevent the device from booting. You will need to re-flash the SPI boot firmware to restore normal operation. Do not erase the SPI boot firmware unless absolutely necessary.

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/spi-fw.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/spi-fw.md
@@ -103,6 +103,13 @@ sudo edl-ng --memory=spinor rawprogram rawprogram0.xml patch0.xml --loader=prog_
   </TabItem>
 </Tabs>
 
+:::warning Restart the device after flashing
+After the SPI boot firmware is successfully flashed, please restart the device using either of the following methods:
+
+- Re-plug the device power
+- Run the `edl-ng reset` command in the terminal
+:::
+
 ## Erase SPI Boot Firmware
 
 Erasing the SPI boot firmware will prevent the device from booting. You must reflash the SPI boot firmware before the device can boot normally. Do not erase the SPI boot firmware unless necessary.


### PR DESCRIPTION
## Summary

Add a post-flash reboot warning to the Dragon Q6A and Q8B "Flashing SPI Boot Firmware" tutorials.

The warning tells users to do either of:

- Re-plug the device power
- Run `edl-ng reset` in the terminal

Without this hint, users commonly mis-interpret the unchanged boot behavior (caused by the old bootloader still in memory) as a failed flash.

## Files touched

- `docs/dragon/q6a/low-level-dev/spi-fw.md` (Chinese)
- `docs/dragon/q8b/low-level-dev/spi-fw.md` (Chinese)
- `i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/low-level-dev/spi-fw.md` (English)
- `i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/spi-fw.md` (English)

## Why now

- Triggered by an internal support request (吴闽龙, 2026-08-04): add the same hint for both Dragon Q6A and Q8B in lockstep.

## Verification

- `python3 scripts/github_pr_guard.py check --max-scopes 2` — passed (1 commit, 4 files, 2 scopes, bilingual OK).
- `bash scripts/agent-doc-translation-guard.sh` for both Q6A and Q8B Chinese sources — passed.
- `bash scripts/agent-doc-lint.sh` on all 4 files — passed.
