### PR TITLE
docs(downloads): add RKISP Tuner (RK3576) and RK3588 Camera Tuner download links

### DIFF
--- a/docs/rock4/rock4d/download.md
+++ b/docs/rock4/rock4d/download.md
@@ -73,6 +73,10 @@ USB 刷机使用，Loader 文件用于 USB 下载初始化。
 - [Radxa ROCK 4D OpenWRT ext4 sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-4d-ext4-sysupgrade.img.gz)
 - [Radxa ROCK 4D OpenWRT squashfs sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-4d-squashfs-sysupgrade.img.gz)
 
+## 软件工具
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v3.4.4_Test.7z)：Rockchip RK3576 ISP 调参工具，适用于 RK3576 / RK3576J 系列产品的摄像头调试。
+
 ## 百度网盘下载
 
 :::tip

--- a/docs/rock5/rock5a/download.md
+++ b/docs/rock5/rock5a/download.md
@@ -59,6 +59,10 @@ OpenWRT 不是瑞莎官方维护的系统，瑞莎不能保证完整功能，如
 :::
 - [百度网盘下载（rock-5a）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Frock-5a&parentPath=%2Fsharelink3108273493-988411983016443)
 
+## 软件工具
+
+- [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip)：Rockchip RK3588 摄像头调试工具，适用于 RK3588 / RK3588S / RK3588S2 等 RK3588 系列 SoC 的 ISP 参数调优。
+
 ## 质量认证
 
 | 文档                | 下载链接                                                                                               |

--- a/docs/rock5/rock5b/download.md
+++ b/docs/rock5/rock5b/download.md
@@ -177,6 +177,8 @@ Android：
 
 - [Upgrade Tool](https://dl.radxa.com/tools/linux/upgrade_tool_v2.30_for_linux.zip)
 
+- [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip)：Rockchip RK3588 摄像头调试工具，适用于 RK3588 / RK3588S / RK3588S2 等 RK3588 系列 SoC 的 ISP 参数调优。
+
 ## 硬件设计
 
 <Tabs queryString="HardwareDesign">

--- a/docs/rock5/rock5c/download.md
+++ b/docs/rock5/rock5c/download.md
@@ -38,6 +38,10 @@ Armbian 的默认凭据如下：
 - [Radxa ROCK 5C Kaihong OS for microSD HDMI](https://github.com/radxa/KaihongOs/releases/download/kaihongos_v1.0_Beta/KHS_3588S_SBC-HDMI-SD-GPT-20260121-0346.zip)：适用于 microSD 卡启动系统，支持 HDMI 显示。
 - [Radxa ROCK 5C Kaihong OS for microSD MIPI](https://github.com/radxa/KaihongOs/releases/download/kaihongos_v1.0_Beta/KHS_3588S_SBC-MIPI-SD-GPT-20260121-0531.zip)：适用于 microSD 卡启动系统，支持瑞莎 8 寸显示屏。
 
+## 软件工具
+
+- [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip)：Rockchip RK3588 摄像头调试工具，适用于 RK3588S2 等 RK3588 系列 SoC 的 ISP 参数调优。仅适用于 ROCK 5C 标准版（RK3588S2），ROCK 5C Lite 版（RK3582）请使用对应工具。
+
 ## 百度网盘下载
 
 :::tip

--- a/docs/rock5/rock5itx/download.md
+++ b/docs/rock5/rock5itx/download.md
@@ -69,6 +69,10 @@ Armbian 的默认凭据如下：
 - [百度网盘下载（rock-5-itx）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Frock-5-itx&parentPath=%2Fsharelink3108273493-988411983016443)
 - [百度网盘下载（rock-5-itx-6_1）](https://pan.baidu.com/s/56vG8RCxe-5T_27AWQcREGA#list/path=%2Fsharelink3108273493-988411983016443%2Fimage-release%2Frock-5-itx-6_1&parentPath=%2Fsharelink3108273493-988411983016443)
 
+## 软件工具
+
+- [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip)：Rockchip RK3588 摄像头调试工具，适用于 RK3588 系列 SoC 的 ISP 参数调优。仅适用于 ROCK 5 ITX（基于 RK3588）；ROCK 5 ITX+（基于 RK3582）请使用对应工具。
+
 ## 质量认证
 
 ## 参考文档

--- a/docs/rock5/rock5t/download.md
+++ b/docs/rock5/rock5t/download.md
@@ -39,6 +39,8 @@ Armbian 的默认凭据如下：
 
 &emsp;&emsp; [DriverAssitant](https://dl.radxa.com/tools/windows/DriverAssitant.zip)（USB驱动）
 
+&emsp;&emsp; [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip)：Rockchip RK3588 摄像头调试工具，适用于 RK3588 / RK3588J 等 RK3588 系列 SoC 的 ISP 参数调优。
+
 ## 百度网盘下载
 
 :::tip

--- a/docs/som/cm/cm4/download.md
+++ b/docs/som/cm/cm4/download.md
@@ -67,6 +67,10 @@ USB 刷机使用，Loader 文件用于 USB 下载初始化。
 
 - [RKDevTool](https://dl.radxa.com/tools/windows/RKDevTool_Release.zip)
 
+## 摄像头工具
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v3.4.4_Test.7z)：Rockchip RK3576 ISP 调参工具，适用于 RK3576 / RK3576J 系列产品的摄像头调试。
+
 ## 社区资源
 
 - [Radxa CM4 KiCAD 库文件](https://github.com/swdee/radxa-cm4-kicad) 由社区用户 [@3djelly](https://forum.radxa.com/u/3djelly) 贡献

--- a/docs/som/cm/cm5/download.md
+++ b/docs/som/cm/cm5/download.md
@@ -41,6 +41,10 @@ sidebar_position: 99
 3. [RKDevTool](https://dl.radxa.com/tools/windows/RKDevTool_Release.zip) - Windows 图形化刷机工具(内含中文使用文档)
 4. [DriverAssitant](https://dl.radxa.com/tools/windows/DriverAssitant.zip) - Rockchip 平台 Windows 通用驱动
 
+### 摄像头工具
+
+- [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip)：Rockchip RK3588 摄像头调试工具，适用于 RK3588S / RK3588S2 等 RK3588 系列 SoC 的 ISP 参数调优。
+
 ### Loader 文件
 
 USB 刷机使用，Loader 文件用于 USB 下载初始化。

--- a/docs/som/nx/nx4/download.md
+++ b/docs/som/nx/nx4/download.md
@@ -12,6 +12,10 @@ sidebar_position: 150
 
 - [RKDevTool](https://dl.radxa.com/tools/windows/RKDevTool_Release.zip)
 
+## 摄像头工具
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v3.4.4_Test.7z)：Rockchip RK3576 ISP 调参工具，适用于 RK3576 / RK3576J 系列产品的摄像头调试。
+
 ## Loader 文件
 
 用于初始化 USB 下载。

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/download.md
@@ -74,6 +74,10 @@ If the SPI Flash has not been erased, you can directly write the system image to
 - [Radxa ROCK 4D OpenWRT ext4 sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-4d-ext4-sysupgrade.img.gz)
 - [Radxa ROCK 4D OpenWRT squashfs sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-4d-squashfs-sysupgrade.img.gz)
 
+## Software Tools
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v3.4.4_Test.7z): Rockchip RK3576 ISP tuning tool for camera debugging on RK3576 / RK3576J series products.
+
 ## Hardware Design
 
 - [Schematic v1.11](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_SCH_V1.11.pdf)

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/download.md
@@ -48,6 +48,10 @@ OpenWRT is not maintained by Radxa officially. Radxa cannot guarantee full funct
 
 :::
 
+## Software Tools
+
+- [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip): Rockchip RK3588 camera tuning tool for ISP parameter tuning on RK3588 / RK3588S / RK3588S2 series SoCs.
+
 ## Compliance Documents
 
 | Document                           | Download                                                                                                   |

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/download.md
@@ -163,6 +163,8 @@ Android：
 
 - [Upgrade Tool](https://dl.radxa.com/tools/linux/upgrade_tool_v2.30_for_linux.zip)
 
+- [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip): Rockchip RK3588 camera tuning tool for ISP parameter tuning on RK3588 / RK3588S / RK3588S2 series SoCs.
+
 ## Hardware Design
 
 <Tabs queryString="HardwareDesign">

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/download.md
@@ -39,6 +39,10 @@ Kaihong OS Beta version firmware as follows:
 - [Radxa ROCK 5C Kaihong OS for microSD HDMI](https://github.com/radxa/KaihongOs/releases/download/kaihongos_v1.0_Beta/KHS_3588S_SBC-HDMI-SD-GPT-20260121-0346.zip): For booting from a microSD card with HDMI display.
 - [Radxa ROCK 5C Kaihong OS for microSD MIPI](https://github.com/radxa/KaihongOs/releases/download/kaihongos_v1.0_Beta/KHS_3588S_SBC-MIPI-SD-GPT-20260121-0531.zip): For booting from a microSD card with Radxa 8-inch display.
 
+## Software Tools
+
+- [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip): Rockchip RK3588 camera tuning tool for ISP parameter tuning on RK3588S2 series SoCs. Only applicable to ROCK 5C Standard Edition (RK3588S2); ROCK 5C Lite Edition (RK3582) should use a compatible tool.
+
 ## Hardware Design
 
 ### V1.1

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/download.md
@@ -57,6 +57,10 @@ Default Armbian credentials:
 - [Radxa ROCK 5 ITX OpenWrt ext4 sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-5-itx-ext4-sysupgrade.img.gz)
 - [Radxa ROCK 5 ITX OpenWrt squashfs sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-5-itx-squashfs-sysupgrade.img.gz)
 
+## Software Tools
+
+- [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip): Rockchip RK3588 camera tuning tool for ISP parameter tuning on RK3588 series SoCs. Only applicable to ROCK 5 ITX (based on RK3588); ROCK 5 ITX+ (based on RK3582) should use a compatible tool.
+
 ## Quality Certification
 
 ## Reference Documentation

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/download.md
@@ -39,6 +39,8 @@ Default Armbian credentials:
 
 &emsp;&emsp; [DriverAssitant](https://dl.radxa.com/tools/windows/DriverAssitant.zip)（USB driver）
 
+&emsp;&emsp; [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip): Rockchip RK3588 camera tuning tool for ISP parameter tuning on RK3588 / RK3588J series SoCs.
+
 ## Hardware Design
 
 ### V1.2

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm4/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm4/download.md
@@ -54,6 +54,10 @@ Compatible with microSD cards, onboard eMMC, and NVMe SSD for system boot.
 - [DriverAssitant](https://dl.radxa.com/tools/windows/DriverAssitant.zip)
 - [RKDevTool](https://dl.radxa.com/tools/windows/RKDevTool_Release.zip)
 
+## Camera Tools
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v3.4.4_Test.7z): Rockchip RK3576 ISP tuning tool for camera debugging on RK3576 / RK3576J series products.
+
 ## Community Resources
 
 - [Radxa CM4 KiCAD library](https://github.com/swdee/radxa-cm4-kicad) contributed by community user [@3djelly](https://forum.radxa.com/u/3djelly)

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm5/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm5/download.md
@@ -28,6 +28,10 @@ sidebar_position: 99
 3. [RKDevTool](https://dl.radxa.com/tools/windows/RKDevTool_Release.zip)
    [DriverAssitant](https://dl.radxa.com/tools/windows/DriverAssitant.zip) (related driver)
 
+## Camera Tools
+
+- [RK3588 Camera Tuner](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip): Rockchip RK3588 camera tuning tool for ISP parameter tuning on RK3588S / RK3588S2 series SoCs.
+
 ### Loader File
 
 For USB flashing, the Loader file is used for USB download initialization.

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/nx/nx4/download.md
@@ -12,6 +12,10 @@ sidebar_position: 150
 
 - [RKDevTool](https://dl.radxa.com/tools/windows/RKDevTool_Release.zip)
 
+## Camera Tools
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v3.4.4_Test.7z): Rockchip RK3576 ISP tuning tool for camera debugging on RK3576 / RK3576J series products.
+
 ## Loader files
 
 Used to initialize USB download.


### PR DESCRIPTION
## 概述

为所有基于 Rockchip RK3576 / RK3588 系列 SoC 的产品资源下载页面补充 Rockchip 官方 ISP / 摄像头调参工具的下载链接，并同步中英文两个版本。

- **RK3576 / RK3576J 产品**：增加 [RKISP Tuner v3.4.4](https://dl.radxa.com/tools/windows/RKISP_Tuner_v3.4.4_Test.7z)
- **RK3588 系列 (RK3588 / RK3588S / RK3588S2 / RK3588J) 产品**：增加 [RK3588 Camera Tuner V2.10](https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip)

## 改动范围

### RK3576 / RK3576J（新增 RKISP Tuner）
- ROCK 4D
- Radxa CM4
- Radxa NX4

### RK3588 系列（新增 RK3588 Camera Tuner）
- ROCK 5A（RK3588S）
- ROCK 5B / ROCK 5B+（RK3588）
- ROCK 5C（**仅标准版 RK3588S2**；Lite 版为 RK3582，已在文档中提示使用对应工具）
- ROCK 5T / ROCK 5T Industrial（RK3588 / RK3588J）
- ROCK 5 ITX（**仅 RK3588 版**；ROCK 5 ITX+ 为 RK3582，已在文档中提示使用对应工具）
- Radxa CM5（RK3588S / RK3588S2）

### 故意未改动
- **AICore DX-M1 / DX-M1M**：不是 RK3588 平台，是基于 DEEPX DX-M1 NPU 的 M.2 AI 加速模组，不适用 Rockchip RK3588 Camera Tuner

## 同步说明

- 中文版（`docs/`）和英文版（`i18n/en/docusaurus-plugin-content-docs/current/`）均同步更新，共 18 个文件、68 行新增
- `agent-doc-translation-guard` 已通过
- 对原本没有「软件工具」section 的下载页，新增 `## 软件工具` / `## Software Tools` 区块
- 对已有工具/刷机工具 section 的页面，追加在原有列表下方，格式与现有条目保持一致

## 关联说明

- 链接已实测 `https://dl.radxa.com/tools/windows/RKISP_Tuner_v3.4.4_Test.7z` 与 `https://dl.radxa.com/tools/windows/RK3588_Camera_Tuner_V2.10.zip` 均返回 200
- 不涉及产品资料 / datasheet / BOM 调整
- 暂未在 radxa.com 主站更新入口（如果需要把下载入口也补到主站，请单独提主站 PR）

## Checklist

- [x] 中英文同步
- [x] 只新增文档内容，未改原有章节结构
- [x] 区分 5C / 5ITX 两种变体（标准 vs Lite / +）
- [x] 新增 section 命名与现有约定一致
- [x] 排除 DX-M1 / DX-M1M（DEEPX NPU 模组，非 RK3588）
