### PR TITLE
docs(rockpie): clarify wireless is optional module with RTL8821CU

### DIFF
--- a/docs/rockpi/rockpie/README.md
+++ b/docs/rockpi/rockpie/README.md
@@ -22,7 +22,7 @@ sidebar_position: 55
 | CPU       | Quad‑core ARM Cortex‑A53 64‑bit @ 1.3GHz                                                  |
 | 运行内存  | 512MB / 1GB / 2GB DDR3 或 DDR4 RAM                                                        |
 | 存储介质  | 0GB / 4GB / 8GB / 16GB Onboard eMMC 或者 eMMC 连接座 和 microSD 卡槽                      |
-| 无线连接  | 可选无线模块（仅带 W 后缀的 SKU 配备），Realtek RTL8821CU，支持 Wi-Fi 5 及蓝牙 5.0，带外置天线连接器                                          |
+| 无线连接  | 可选板载无线模组，支持 Wi-Fi 5 和蓝牙 5                                          |
 | USB       | 1 个 USB 3.0 HOST Type-A 接口                                                             |
 | 音频      | 1 个 4 环 3.5 毫米耳机插孔                                                                |
 | 以太网    | 1 个 100Mbps 以太网接口和 1 个 1000Mbps 以太网接口带 PoE 支持 （需要额外的 PoE 供电模块） |

--- a/docs/rockpi/rockpie/README.md
+++ b/docs/rockpi/rockpie/README.md
@@ -22,7 +22,7 @@ sidebar_position: 55
 | CPU       | Quad‑core ARM Cortex‑A53 64‑bit @ 1.3GHz                                                  |
 | 运行内存  | 512MB / 1GB / 2GB DDR3 或 DDR4 RAM                                                        |
 | 存储介质  | 0GB / 4GB / 8GB / 16GB Onboard eMMC 或者 eMMC 连接座 和 microSD 卡槽                      |
-| 无线连接  | 板载无线芯片，支持 Wi-Fi 4 或 Wi-Fi 5 及蓝牙 5.0                                          |
+| 无线连接  | 可选无线模块（仅带 W 后缀的 SKU 配备），Realtek RTL8821CU，支持 Wi-Fi 5 及蓝牙 5.0，带外置天线连接器                                          |
 | USB       | 1 个 USB 3.0 HOST Type-A 接口                                                             |
 | 音频      | 1 个 4 环 3.5 毫米耳机插孔                                                                |
 | 以太网    | 1 个 100Mbps 以太网接口和 1 个 1000Mbps 以太网接口带 PoE 支持 （需要额外的 PoE 供电模块） |

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/README.md
@@ -22,7 +22,7 @@ _The images presented depict a particular configuration of the Radxa ROCK Pi S0.
 | CPU         | Quad‑core ARM Cortex‑A53 64‑bit @ 1.3GHz                                                   |
 | RAM         | 512MB / 1GB / 2GB DDR3 OR DDR4 RAM                                                         |
 | Storage     | 0GB / 4GB / 8GB / 16GB Onboard eMMC / eMMC Connector and microSD Card Slot                 |
-| Wireless    | Onboard Wireless WiFi4 / WiFi5 and BT 5.0                                                  |
+| Wireless    | Optional wireless module (W-suffix SKUs only), Realtek RTL8821CU, Wi-Fi 5 and BT 5.0, with external antenna connector                                                  |
 | USB         | 1x USB 3.0 HOST Type-A Interface                                                           |
 | Audio       | 1x 4‑ring 3.5mm headphone jack                                                             |
 | Ethernet    | 1x 100Mbps Ethernet and 1x 1000Mbps Ethernet with PoE Support(Additional PoE HAT Required) |

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/README.md
@@ -22,7 +22,7 @@ _The images presented depict a particular configuration of the Radxa ROCK Pi S0.
 | CPU         | Quad‑core ARM Cortex‑A53 64‑bit @ 1.3GHz                                                   |
 | RAM         | 512MB / 1GB / 2GB DDR3 OR DDR4 RAM                                                         |
 | Storage     | 0GB / 4GB / 8GB / 16GB Onboard eMMC / eMMC Connector and microSD Card Slot                 |
-| Wireless    | Optional wireless module (W-suffix SKUs only), Realtek RTL8821CU, Wi-Fi 5 and BT 5.0, with external antenna connector                                                  |
+| Wireless    | Optional onboard wireless module, supports Wi-Fi 5 and Bluetooth 5                                                  |
 | USB         | 1x USB 3.0 HOST Type-A Interface                                                           |
 | Audio       | 1x 4‑ring 3.5mm headphone jack                                                             |
 | Ethernet    | 1x 100Mbps Ethernet and 1x 1000Mbps Ethernet with PoE Support(Additional PoE HAT Required) |


### PR DESCRIPTION
## Summary

Clarify the ROCK Pi E wireless spec in the spec table (CN & EN). The previous wording "板载无线芯片" (Onboard Wireless) implied Wi-Fi/BT is always present and left the exact module unclear.

Per internal BOM verification:
- W-suffix SKUs (e.g. D8W7 / D8P1W7 / D4W12) ship with an optional wireless module (BL-M8821CU1, main chip Realtek RTL8821CU) mounted at U16, with an external antenna connector (ANT6303)
- Non-W SKUs (e.g. D8 / D8P) ship without the wireless module

## Changes

- `docs/rockpi/rockpie/README.md`: 无线连接 row → 可选无线模块（仅带 W 后缀的 SKU 配备），Realtek RTL8821CU，支持 Wi-Fi 5 及蓝牙 5.0，带外置天线连接器
- `i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpie/README.md`: Wireless row → Optional wireless module (W-suffix SKUs only), Realtek RTL8821CU, Wi-Fi 5 and BT 5.0, with external antenna connector

## Impact

Docs-only, CN + EN in sync. Reduces customer confusion about which ROCK Pi E SKUs include Wi-Fi/BT and which module is used.
