### PR TITLE
docs(downloads): add RKISP Tuner and camera_engine_rkaiq note for RK356X products

### DIFF
--- a/docs/rock3/rock3a/getting-started/download.md
+++ b/docs/rock3/rock3a/getting-started/download.md
@@ -41,6 +41,14 @@ Armbian 的默认凭据如下：
 
 更多镜像请查看：[Radxa ROCK 3A Release](https://github.com/radxa-build/rock-3a/releases/latest)
 
+## 软件工具
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar)：Rockchip RK356X ISP 调参工具，适用于 RK3566 / RK3568 系列产品的摄像头调试。
+
+:::tip
+使用 RK356X 平台 Debian12 系统调试 RKISP 效果时，需要手动更新系统中的 [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) 包。
+:::
+
 ## 质量认证
 
 ### CE EMC

--- a/docs/rock3/rock3b/download.md
+++ b/docs/rock3/rock3b/download.md
@@ -20,6 +20,14 @@ sidebar_position: 2
 - [Radxa ROCK 3B OpenWrt](https://openwrt.org/toh/hwdata/radxa/radxa_rock_3b)
 - [Radxa ROCK 3B OpenWrt ext4 sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-3b-ext4-sysupgrade.img.gz)
 
+## 软件工具
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar)：Rockchip RK356X ISP 调参工具，适用于 RK3566 / RK3568 系列产品的摄像头调试。
+
+:::tip
+使用 RK356X 平台 Debian12 系统调试 RKISP 效果时，需要手动更新系统中的 [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) 包。
+:::
+
 ## 硬件设计
 
 <Tabs queryString="HardwareDesign">

--- a/docs/rock3/rock3c/getting-started/download.md
+++ b/docs/rock3/rock3c/getting-started/download.md
@@ -47,3 +47,11 @@ sidebar_position: 20
 
 - [Radxa ROCK 3C OpenWrt](https://openwrt.org/toh/hwdata/radxa/radxa_rock_3c)
 - [Radxa ROCK 3C OpenWrt ext4 sysupgrade 镜像](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-3c-ext4-sysupgrade.img.gz)
+
+## 软件工具
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar)：Rockchip RK356X ISP 调参工具，适用于 RK3566 / RK3568 系列产品的摄像头调试。
+
+:::tip
+使用 RK356X 平台 Debian12 系统调试 RKISP 效果时，需要手动更新系统中的 [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) 包。
+:::

--- a/docs/som/cm/cm3/download.md
+++ b/docs/som/cm/cm3/download.md
@@ -26,6 +26,14 @@ Android:
 
 - [Radxa_CM3_Android11-rkr12-20240719-gpt.zip](https://github.com/radxa/manifests/releases/download/android11-radxa-20240719/Radxa_CM3_Android11-rkr12-20240719-gpt.zip)
 
+## 软件工具
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar)：Rockchip RK356X ISP 调参工具，适用于 RK3566 / RK3568 系列产品的摄像头调试。
+
+:::tip
+使用 RK356X 平台 Debian12 系统调试 RKISP 效果时，需要手动更新系统中的 [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) 包。
+:::
+
 ## 百度网盘下载
 
 :::tip

--- a/docs/som/cm/cm3i/download.md
+++ b/docs/som/cm/cm3i/download.md
@@ -20,6 +20,14 @@ sidebar_position: 99
 
 - [Android11 Image](https://github.com/radxa/manifests/releases/download/android11-radxa-20240724/Radxa_CM3I_Android11_r12-20240724-gpt.zip)
 
+## 软件工具
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar)：Rockchip RK356X ISP 调参工具，适用于 RK3566 / RK3568 系列产品的摄像头调试。
+
+:::tip
+使用 RK356X 平台 Debian12 系统调试 RKISP 效果时，需要手动更新系统中的 [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) 包。
+:::
+
 ## 硬件设计
 
 <Tabs queryString="model">

--- a/docs/som/cm/cm3j/download.md
+++ b/docs/som/cm/cm3j/download.md
@@ -24,6 +24,14 @@ Debian OS:
 
 - 系统镜像： [Debian b2](https://github.com/radxa-build/radxa-cm3j-rpi-cm4-io/releases/download/rsdk-b2/radxa-cm3j-rpi-cm4-io_bullseye_xfce_b2.output.img.xz)
 
+## 软件工具
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar)：Rockchip RK356X ISP 调参工具，适用于 RK3566 / RK3568 系列产品的摄像头调试。
+
+:::tip
+使用 RK356X 平台 Debian12 系统调试 RKISP 效果时，需要手动更新系统中的 [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) 包。
+:::
+
 ## 硬件设计
 
 - 数据手册

--- a/docs/zero/zero3/download.md
+++ b/docs/zero/zero3/download.md
@@ -78,6 +78,14 @@ Armbian 的默认凭据如下：
 非瑞莎官方维护的镜像，瑞莎不能保证完整功能，如遇到问题，请到 [OpenWRT 论坛](https://forum.openwrt.org/) 寻求帮助。
 :::
 
+## 软件工具
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar)：Rockchip RK356X ISP 调参工具，适用于 RK3566 / RK3568 系列产品的摄像头调试。
+
+:::tip
+使用 RK356X 平台 Debian12 系统调试 RKISP 效果时，需要手动更新系统中的 [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) 包。
+:::
+
 ## 百度网盘下载
 
 :::tip

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/getting-started/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/getting-started/download.md
@@ -42,6 +42,14 @@ Default Armbian credentials:
 
 For more images, please check: [Radxa ROCK 3A Release](https://github.com/radxa-build/rock-3a/releases/latest)
 
+## Software Tools
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar): Rockchip RK356X ISP tuning tool for camera debugging on RK3566 / RK3568 series products.
+
+:::tip
+When debugging RKISP effects on an RK356X platform with a Debian12 system, you need to manually update the [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) package in the system.
+:::
+
 ## Quality Certification
 
 ### CE EMC

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/download.md
@@ -20,6 +20,14 @@ Except for the above mirrors which have been fully tested officially, the other 
 - [Radxa ROCK 3B OpenWrt](https://openwrt.org/toh/hwdata/radxa/radxa_rock_3b)
 - [Radxa ROCK 3B OpenWrt ext4 sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-3b-ext4-sysupgrade.img.gz)
 
+## Software Tools
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar): Rockchip RK356X ISP tuning tool for camera debugging on RK3566 / RK3568 series products.
+
+:::tip
+When debugging RKISP effects on an RK356X platform with a Debian12 system, you need to manually update the [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) package in the system.
+:::
+
 ## Hardware Design
 
 <Tabs queryString="HardwareDesign">

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/getting-started/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/getting-started/download.md
@@ -48,3 +48,11 @@ Except for the above mirrors which have been fully tested officially, the other 
 
 - [Radxa ROCK 3C OpenWrt](https://openwrt.org/toh/hwdata/radxa/radxa_rock_3c)
 - [Radxa ROCK 3C OpenWrt ext4 sysupgrade image](https://downloads.openwrt.org/releases/25.12.0/targets/rockchip/armv8/openwrt-25.12.0-rockchip-armv8-radxa_rock-3c-ext4-sysupgrade.img.gz)
+
+## Software Tools
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar): Rockchip RK356X ISP tuning tool for camera debugging on RK3566 / RK3568 series products.
+
+:::tip
+When debugging RKISP effects on an RK356X platform with a Debian12 system, you need to manually update the [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) package in the system.
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/download.md
@@ -26,6 +26,14 @@ Android:
 
 - [Radxa_CM3_Android11-rkr12-20240719-gpt.zip](https://github.com/radxa/manifests/releases/download/android11-radxa-20240719/Radxa_CM3_Android11-rkr12-20240719-gpt.zip)
 
+## Software Tools
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar): Rockchip RK356X ISP tuning tool for camera debugging on RK3566 / RK3568 series products.
+
+:::tip
+When debugging RKISP effects on an RK356X platform with a Debian12 system, you need to manually update the [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) package in the system.
+:::
+
 ## Third Part Images
 
 - [Radxa CM3 IO OpenWrt](https://firmware-selector.openwrt.org/?version=SNAPSHOT&target=rockchip%2Farmv8&id=radxa_cm3-io)

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3i/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3i/download.md
@@ -20,6 +20,14 @@ sidebar_position: 99
 
 - [Android11 Image](https://github.com/radxa/manifests/releases/download/android11-radxa-20240724/Radxa_CM3I_Android11_r12-20240724-gpt.zip)
 
+## Software Tools
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar): Rockchip RK356X ISP tuning tool for camera debugging on RK3566 / RK3568 series products.
+
+:::tip
+When debugging RKISP effects on an RK356X platform with a Debian12 system, you need to manually update the [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) package in the system.
+:::
+
 ## Hardware Design
 
 <Tabs queryString="model">

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3j/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3j/download.md
@@ -24,6 +24,14 @@ Debian OS:
 
 - System Image: [Debian b2](https://github.com/radxa-build/radxa-cm3j-rpi-cm4-io/releases/download/rsdk-b2/radxa-cm3j-rpi-cm4-io_bullseye_xfce_b2.output.img.xz)
 
+## Software Tools
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar): Rockchip RK356X ISP tuning tool for camera debugging on RK3566 / RK3568 series products.
+
+:::tip
+When debugging RKISP effects on an RK356X platform with a Debian12 system, you need to manually update the [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) package in the system.
+:::
+
 ## Hardware Design
 
 - Datasheet

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/download.md
@@ -78,6 +78,14 @@ Default Armbian credentials:
 These images are not maintained by Radxa officially. Radxa cannot guarantee full functionality. If you encounter any problems, please seek help from the [OpenWRT Forum](https://forum.openwrt.org/).
 :::
 
+## Software Tools
+
+- [RKISP Tuner](https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar): Rockchip RK356X ISP tuning tool for camera debugging on RK3566 / RK3568 series products.
+
+:::tip
+When debugging RKISP effects on an RK356X platform with a Debian12 system, you need to manually update the [camera_engine_rkaiq](https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb) package in the system.
+:::
+
 ## Quality Certification
 
 ## Enclosures


### PR DESCRIPTION
## Summary

为所有基于 Rockchip RK356X（RK3566 / RK3568）处理器的产品「资源下载汇总」页面补充摄像头调试工具：

1. **Camera RKISP Tuner 工具**下载链接：`https://dl.radxa.com/tools/windows/RKISP_Tuner_v2.3.7_Release.rar`
2. **提示**：使用 RK356X 平台 Debian12 系统调试 RKISP 效果时，需要手动更新系统中的 `camera_engine_rkaiq` 包（包名带跳转链接：`https://dl.radxa.com/tools/windows/camera_engine_rkaiq_rk3568_rkaiq_v6.9.0_arm64.deb`）

中英文同步修改（14 个文件，7 个产品 × 2 种语言）。

## 覆盖产品（RK356X 家族）

- ROCK 3A / ROCK 3B / ROCK 3C
- ZERO 3W / 3E
- Radxa CM3 / CM3I / CM3J

## 设计说明

- 新增 `## 软件工具` / `## Software Tools` 区块，与已有 RK3576 / RK3588 系列（PR #1967）的写法保持一致
- `camera_engine_rkaiq` 提示使用 `:::tip` 提示块
- **不包含** Radxa E25：虽为 RK3566 平台，但它是网络扩展板，无摄像头接口，RKISP 调参与之无关

## 来源

- 需求来自售后技术支持群（2026-08-06 吴闽龙）

## 影响范围

- 仅 docs.radxa.com 产品下载页内容新增，无结构性改动
