### PR TITLE
docs: remove width scaling on rock3a/rock3c camera connection images

### DIFF
--- a/docs/rock3/rock3a/accessories/camera.md
+++ b/docs/rock3/rock3a/accessories/camera.md
@@ -38,7 +38,7 @@ sudo rsetup
 请注意 camera 排线的接口朝向！
 :::
 
-<img src="../../../img/rock3/3a/rock3a-rpi-imx219.webp" width = "500" alt="rock 3a rpi imx219"/>
+<img src="../../../img/rock3/3a/rock3a-rpi-imx219.webp" alt="rock 3a rpi imx219"/>
 
 ### 图像预览
 

--- a/docs/rock3/rock3c/accessories/camera.md
+++ b/docs/rock3/rock3c/accessories/camera.md
@@ -25,7 +25,7 @@ Radxa ROCK 3C 拥有一个 15 PIN 的 CSI 接口,接口定义如下:
 请注意 camera 排线的接口朝向！
 :::
 
-<img src="../../../img/rock3/3c/rock3c-camera-connect.webp" width = "400" alt="rock 3c camera connect"/>
+<img src="../../../img/rock3/3c/rock3c-camera-connect.webp" alt="rock 3c camera connect"/>
 
 ### 2. [rsetup 开启摄像头 overlay](../system-config/rsetup)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/accessories/camera.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/accessories/camera.md
@@ -38,7 +38,7 @@ The hardware connections are as follows.
 Please note the orientation of the camera cable!
 :::
 
-<img src="../../../img/rock3/3a/rock3a-rpi-imx219.webp" width = "500" alt="rock 3a rpi imx219"/>
+<img src="../../../img/rock3/3a/rock3a-rpi-imx219.webp" alt="rock 3a rpi imx219"/>
 
 ### Image preview
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/accessories/camera.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3c/accessories/camera.md
@@ -25,7 +25,7 @@ Currently supported cameras are:
 Please pay attention to the direction of the camera cable interface!
 :::
 
-<img src="../../../img/rock3/3c/rock3c-camera-connect.webp" width = "400" alt="rock 3c camera connect"/>
+<img src="../../../img/rock3/3c/rock3c-camera-connect.webp" alt="rock 3c camera connect"/>
 
 ### 2. [rsetup enable camera overlay](../system-config/rsetup)
 


### PR DESCRIPTION
## 变更内容

继 PR #1973（已合并，替换 ROCK 3A / ROCK 3C 摄像头硬件连接示意图）之后，本次调整图片显示方式：

- 移除 `rock3a/accessories/camera.md` 硬件连接图的 `width = "500"` 缩放限制
- 移除 `rock3c/accessories/camera.md` 硬件连接图的 `width = "400"` 缩放限制
- 中英文页面同步修改

## 背景

新替换的连接示意图为宽幅图（约 2100×1000 px），原 `width` 限制导致页面显示偏小。去掉缩放后图片按原始尺寸正常显示（页面容器自动限制最大宽度），连接细节更清晰。

## 影响范围

- `docs/rock3/rock3a/accessories/camera.md`
- `docs/rock3/rock3c/accessories/camera.md`
- 对应 `i18n/en` 英文版

无其他文案变更。
