### PR TITLE
docs(radxa-os): fix heading levels and note format in remote-access template

### DIFF
--- a/docs/common/radxa-os/_remote-access.mdx
+++ b/docs/common/radxa-os/_remote-access.mdx
@@ -1,10 +1,10 @@
 import { PreView } from "@site/src/utils/docs";
 
-### SSH
+## SSH
 
 本教程介绍如何使用 SSH 从另一台计算机远程访问电路板。
 
-#### 查看用户名
+### 查看用户名
 
 在电路板上打开终端，在终端中输入以下命令查看用户名
 
@@ -17,9 +17,9 @@ import { PreView } from "@site/src/utils/docs";
 
 该命令显示当前用户的用户名，如上图所示，当前用户的用户名为 radxa
 
-#### 查看 IP 地址
+### 查看 IP 地址
 
-##### 通过命令查看 IP
+#### 通过命令查看 IP
 
 在电路板上打开终端，在终端中输入以下命令查看 IP 地址：
 
@@ -46,7 +46,7 @@ import { PreView } from "@site/src/utils/docs";
        valid_lft forever preferred_lft forever
 ```
 
-##### 使用 Angryip 查找 IP
+#### 使用 Angryip 查找 IP
 
 在无法直接操作主板获取无屏幕或远程 IP 地址时，可以使用此方法查找 IP 地址。
 
@@ -58,7 +58,7 @@ import { PreView } from "@site/src/utils/docs";
 
 - Ctrl + F 查找 `rock` 关键字，找到主板的 IP 地址。
 
-#### 检查 SSH 服务状态
+### 检查 SSH 服务状态
 
 在终端中运行以下命令：
 
@@ -117,17 +117,17 @@ May 08 07:53:22 radxa-zero sshd[783]: pam_env(sshd:session): deprecated reading 
   `}
 </PreView>
 
-#### SSH 连接到电路板
+### SSH 连接到电路板
 
 ```bash
 ssh [username]@[IP address] # or ssh [username]@[hostname]
 ```
 
-### VNC
+## VNC
 
 本教程介绍如何使用 VNC 从 Windows 计算机远程访问系统。
 
-#### 安装 VNC 服务器
+### 安装 VNC 服务器
 
 1. 打开终端应用程序，输入以下命令更新软件包列表。
 
@@ -161,11 +161,11 @@ ssh [username]@[IP address] # or ssh [username]@[hostname]
   `}
 </PreView>
 
-::注意
+:::note
 您是否要输入只允许查看的密码（y/n）？ n 提示只允许查看，您是否要选择否并输入 n，这样您就可以根据自己的情况进行远程操作，而不仅仅是观看？
 :::
 
-#### 配置 VNC 服务器
+### 配置 VNC 服务器
 
 1. TigerVNC 启动后，将创建一个包含 VNC 服务器 IP 地址和端口号（通常为 5901）的 VNC 会话。要改变 VNC 服务器的配置方式，首先要使用以下命令停止运行在 5901 端口的 VNC 服务器实例：
 
@@ -224,20 +224,20 @@ ssh [username]@[IP address] # or ssh [username]@[hostname]
 
 5. 在 VNC 查看器上测试连接： 在 Windows PC 上打开 VNC 查看器，输入产品的 IP 地址和端口号，然后使用 VNC 服务器的用户名和密码进行验证。
 
-#### 在 Windows PC 上安装 VNC 查看器
+### 在 Windows PC 上安装 VNC 查看器
 
 1. 在浏览器上进入 VNC 查看器下载页面，如 https://www.realvnc.com/en/connect/download/viewer/。
 2. 下载并安装 VNC 查看器。
 
-#### 连接设置
+### 连接设置
 
 1. 在 VNC 查看器上输入产品的 IP 地址和端口号。2.
 2. 使用 VNC 服务器的用户名和密码进行验证。
 3. 连接成功后，即可进行远程控制。
 
-### TeamViewer
+## TeamViewer
 
-#### 安装 TeamViewer
+### 安装 TeamViewer
 
 <PreView params={{ model: props.model }}>
   {`
@@ -246,7 +246,7 @@ ssh [username]@[IP address] # or ssh [username]@[hostname]
   `}
 </PreView>
 
-#### 配置 TeamViewer
+### 配置 TeamViewer
 
 <PreView params={{ model: props.model }}>
   {`
@@ -254,7 +254,7 @@ ssh [username]@[IP address] # or ssh [username]@[hostname]
   `}
 </PreView>
 
-#### 卸载 xfce4-screensaver
+### 卸载 xfce4-screensaver
 
 :::info
 此程序修复了 TeamViewer 的键盘和鼠标控件因长时间挂起而无法工作的问题。
@@ -266,7 +266,7 @@ ssh [username]@[IP address] # or ssh [username]@[hostname]
   `}
 </PreView>
 
-#### 配置虚拟显示器
+### 配置虚拟显示器
 
 :::info
 如果已连接真实显示器，则此步骤为可选步骤。
@@ -306,6 +306,6 @@ Section "Screen"
 EndSection
 ```
 
-#### 连接到 TeamViewer
+### 连接到 TeamViewer
 
 您可以参考 [TeamViewer 官方文档](https://community.teamviewer.com/Chinese/kb/articles/109101-%E9%80%9A%E8%BF%87teamviewer-%E8%BF%9E%E6%8E%A5)。

--- a/docs/common/radxa-os/xfce/_remote-access.mdx
+++ b/docs/common/radxa-os/xfce/_remote-access.mdx
@@ -1,10 +1,10 @@
 import { PreView } from "@site/src/utils/docs";
 
-### SSH
+## SSH
 
 本教程介绍如何使用 SSH 从另一台计算机远程访问电路板。
 
-#### 查看用户名
+### 查看用户名
 
 在电路板上打开终端，在终端中输入以下命令查看用户名
 
@@ -17,9 +17,9 @@ import { PreView } from "@site/src/utils/docs";
 
 该命令显示当前用户的用户名，如上图所示，当前用户的用户名为 radxa
 
-#### 查看 IP 地址
+### 查看 IP 地址
 
-##### 通过命令查看 IP
+#### 通过命令查看 IP
 
 在电路板上打开终端，在终端中输入以下命令查看 IP 地址：
 
@@ -46,7 +46,7 @@ import { PreView } from "@site/src/utils/docs";
        valid_lft forever preferred_lft forever
 ```
 
-##### 使用 Angryip 查找 IP
+#### 使用 Angryip 查找 IP
 
 在无法直接操作主板获取无屏幕或远程 IP 地址时，可以使用此方法查找 IP 地址。
 
@@ -58,7 +58,7 @@ import { PreView } from "@site/src/utils/docs";
 
 - Ctrl + F 查找 `rock` 关键字，找到主板的 IP 地址。
 
-#### 检查 SSH 服务状态
+### 检查 SSH 服务状态
 
 在终端中运行以下命令：
 
@@ -109,17 +109,17 @@ May 08 07:53:22 radxa-zero sshd[783]: pam_env(sshd:session): deprecated reading 
   `}
 </PreView>
 
-#### SSH 连接到电路板
+### SSH 连接到电路板
 
 ```bash
 ssh [username]@[IP address] # or ssh [username]@[hostname]
 ```
 
-### VNC
+## VNC
 
 本教程介绍如何使用 VNC 从 Windows 计算机远程访问系统。
 
-#### 安装 VNC 服务器
+### 安装 VNC 服务器
 
 1. 打开终端应用程序，输入以下命令更新软件包列表。
 
@@ -153,11 +153,11 @@ ssh [username]@[IP address] # or ssh [username]@[hostname]
   `}
 </PreView>
 
-::注意
+:::note
 您是否要输入只允许查看的密码（y/n）？ n 提示只允许查看，您是否要选择否并输入 n，这样您就可以根据自己的情况进行远程操作，而不仅仅是观看？
 :::
 
-#### 配置 VNC 服务器
+### 配置 VNC 服务器
 
 1. TigerVNC 启动后，将创建一个包含 VNC 服务器 IP 地址和端口号（通常为 5901）的 VNC 会话。要改变 VNC 服务器的配置方式，首先要使用以下命令停止运行在 5901 端口的 VNC 服务器实例：
 
@@ -216,20 +216,20 @@ ssh [username]@[IP address] # or ssh [username]@[hostname]
 
 5. 在 VNC 查看器上测试连接： 在 Windows PC 上打开 VNC 查看器，输入产品的 IP 地址和端口号，然后使用 VNC 服务器的用户名和密码进行验证。
 
-#### 在 Windows PC 上安装 VNC 查看器
+### 在 Windows PC 上安装 VNC 查看器
 
 1. 在浏览器上进入 VNC 查看器下载页面，如 https://www.realvnc.com/en/connect/download/viewer/。
 2. 下载并安装 VNC 查看器。
 
-#### 连接设置
+### 连接设置
 
 1. 在 VNC 查看器上输入产品的 IP 地址和端口号。2.
 2. 使用 VNC 服务器的用户名和密码进行验证。
 3. 连接成功后，即可进行远程控制。
 
-### TeamViewer
+## TeamViewer
 
-#### 安装 TeamViewer
+### 安装 TeamViewer
 
 <PreView params={{ model: props.model }}>
   {`
@@ -238,7 +238,7 @@ ssh [username]@[IP address] # or ssh [username]@[hostname]
   `}
 </PreView>
 
-#### 配置 TeamViewer
+### 配置 TeamViewer
 
 <PreView params={{ model: props.model }}>
   {`
@@ -246,7 +246,7 @@ ssh [username]@[IP address] # or ssh [username]@[hostname]
   `}
 </PreView>
 
-#### 卸载 xfce4-screensaver
+### 卸载 xfce4-screensaver
 
 :::info
 此程序修复了 TeamViewer 的键盘和鼠标控件因长时间挂起而无法工作的问题。
@@ -258,7 +258,7 @@ ssh [username]@[IP address] # or ssh [username]@[hostname]
   `}
 </PreView>
 
-#### 配置虚拟显示器
+### 配置虚拟显示器
 
 :::info
 如果已连接真实显示器，则此步骤为可选步骤。
@@ -298,6 +298,6 @@ Section "Screen"
 EndSection
 ```
 
-#### 连接到 TeamViewer
+### 连接到 TeamViewer
 
 您可以参考 [TeamViewer 官方文档](https://community.teamviewer.com/Chinese/kb/articles/109101-%E9%80%9A%E8%BF%87teamviewer-%E8%BF%9E%E6%8E%A5)。

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_remote-access.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_remote-access.mdx
@@ -1,10 +1,10 @@
 import { PreView } from "@site/src/utils/docs";
 
-### SSH
+## SSH
 
 This is a tutorial on how to access the board remotely from another computer using SSH.
 
-#### View username
+### View username
 
 Open a terminal on the board and enter the following command in the terminal to view the username
 
@@ -17,9 +17,9 @@ Open a terminal on the board and enter the following command in the terminal to 
 
 This command displays the username of the current user, as shown above, the current user's username is radxa
 
-#### View IP address
+### View IP address
 
-##### View IP by command
+#### View IP by command
 
 Open a terminal on the board and enter the following command in the terminal to view the IP address:
 
@@ -46,7 +46,7 @@ The ip address on the same network segment as the host is the ip address we need
        valid_lft forever preferred_lft forever
 ```
 
-##### Finding IPs with Angryip
+#### Finding IPs with Angryip
 
 This method can be used to look up an ip address when you can't operate the motherboard directly to get an ip address without a screen or remotely.
 
@@ -58,7 +58,7 @@ This method can be used to look up an ip address when you can't operate the moth
 
 - Ctrl + F Look for the `rock` keyword to find the IP address of the board.
 
-#### Checking SSH Service Status
+### Checking SSH Service Status
 
 Run the following command in a terminal:
 
@@ -117,17 +117,17 @@ May 08 07:53:22 radxa-zero sshd[783]: pam_env(sshd:session): deprecated reading 
   `}
 </PreView>
 
-#### SSH connection to the board
+### SSH connection to the board
 
 ```bash
 ssh [username]@[IP address] # or ssh [username]@[hostname]
 ```
 
-### VNC
+## VNC
 
 This is a tutorial on how to remotely access your system from a Windows computer using VNC.
 
-#### Installing VNC Server
+### Installing VNC Server
 
 1. Open the Terminal application and enter the following command to update the package list.
 
@@ -165,7 +165,7 @@ This is a tutorial on how to remotely access your system from a Windows computer
 Would you like to enter a view-only password (y/n)? n Prompt for view-only, would you like to select no and enter n so that you can operate remotely instead of just watching, depending on your situation?
 :::
 
-#### Configuring the VNC Server
+### Configuring the VNC Server
 
 1. Once TigerVNC starts, it will create a VNC session containing the IP address and port number (usually 5901) of the VNC server. To change the way the VNC server is configured, first stop the instance of the VNC server running on port 5901 with the following command:
 
@@ -224,20 +224,20 @@ Edit the xstartup configuration file as follows:
 
 5. Test the connection on the VNC viewer: On your Windows PC, open the VNC viewer, enter the IP address and port number of your product, and then authenticate with the VNC server's username and password.
 
-#### Installing the VNC Viewer on a Windows PC
+### Installing the VNC Viewer on a Windows PC
 
 1. Go to the VNC viewer download page on your web browser, e.g. https://www.realvnc.com/en/connect/download/viewer/
 2. Download and install the VNC viewer.
 
-#### Connection Setup
+### Connection Setup
 
 1. On the VNC viewer, enter the IP address and port number of the product. 2.
 2. Use the VNC server's user name and password to authenticate.
 3. After a successful connection, you can remote control.
 
-### TeamViewer
+## TeamViewer
 
-#### Installing TeamViewer
+### Installing TeamViewer
 
 <PreView params={{ model: props.model }}>
   {`
@@ -246,7 +246,7 @@ Edit the xstartup configuration file as follows:
   `}
 </PreView>
 
-#### configure TeamViewer
+### configure TeamViewer
 
 <PreView params={{ model: props.model }}>
   {`
@@ -254,7 +254,7 @@ Edit the xstartup configuration file as follows:
   `}
 </PreView>
 
-#### uninstall xfce4-screensaver
+### uninstall xfce4-screensaver
 
 :::info
 This procedure fixes a problem with TeamViewer's keyboard and mouse controls not working due to prolonged hang time.
@@ -266,7 +266,7 @@ This procedure fixes a problem with TeamViewer's keyboard and mouse controls not
   `}
 </PreView>
 
-#### Configuring virtual monitors
+### Configuring virtual monitors
 
 :::info
 This step is optional if a real monitor is connected.
@@ -306,6 +306,6 @@ Section "Screen"
 EndSection
 ```
 
-#### Connecting to TeamViewer
+### Connecting to TeamViewer
 
 You can refer to [TeamViewer official documentation](https://community.teamviewer.com/Chinese/kb/articles/109101-%E9%80%9A%E8%BF%87teamviewer-%E8%BF%9E%E6%8E%A5).

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/xfce/_remote-access.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/xfce/_remote-access.mdx
@@ -1,10 +1,10 @@
 import { PreView } from "@site/src/utils/docs";
 
-### SSH
+## SSH
 
 This is a tutorial on how to access the board remotely from another computer using SSH.
 
-#### View username
+### View username
 
 Open a terminal on the board and enter the following command in the terminal to view the username
 
@@ -17,9 +17,9 @@ Open a terminal on the board and enter the following command in the terminal to 
 
 This command displays the username of the current user, as shown above, the current user's username is radxa
 
-#### View IP address
+### View IP address
 
-##### View IP by command
+#### View IP by command
 
 Open a terminal on the board and enter the following command in the terminal to view the IP address:
 
@@ -46,7 +46,7 @@ The ip address on the same network segment as the host is the ip address we need
        valid_lft forever preferred_lft forever
 ```
 
-##### Finding IPs with Angryip
+#### Finding IPs with Angryip
 
 This method can be used to look up an ip address when you can't operate the motherboard directly to get an ip address without a screen or remotely.
 
@@ -58,7 +58,7 @@ This method can be used to look up an ip address when you can't operate the moth
 
 - Ctrl + F Look for the `rock` keyword to find the IP address of the board.
 
-#### Checking SSH Service Status
+### Checking SSH Service Status
 
 Run the following command in a terminal:
 
@@ -109,17 +109,17 @@ May 08 07:53:22 radxa-zero sshd[783]: pam_env(sshd:session): deprecated reading 
   `}
 </PreView>
 
-#### SSH connection to the board
+### SSH connection to the board
 
 ```bash
 ssh [username]@[IP address] # or ssh [username]@[hostname]
 ```
 
-### VNC
+## VNC
 
 This is a tutorial on how to remotely access your system from a Windows computer using VNC.
 
-#### Installing VNC Server
+### Installing VNC Server
 
 1. Open the Terminal application and enter the following command to update the package list.
 
@@ -157,7 +157,7 @@ This is a tutorial on how to remotely access your system from a Windows computer
 Would you like to enter a view-only password (y/n)? n Prompt for view-only, would you like to select no and enter n so that you can operate remotely instead of just watching, depending on your situation?
 :::
 
-#### Configuring the VNC Server
+### Configuring the VNC Server
 
 1. Once TigerVNC starts, it will create a VNC session containing the IP address and port number (usually 5901) of the VNC server. To change the way the VNC server is configured, first stop the instance of the VNC server running on port 5901 with the following command:
 
@@ -216,20 +216,20 @@ Edit the xstartup configuration file as follows:
 
 5. Test the connection on the VNC viewer: On your Windows PC, open the VNC viewer, enter the IP address and port number of your product, and then authenticate with the VNC server's username and password.
 
-#### Installing the VNC Viewer on a Windows PC
+### Installing the VNC Viewer on a Windows PC
 
 1. Go to the VNC viewer download page on your web browser, e.g. https://www.realvnc.com/en/connect/download/viewer/
 2. Download and install the VNC viewer.
 
-#### Connection Setup
+### Connection Setup
 
 1. On the VNC viewer, enter the IP address and port number of the product. 2.
 2. Use the VNC server's user name and password to authenticate.
 3. After a successful connection, you can remote control.
 
-### TeamViewer
+## TeamViewer
 
-#### Installing TeamViewer
+### Installing TeamViewer
 
 <PreView params={{ model: props.model }}>
   {`
@@ -238,7 +238,7 @@ Edit the xstartup configuration file as follows:
   `}
 </PreView>
 
-#### configure TeamViewer
+### configure TeamViewer
 
 <PreView params={{ model: props.model }}>
   {`
@@ -246,7 +246,7 @@ Edit the xstartup configuration file as follows:
   `}
 </PreView>
 
-#### uninstall xfce4-screensaver
+### uninstall xfce4-screensaver
 
 :::info
 This procedure fixes a problem with TeamViewer's keyboard and mouse controls not working due to prolonged hang time.
@@ -258,7 +258,7 @@ This procedure fixes a problem with TeamViewer's keyboard and mouse controls not
   `}
 </PreView>
 
-#### Configuring virtual monitors
+### Configuring virtual monitors
 
 :::info
 This step is optional if a real monitor is connected.
@@ -298,6 +298,6 @@ Section "Screen"
 EndSection
 ```
 
-#### Connecting to TeamViewer
+### Connecting to TeamViewer
 
 You can refer to [TeamViewer official documentation](https://community.teamviewer.com/Chinese/kb/articles/109101-%E9%80%9A%E8%BF%87teamviewer-%E8%BF%9E%E6%8E%A5).


### PR DESCRIPTION
## Summary

Optimize the remote-access template tutorials that back the Remote Access pages across products (rock3c, rock3a, cm3j, zero series, sbc template) plus the xfce basic software configuration page:

1. **Fix heading hierarchy**: The imported MDX content previously started at `###` (H3) directly under the H1 wrapper page, skipping H2. Promoted all content headings one level — `###` → `##` (SSH / VNC / TeamViewer), `####` → `###` (subsections), `#####` → `####` (sub-subsections) — so the page renders a clean H1 → H2 → H3 → H4 hierarchy without skipped levels.
2. **Fix malformed admonition**: The zh files had a broken note block `::注意 ... :::` (missing one colon). Changed to the standard `:::note ... :::` convention, matching the en versions and other zh files in the repo.

Files changed (all zh + en pairs in sync):
- `docs/common/radxa-os/_remote-access.mdx` + en counterpart
- `docs/common/radxa-os/xfce/_remote-access.mdx` + en counterpart

## Test plan

- `github_pr_guard.py pr 1975` passed: 4 files, bilingual pairs complete, no blocking reasons.
