### PR TITLE
docs(airbox-q900): add QDL GitHub download link and Ubuntu udev rules for EDL verification

### DIFF
--- a/docs/fogwise/airbox-q900/download.md
+++ b/docs/fogwise/airbox-q900/download.md
@@ -24,7 +24,8 @@ sidebar_position: 150
 
 ## 软件工具
 
-- [QDL 工具](https://softwarecenter.qualcomm.com/catalog/item/Qualcomm_Device_Loader)
+- [QDL 工具（Qualcomm Software Center）](https://softwarecenter.qualcomm.com/catalog/item/Qualcomm_Device_Loader)
+- [QDL 工具（Qualcomm GitHub 仓库）](https://github.com/linux-msm/qdl)
 
 Qualcomm Device Loader (QDL) 是 Qualcomm 提供的用于刷写 Qualcomm 芯片的工具。
 

--- a/docs/fogwise/airbox-q900/getting-started/install-system/onboard-ufs.md
+++ b/docs/fogwise/airbox-q900/getting-started/install-system/onboard-ufs.md
@@ -62,7 +62,38 @@ Fogwise® AIRbox Q900 板载 128GB UFS。
 
 <TabItem value="Ubuntu">
 
-使用 `lsusb` 命令查看设备是否进入 QDL 模式。
+1. 创建 udev 规则文件
+
+使用以下命令创建 udev 规则文件。
+
+<NewCodeBlock tip="Ubuntu$" type="host">
+
+```bash
+sudo nano /etc/udev/rules.d/51-qcom-usb.rules
+```
+
+</NewCodeBlock>
+
+2. 添加以下内容
+
+```text
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="05c6", ATTRS{idProduct}=="9008", MODE="0666", GROUP="plugdev"
+```
+
+3. 保存文件后，重新加载 udev 规则并触发设备检测
+
+<NewCodeBlock tip="Ubuntu$" type="host">
+
+```bash
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+</NewCodeBlock>
+
+4. 重新插拔 USB 数据线，使规则生效
+
+5. 使用 `lsusb` 命令查看设备是否进入 QDL 模式
 
 <NewCodeBlock tip="Ubuntu$" type="host">
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/download.md
@@ -12,7 +12,8 @@ sidebar_position: 150
 
 ## Software Tools
 
-- [QDL Tool](https://softwarecenter.qualcomm.com/catalog/item/Qualcomm_Device_Loader)
+- [QDL Tool (Qualcomm Software Center)](https://softwarecenter.qualcomm.com/catalog/item/Qualcomm_Device_Loader)
+- [QDL Tool (Qualcomm GitHub Repository)](https://github.com/linux-msm/qdl)
 
 Qualcomm Device Loader (QDL) is a tool provided by Qualcomm for flashing Qualcomm chips.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/getting-started/install-system/onboard-ufs.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/getting-started/install-system/onboard-ufs.md
@@ -63,7 +63,38 @@ After successfully installing the driver, try unplugging and replugging the USB 
 
 <TabItem value="Ubuntu">
 
-Use the `lsusb` command to check if the device has entered QDL mode.
+1. Create a udev rules file
+
+Use the following command to create a udev rules file.
+
+<NewCodeBlock tip="Ubuntu$" type="host">
+
+```bash
+sudo nano /etc/udev/rules.d/51-qcom-usb.rules
+```
+
+</NewCodeBlock>
+
+2. Add the following content
+
+```text
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="05c6", ATTRS{idProduct}=="9008", MODE="0666", GROUP="plugdev"
+```
+
+3. After saving the file, reload the udev rules and trigger device detection
+
+<NewCodeBlock tip="Ubuntu$" type="host">
+
+```bash
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+</NewCodeBlock>
+
+4. Replug the USB cable to apply the rules
+
+5. Use the `lsusb` command to check if the device has entered QDL mode
 
 <NewCodeBlock tip="Ubuntu$" type="host">
 


### PR DESCRIPTION
## Summary

Improve the Fogwise® AIRbox Q900 documentation for QDL tool download and Ubuntu EDL mode verification.

### Changes

1. **Download page** (`fogwise/airbox-q900/download.md`, zh + en)
   - Add the Qualcomm GitHub repository (linux-msm/qdl) as an additional QDL tool download source, alongside the existing Qualcomm Software Center link.

2. **Install system to onboard UFS** (`fogwise/airbox-q900/getting-started/install-system/onboard-ufs.md`, zh + en)
   - Add a step-by-step udev rule setup in the "Verifying EDL Mode > Ubuntu" section before the existing `lsusb` check:
     - Create `/etc/udev/rules.d/51-qcom-usb.rules` with vendor/product IDs `05c6:9008`
     - Reload udev rules and trigger device detection
     - Replug the USB cable
   - The existing `lsusb` verification steps remain unchanged after the new steps.

### Background

- Ubuntu users without proper udev permissions may fail to see the Qualcomm QDL device (05c6:9008) with `lsusb`, which blocks the subsequent `qdl` flashing flow. Adding the udev rule steps reduces this common setup failure.
- QDL is also maintained on GitHub (linux-msm/qdl); linking it gives users an alternative official source.

### Scope

- Docs only, 4 files (zh + en), single product scope (`fogwise/airbox-q900`).
