### PR TITLE
docs(airbox-q900): add per-platform download tabs with QDL compile steps for Ubuntu 26.04

### DIFF
--- a/docs/fogwise/airbox-q900/getting-started/install-system/onboard-ufs.md
+++ b/docs/fogwise/airbox-q900/getting-started/install-system/onboard-ufs.md
@@ -121,6 +121,62 @@ Bus 001 Device 012: ID 05c6:9008 Qualcomm, Inc. Gobi Wireless Modem (QDL mode)
 
 进入 [资源汇总下载](../../download.md) 页面下载启动固件和系统镜像文件。
 
+<Tabs queryString="download-platform">
+
+<TabItem value="Windows">
+
+进入 [资源汇总下载](../../download.md) 页面下载启动固件和系统镜像文件和 QDL 工具。
+
+</TabItem>
+
+<TabItem value="Ubuntu 22.04 / 24.04">
+
+进入 [资源汇总下载](../../download.md) 页面下载启动固件和系统镜像文件和 QDL 工具。
+
+</TabItem>
+
+<TabItem value="Ubuntu 26.04">
+
+Ubuntu 26.04 需要自行编译 QDL 工具，编译步骤参考 [QDL 官方文档](https://github.com/linux-msm/qdl/blob/master/README.md)。
+
+1. 安装编译依赖
+
+<NewCodeBlock tip="Ubuntu$" type="host">
+
+```bash
+sudo apt install libxml2-dev libusb-1.0-0-dev libzip-dev meson ninja-build help2man
+```
+
+</NewCodeBlock>
+
+2. 下载 QDL 源码
+
+<NewCodeBlock tip="Ubuntu$" type="host">
+
+```bash
+git clone https://github.com/linux-msm/qdl.git
+cd qdl
+```
+
+</NewCodeBlock>
+
+3. 编译 QDL
+
+<NewCodeBlock tip="Ubuntu$" type="host">
+
+```bash
+meson setup build
+meson compile -C build
+```
+
+</NewCodeBlock>
+
+编译完成后，`build/qdl` 即为 QDL 可执行文件。
+
+</TabItem>
+
+</Tabs>
+
 ### 设置环境变量
 
 设置环境变量，可以简化后续的烧录操作，简化命令。

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/getting-started/install-system/onboard-ufs.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/getting-started/install-system/onboard-ufs.md
@@ -122,6 +122,62 @@ This section describes how to install the system onto the onboard UFS of the Fog
 
 Go to the [Resource Downloads](../../download.md) page to download the boot firmware and system image files.
 
+<Tabs queryString="download-platform">
+
+<TabItem value="Windows">
+
+Go to the [Resource Downloads](../../download.md) page to download the boot firmware, system image files, and the QDL tool.
+
+</TabItem>
+
+<TabItem value="Ubuntu 22.04 / 24.04">
+
+Go to the [Resource Downloads](../../download.md) page to download the boot firmware, system image files, and the QDL tool.
+
+</TabItem>
+
+<TabItem value="Ubuntu 26.04">
+
+For Ubuntu 26.04, you need to compile the QDL tool from source. For compilation steps, refer to the [official QDL documentation](https://github.com/linux-msm/qdl/blob/master/README.md).
+
+1. Install build dependencies
+
+<NewCodeBlock tip="Ubuntu$" type="host">
+
+```bash
+sudo apt install libxml2-dev libusb-1.0-0-dev libzip-dev meson ninja-build help2man
+```
+
+</NewCodeBlock>
+
+2. Download the QDL source code
+
+<NewCodeBlock tip="Ubuntu$" type="host">
+
+```bash
+git clone https://github.com/linux-msm/qdl.git
+cd qdl
+```
+
+</NewCodeBlock>
+
+3. Compile QDL
+
+<NewCodeBlock tip="Ubuntu$" type="host">
+
+```bash
+meson setup build
+meson compile -C build
+```
+
+</NewCodeBlock>
+
+After compilation, `build/qdl` is the QDL executable.
+
+</TabItem>
+
+</Tabs>
+
 ### Set Environment Variables
 
 Setting environment variables can simplify subsequent flashing operations and commands.


### PR DESCRIPTION
## Summary

Add per-platform download tabs to the Fogwise® AIRbox Q900 "Install System to Onboard UFS" tutorial (zh + en).

### Changes

In the **Download Files** section of `fogwise/airbox-q900/getting-started/install-system/onboard-ufs.md`:

- Added a `<Tabs>` group with three options:
  - **Windows**: point users to the Resource Downloads page for boot firmware, system image files, and the QDL tool.
  - **Ubuntu 22.04 / 24.04**: same guidance as Windows.
  - **Ubuntu 26.04**: QDL tool compilation steps from the official [linux-msm/qdl README](https://github.com/linux-msm/qdl/blob/master/README.md) (build section only): install dependencies, clone the source, then `meson setup build` + `meson compile -C build`. Notes that `build/qdl` is the resulting executable.

### Background

- On newer Ubuntu versions (26.04), the prebuilt QDL Linux binary may not be available/suitable, so users need to compile QDL from source. The tabs make the download instructions match each platform's workflow.

### Scope

- Docs only, 2 files (zh + en), single product scope (`fogwise/airbox-q900`).
