### PR TITLE
docs(dragon-q6a): add MIPI DSI connector spec and third-party display note

### DIFF
--- a/docs/dragon/q6a/hardware-use/mipi-dsi.md
+++ b/docs/dragon/q6a/hardware-use/mipi-dsi.md
@@ -13,9 +13,13 @@ sidebar_position: 11
 | [Radxa Display 10 FHD](https://radxa.com/products/accessories/display-10fhd) |        10.1        | 1200\*1920 |
 |   [Radxa Display 8 HD](https://radxa.com/products/accessories/display-8hd)   |         8          | 800\*1280  |
 
+:::note
+仅支持上表列出的瑞莎官方显示器。第三方显示器（例如 Raspberry Pi 7\" 触控屏）未经官方适配：即使通过转接排线完成物理连接，显示与触控功能仍取决于系统镜像中是否包含匹配的 panel driver / 设备树，无法保证兼容。
+:::
+
 ## 硬件连接
 
-将 MIPI 显示屏通过 FPC 排线连接到 Dragon Q6A 的 MIPI DSI 接口。
+将 MIPI 显示屏通过 FPC 排线连接到 Dragon Q6A 的 MIPI DSI 接口（39-Pin / 0.3mm 间距 FPC 接口）。
 
 :::tip 接口位置
 可以参考 [硬件信息](./hardware-info) 教程找到对应硬件接口位置

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/hardware-use/mipi-dsi.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/hardware-use/mipi-dsi.md
@@ -13,9 +13,13 @@ The Dragon Q6A has one 4-lane MIPI DSI interface on board for connecting MIPI di
 | [Radxa Display 10 FHD](https://radxa.com/products/accessories/display-10fhd) |       10.1       | 1200\*1920 |
 |   [Radxa Display 8 HD](https://radxa.com/products/accessories/display-8hd)   |        8         | 800\*1280  |
 
+:::note
+Only the Radxa official displays listed above are supported. Third-party displays (e.g., the Raspberry Pi 7\" touchscreen) are not officially adapted: even if a physical connection is made with an adapter cable, display and touch functionality depend on whether the system image includes a matching panel driver / device tree, and compatibility cannot be guaranteed.
+:::
+
 ## Hardware Connection
 
-Connect the MIPI display to the Dragon Q6A's MIPI DSI interface via an FPC ribbon cable.
+Connect the MIPI display to the Dragon Q6A's MIPI DSI interface (39-Pin / 0.3mm pitch FPC connector) via an FPC ribbon cable.
 
 :::tip Interface Location
 Refer to the [Hardware Information](./hardware-info) tutorial to locate the corresponding hardware interface.


### PR DESCRIPTION
## Summary

Update the Dragon Q6A MIPI DSI documentation page (ZH + EN) with two clarifications that came up in recent customer support:

1. **DSI connector spec**: Document the MIPI DSI FPC connector as **39-Pin / 0.3mm pitch** (consistent with the existing MIPI CSI page style which lists connector type/pitch).
2. **Third-party display note**: Clarify that only the Radxa official displays listed on the page (Display 10 FHD / Display 8 HD) are supported. Third-party displays such as the Raspberry Pi 7" touchscreen are **not officially adapted** — even with a physical adapter cable, display/touch functionality depends on a matching panel driver / device tree in the system image, and compatibility cannot be guaranteed.

## Why

Customers repeatedly asked whether the Q6A DSI connector is 39-pin and whether the Raspberry Pi 7" touchscreen can be used with the Q6A. The page previously only listed supported displays with no connector spec and no compatibility guidance, which led to repeated support questions.

## Changes

- `docs/dragon/q6a/hardware-use/mipi-dsi.md` (ZH)
- `i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/hardware-use/mipi-dsi.md` (EN)

Both files updated in sync (2 files, +10/-2).
