### PR TITLE
docs(rock3a): align download page with latest official images (Bookworm KDE R2 + Armbian link)

### DIFF
--- a/docs/rock3/rock3a/getting-started/download.md
+++ b/docs/rock3/rock3a/getting-started/download.md
@@ -18,7 +18,7 @@ sidebar_position: 5
 
 ## 操作系统镜像
 
-- [Radxa ROCK 3A Debian Build 25](https://github.com/radxa-build/rock-3a/releases/download/b25/rock-3a_debian_bullseye_xfce_b25.img.xz)
+- [Radxa ROCK 3A Bookworm KDE R2](https://github.com/radxa-build/rock-3a/releases/download/rsdk-r2/rock-3a_bookworm_kde_r2.output_512.img.xz)
 
 :::caution
 除了上面的镜像经过官方充分测试外，其他镜像未经过严格测试，可能会存在未知问题，仅用于评估使用。

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/getting-started/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/getting-started/download.md
@@ -19,7 +19,7 @@ title: Resource Download
 
 ## Operating system images
 
-- [Radxa ROCK 3A Debian Build 25](https://github.com/radxa-build/rock-3a/releases/download/b25/rock-3a_debian_bullseye_xfce_b25.img.xz)
+- [Radxa ROCK 3A Bookworm KDE R2](https://github.com/radxa-build/rock-3a/releases/download/rsdk-r2/rock-3a_bookworm_kde_r2.output_512.img.xz)
 
 :::caution
 Except for the above images which have been fully tested officially, the other images have not been rigorously tested and may have unknown issues and are for evaluation purposes only.


### PR DESCRIPTION
## 背景 / Background

客户反馈 / 内部对齐检查发现 `rock3/rock3a/getting-started/download`（资源下载汇总）页面存在两处过时信息：

1. 推荐的官方操作系统镜像仍是旧的 **Radxa ROCK 3A Debian Build 25**（bullseye xfce b25），而 `rock3/images`（镜像下载）页面与 `radxa-build/rock-3a` 最新 release（`rsdk-r2`）均已是 **Bookworm KDE R2**。
2. Armbian 下载链接仍指向旧的 `https://www.armbian.com/rock-3a/`，最新地址为 `https://armbian.com/boards/rock-3a/`，且未提示用户可前往 Armbian 官网获取其他类型镜像。

## 修改 / Changes

- 将 ROCK 3A download 页推荐官方镜像从 `Debian Build 25` 更新为 **Bookworm KDE R2**（`rock-3a_bookworm_kde_r2.output_512.img.xz`），与 `rock3/images` 页及最新 release 对齐
- 将 Armbian 链接更新为 `https://armbian.com/boards/rock-3a/`，并新增 tip 提示用户可前往 Armbian 官网获取其他类型镜像

涉及文件：
- 中文：`docs/rock3/rock3a/getting-started/download.md`
- English：`i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/getting-started/download.md`

## 影响范围 / Impact

- 仅更新 ROCK 3A 资源下载页的推荐镜像与 Armbian 链接
- 不改变镜像文件本身；`rock3/images` 页无改动（已是 R2）
- 中英文同步修改
