### PR TITLE
docs(rock3a): update Armbian link to latest board page and add tip

### DIFF
--- a/docs/rock3/rock3a/getting-started/download.md
+++ b/docs/rock3/rock3a/getting-started/download.md
@@ -24,7 +24,11 @@ sidebar_position: 5
 除了上面的镜像经过官方充分测试外，其他镜像未经过严格测试，可能会存在未知问题，仅用于评估使用。
 :::
 
-- [Radxa ROCK 3A Armbian](https://www.armbian.com/rock-3a/)
+- [Radxa ROCK 3A Armbian](https://armbian.com/boards/rock-3a/)
+
+:::tip
+如需其他类型的 Armbian 镜像，请前往 [Armbian 官网](https://armbian.com/boards/rock-3a/) 获取。
+:::
 
 Armbian 的默认凭据如下：
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/getting-started/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/getting-started/download.md
@@ -25,7 +25,11 @@ title: Resource Download
 Except for the above images which have been fully tested officially, the other images have not been rigorously tested and may have unknown issues and are for evaluation purposes only.
 :::
 
-- [Radxa ROCK 3A Armbian](https://www.armbian.com/rock-3a/)
+- [Radxa ROCK 3A Armbian](https://armbian.com/boards/rock-3a/)
+
+:::tip
+For other types of Armbian images, please visit the [Armbian official website](https://armbian.com/boards/rock-3a/).
+:::
 
 Default Armbian credentials:
 


### PR DESCRIPTION
## 背景 / Background

上一 PR（#1982）合并时只合入了 Bookworm KDE R2 镜像更新；本次将 ROCK 3A 资源下载页的 Armbian 入口一并更新（当时在合并后追加，未随 #1982 合并）。

## 修改 / Changes

- 将 Armbian 下载链接从旧的 `https://www.armbian.com/rock-3a/` 更新为最新板卡页 `https://armbian.com/boards/rock-3a/`
- 新增 tip：提示用户如需其他类型的 Armbian 镜像，可前往 Armbian 官网获取

涉及文件：
- 中文：`docs/rock3/rock3a/getting-started/download.md`
- English：`i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/getting-started/download.md`

## 影响范围 / Impact

- 仅更新 ROCK 3A 下载页的 Armbian 链接与提示，中英文同步
- 不影响镜像文件本身
