### PR TITLE
docs: add serial port permission denied tip to UART debug common template

### DIFF
--- a/docs/common/radxa-os/system-config/_uart_debug.mdx
+++ b/docs/common/radxa-os/system-config/_uart_debug.mdx
@@ -83,6 +83,22 @@ import { Image } from "@site/src/utils/docs";
   />
 </div>
 
+:::tip 串口无法打开
+若出现 `Error: Permission denied, cannot open /dev/ttyUSB*` 错误提示，说明当前用户没有串口设备的访问权限。请先确认主板对应的串口设备号，例如 `/dev/ttyUSB0`，然后执行：
+
+```bash
+sudo chmod 666 /dev/ttyUSB0
+```
+
+此方法重启或重新插拔设备后可能失效。建议将当前用户永久加入串口用户组：
+
+```bash
+sudo usermod -aG dialout "$USER"
+```
+
+执行后注销并重新登录，使权限配置生效。
+:::
+
 连接成功后，按回车会出现登陆信息，然后使用对应系统的用户账号和密码进行登陆（终端输入密码不会显示出来，输入完密码按回车登陆）。
 
 :::tip Android 系统登录

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_uart_debug.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/system-config/_uart_debug.mdx
@@ -83,6 +83,22 @@ Click the run button to log in to the serial port device.
   />
 </div>
 
+:::tip Serial Port Cannot Be Opened
+If you see the error `Error: Permission denied, cannot open /dev/ttyUSB*`, the current user does not have permission to access the serial port device. First confirm the serial device number corresponding to your board, e.g. `/dev/ttyUSB0`, then run:
+
+```bash
+sudo chmod 666 /dev/ttyUSB0
+```
+
+This method may no longer work after a reboot or replugging the device. It is recommended to permanently add the current user to the serial port user group:
+
+```bash
+sudo usermod -aG dialout "$USER"
+```
+
+After that, log out and log back in for the permission change to take effect.
+:::
+
 After a successful connection, press Enter to display the login prompt. Then use the corresponding system username and password to log in (the password will not be displayed as you type; press Enter after entering the password).
 
 :::tip Android System Login


### PR DESCRIPTION
## 背景

来自支持案例：用户按通用 UART 调试教程操作时，在 Linux 下打开串口报 `Error: Permission denied, cannot open /dev/ttyUSB*`，教程缺少权限处理说明。

## 修改内容

在通用串口调试模板 `_uart_debug.mdx`（中文 + 英文）的「登录串口」章节增加 `:::tip 串口无法打开` 提示：

1. 临时方案：`sudo chmod 666 /dev/ttyUSB0`
2. 说明该方案在重启/重新插拔后可能失效
3. 永久方案：`sudo usermod -aG dialout "$USER"`，注销重登生效

该模板被 dragon/q6a 等多款产品页面引用，修改后全站通用串口教程同步覆盖此常见问题。
