### PR TITLE
docs: correct SARADC_IN4 voltage to 1.8V (max 1.98V) on ROCK 5T

### DIFF
--- a/docs/rock5/rock5t/hardware-design/hardware-interface.md
+++ b/docs/rock5/rock5t/hardware-design/hardware-interface.md
@@ -33,7 +33,7 @@ description: "详细介绍 ROCK 5T 硬件信息"
 | GPIO       | 电压 | 最高  |
 | ---------- | ---- | ----- |
 | 所有的GPIO | 3.3V | 3.63V |
-| SARADC_IN4 | 3.3V | 1.8V  |
+| SARADC_IN4 | 1.8V | 1.98V |
 
 - GPIO Pinout
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/hardware-design/hardware-interface.md
@@ -33,7 +33,7 @@ description: "Detailed hardware information for ROCK 5T"
 | GPIO       | Voltage | MAX   |
 | ---------- | ------- | ----- |
 | All GPIO   | 3.3V    | 3.63V |
-| SARADC_IN4 | 3.3V    | 1.8V  |
+| SARADC_IN4 | 1.8V    | 1.98V |
 
 - GPIO Pinout
 


### PR DESCRIPTION
## Summary
Fix the GPIO voltage table on the ROCK 5T hardware interface page: SARADC_IN4 is powered by the 1.8V SARADC domain (max 1.98V), not 3.3V.

## Motivation
Reported by Radxa hardware colleague: SARADC_IN4 voltage is 1.8V, max 1.98V.
The previous table listed it as 3.3V nominal / 1.8V max, which was incorrect and could mislead customers wiring the SARADC input. Same fix as ROCK 5B (PR #1987).

## Changes
- `docs/rock5/rock5t/hardware-design/hardware-interface.md`: SARADC_IN4 电压 3.3V → 1.8V, 最高 1.8V → 1.98V
- `i18n/en/.../rock5/rock5t/hardware-design/hardware-interface.md`: same fix in English

Aligned with the values already published on CM5 / NX5 hardware interface pages.
