### PR TITLE
docs(rock4d): add 2D mechanical drawing links to download page

### DIFF
--- a/docs/rock4/rock4d/download.md
+++ b/docs/rock4/rock4d/download.md
@@ -94,6 +94,8 @@ USB 刷机使用，Loader 文件用于 USB 下载初始化。
 - [原理图 v1.12](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_SCH_V1.12.pdf)
 - [位号图 v1.11](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_SMD_V1.11.pdf)
 - [位号图 v1.12](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_SMD_v1.12.pdf)
+- [2D 机械图 v1.11](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_2D_V1.11_20250328.pdf)
+- [2D 机械图 DXF v1.11](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_2D_DXF_V1.11_20250328.zip)
 - [3D 模型](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_3D_v1_11_20250328.stp)
 
 ## 参考文档

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/download.md
@@ -84,6 +84,8 @@ If the SPI Flash has not been erased, you can directly write the system image to
 - [Schematic v1.12](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_SCH_V1.12.pdf)
 - [Component Placement v1.11](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_SMD_V1.11.pdf)
 - [Component Placement v1.12](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_SMD_v1.12.pdf)
+- [2D Drawing v1.11](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_2D_V1.11_20250328.pdf)
+- [2D Drawing DXF v1.11](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_2D_DXF_V1.11_20250328.zip)
 - [3D Model](https://dl.radxa.com/rock4/4d/docs/hw/Radxa_ROCK_4D_3D_v1_11_20250328.stp)
 
 ## Reference Documents


### PR DESCRIPTION
## Summary

The ROCK 4D download page lists schematic, component placement and 3D model files, but the official **2D mechanical drawing** (PDF + DXF) published under `dl.radxa.com/rock4/4d/docs/hw/` was missing from the Hardware Design section.

This PR adds both links:
- `Radxa_ROCK_4D_2D_V1.11_20250328.pdf`
- `Radxa_ROCK_4D_2D_DXF_V1.11_20250328.zip`

CN + EN updated in sync.

## Background

Triggered by an internal support question about the ROCK 4D mounting hole size (4× φ2.7mm, M2.5 screws). The answer relies on the official 2D drawing, but it was not reachable from the docs download page — users had to guess the file path on dl.radxa.com.

## What this reduces

- Users/FAE can find the mechanical drawing (mounting holes, board outline 85×56mm) directly from the docs download page instead of hunting on dl.radxa.com
- Fewer repeated support questions about mounting hole positions / board dimensions

## Verification

- Both URLs return HTTP 200 (PDF ~1.0MB, DXF zip ~1.0MB)
- `github_pr_guard.py check` passes: ok=True, single scope, bilingual synced
