### PR TITLE
docs: fix apt mirror restore commands to match by path

### DIFF
--- a/docs/common/radxa-os/_apt-repo.mdx
+++ b/docs/common/radxa-os/_apt-repo.mdx
@@ -284,12 +284,12 @@ sudo apt-get update
   <TabItem value="default" label="恢复默认">
 
 ```bash
-sudo sed -i 's/mirrors.ustc.edu.cn/deb.debian.org/g' /etc/apt/sources.list.d/*
-sudo sed -i 's/mirrors.ustc.edu.cn/deb.ubuntu.com/g' /etc/apt/sources.list.d/*
-sudo sed -i 's/mirrors.tuna.tsinghua.edu.cn/deb.debian.org/g' /etc/apt/sources.list.d/*
-sudo sed -i 's/mirrors.tuna.tsinghua.edu.cn/deb.ubuntu.com/g' /etc/apt/sources.list.d/*
-sudo sed -i 's/mirrors.cqu.edu.cn/deb.debian.org/g' /etc/apt/sources.list.d/*
-sudo sed -i 's/mirrors.cqu.edu.cn/deb.ubuntu.com/g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.ustc.edu.cn/debian|deb.debian.org/debian|g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.ustc.edu.cn/ubuntu|deb.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.tuna.tsinghua.edu.cn/debian|deb.debian.org/debian|g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.tuna.tsinghua.edu.cn/ubuntu|deb.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.cqu.edu.cn/debian|deb.debian.org/debian|g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.cqu.edu.cn/ubuntu|deb.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*
 sudo apt-get update
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_apt-repo.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_apt-repo.mdx
@@ -281,12 +281,12 @@ sudo apt-get update
   <TabItem value="default" label="Restore Defaults">
 
 ```bash
-sudo sed -i 's/mirrors.ustc.edu.cn/deb.debian.org/g' /etc/apt/sources.list.d/*
-sudo sed -i 's/mirrors.ustc.edu.cn/deb.ubuntu.com/g' /etc/apt/sources.list.d/*
-sudo sed -i 's/mirrors.tuna.tsinghua.edu.cn/deb.debian.org/g' /etc/apt/sources.list.d/*
-sudo sed -i 's/mirrors.tuna.tsinghua.edu.cn/deb.ubuntu.com/g' /etc/apt/sources.list.d/*
-sudo sed -i 's/mirrors.cqu.edu.cn/deb.debian.org/g' /etc/apt/sources.list.d/*
-sudo sed -i 's/mirrors.cqu.edu.cn/deb.ubuntu.com/g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.ustc.edu.cn/debian|deb.debian.org/debian|g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.ustc.edu.cn/ubuntu|deb.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.tuna.tsinghua.edu.cn/debian|deb.debian.org/debian|g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.tuna.tsinghua.edu.cn/ubuntu|deb.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.cqu.edu.cn/debian|deb.debian.org/debian|g' /etc/apt/sources.list.d/*
+sudo sed -i 's|mirrors.cqu.edu.cn/ubuntu|deb.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*
 sudo apt-get update
 ```
 


### PR DESCRIPTION
## Summary

Fixes the "Restore Defaults" instructions in the Radxa OS apt repository mirror docs (`_apt-repo.mdx`, zh-CN + en).

## Problem

The restore block used two **sequential domain-only** `sed` replacements per mirror, e.g.:

```bash
sudo sed -i 's/mirrors.cqu.edu.cn/deb.debian.org/g' /etc/apt/sources.list.d/*
sudo sed -i 's/mirrors.cqu.edu.cn/deb.ubuntu.com/g' /etc/apt/sources.list.d/*
```

The first command rewrites **every** occurrence of the mirror host — including Ubuntu source paths — to `deb.debian.org`, so the second command never sees `mirrors.cqu.edu.cn` again. On an Ubuntu system, restoring defaults yields broken entries like `deb.debian.org/ubuntu` instead of `deb.ubuntu.com/ubuntu`.

This was originally flagged by Copilot review on #1781 (comments on both the en and zh files), but #1781 was merged with the issue still present in `main`.

## Fix

Match by path instead of host only, so each distribution is restored to its own default host:

```bash
sudo sed -i 's|mirrors.cqu.edu.cn/debian|deb.debian.org/debian|g' /etc/apt/sources.list.d/*
sudo sed -i 's|mirrors.cqu.edu.cn/ubuntu|deb.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*
```

Applied to all affected mirror blocks (ustc, tuna, cqu) in both `docs/common/radxa-os/_apt-repo.mdx` and the en counterpart.

## Test / verification

- Bilingual guard: en + zh both updated, no missing counterparts.
- The path-based pattern is consistent with the enable commands (host-only swap preserves the `/debian` vs `/ubuntu` path).
