### PR TITLE
docs(fogwise/airbox-q900): point Yocto Build Guide to meta-radxa-dragon wiki

### DIFF
--- a/docs/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/docs/fogwise/airbox-q900/other-os/qualcomm.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## 瑞莎 AIRbox Q900 Yocto 编译指南
 
-请参考 [瑞莎 AIRbox Q900 Yocto 编译指南](https://github.com/radxa/meta-radxa-dragon/blob/meta-qcom-qli-2.0/README-Radxa-AIRbox-Q900.md)
+请参考 [瑞莎 AIRbox Q900 Yocto 编译指南](https://github.com/radxa/meta-radxa-dragon/wiki/AIRbox-Q900)
 
 ## 高通 Linux Yocto 指南
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## Radxa AIRbox Q900 Yocto Build Guide
 
-Please refer to [Radxa AIRbox Q900 Yocto Build Guide](https://github.com/radxa/meta-radxa-dragon/blob/meta-qcom-qli-2.0/README-Radxa-AIRbox-Q900.md)
+Please refer to [Radxa AIRbox Q900 Yocto Build Guide](https://github.com/radxa/meta-radxa-dragon/wiki/AIRbox-Q900)
 
 ## Qualcomm Linux Yocto Guide
 


### PR DESCRIPTION
## Summary

Issue #1729 requested adding Radxa Yocto build guide wiki links for both the Dragon Q6A and the AIRbox Q900:

- Q6A → `https://github.com/radxa/meta-radxa-dragon/wiki/dragon-q6a` (already added in June, commit 2374b5e7e)
- Q900 → `https://github.com/radxa/meta-radxa-dragon/wiki/AIRbox-Q900` (this PR)

The AIRbox Q900 page currently points to a branch blob README (`meta-qcom-qli-2.0/README-Radxa-AIRbox-Q900.md`). This PR switches the "Radxa AIRbox Q900 Yocto Build Guide" link to the wiki page requested in the issue, which contains the full EDL download mode + Yocto build workflow for the Q900.

## Changes

- `docs/fogwise/airbox-q900/other-os/qualcomm.md` — update link to wiki
- `i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md` — same update (EN sync)

Both zh/en versions updated in the same commit.

## Source

- GitHub issue: radxa-docs/docs#1729 (docs-only request)
- Wiki page verified reachable: https://github.com/radxa/meta-radxa-dragon/wiki/AIRbox-Q900

Fixes #1729
