### PR TITLE
docs(zero3/android): fix Android build manifest branch from rk11 to rk12

### DIFF
--- a/docs/zero/zero3/other-os/android/lowlevel-development.md
+++ b/docs/zero/zero3/other-os/android/lowlevel-development.md
@@ -80,7 +80,7 @@ Repo 是 Android 开发中用于管理多个 Git 仓库的工具，它是一个P
 ## 代码下载
 
 ```bash
-$ repo init -u https://github.com/radxa/manifests.git -b Android11_Radxa_rk11 -m rockchip-r-release.xml
+$ repo init -u https://github.com/radxa/manifests.git -b Android11_Radxa_rk12 -m rockchip-r-release.xml
 $ repo sync -d --no-tags -j4
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/android/lowlevel-development.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/android/lowlevel-development.md
@@ -73,7 +73,7 @@ Repo is a tool used in Android development to manage multiple Git repositories. 
 ## code download
 
 ```bash
-$ repo init -u https://github.com/radxa/manifests.git -b Android11_Radxa_rk11 -m rockchip-r-release.xml
+$ repo init -u https://github.com/radxa/manifests.git -b Android11_Radxa_rk12 -m rockchip-r-release.xml
 $ repo sync -d --no-tags -j4
 ```
 


### PR DESCRIPTION
## Summary

Fixes #1878 — Zero 3 Android build fails with `Can not locate config makefile for product "rk356x_radxa_zero3"`.

## Root cause

The lowlevel-development page told users to initialize the Android 11 manifest with:

```
repo init -u https://github.com/radxa/manifests.git -b Android11_Radxa_rk11 -m rockchip-r-release.xml
```

But the `rk356x_radxa_zero3` device configuration only exists in the **Android11_Radxa_rk12** manifest branch (device/rockchip/rk3566 pinned to tag `radxa-android11-rkr12.2`). With the rk11 manifest, the synced source tree has no zero3 device folder, so `lunch rk356x_radxa_zero3-userdebug` cannot locate the product config.

This is also consistent with the [download page](https://docs.radxa.com/zero/zero3/other-os/android/download), which already references the `rkr12` release image (`radxa-zero3-we-android11-rkr12-20240111`).

## Change

- `docs/zero/zero3/other-os/android/lowlevel-development.md` (zh)
- `i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/other-os/android/lowlevel-development.md` (en)

Both updated: `-b Android11_Radxa_rk11` → `-b Android11_Radxa_rk12`.

Verified: the rk12 manifest (`Android11_Radxa_rk12_customization.xml`) pins `device/rockchip/rk356x` to revision `d4bfc34f` (tag `radxa-android11-rkr12.2`), whose tree contains `rk356x_radxa_zero3/` with `rk356x_radxa_zero3-userdebug` product entries.

docs-only, bilingual in sync.
