### PR TITLE
docs(cubie vpm_run): add build-essential prerequisite for stdio.h compile error

### DIFF
--- a/docs/common/ai/_cubie_vpm_run.mdx
+++ b/docs/common/ai/_cubie_vpm_run.mdx
@@ -32,6 +32,15 @@ cd ai-sdk/examples/vpm_run
 
 ### 编译示例
 
+:::tip
+若编译时出现 `fatal error: stdio.h: No such file or directory`，请先安装编译工具链：
+
+```bash
+sudo apt install build-essential libc6-dev
+```
+
+:::
+
 <Tabs>
     <TabItem value="A733">
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_cubie_vpm_run.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_cubie_vpm_run.mdx
@@ -32,6 +32,15 @@ cd ai-sdk/examples/vpm_run
 
 ### Compile the Example
 
+:::tip
+If you get a `fatal error: stdio.h: No such file or directory` error while compiling, install the build toolchain first:
+
+```bash
+sudo apt install build-essential libc6-dev
+```
+
+:::
+
 <Tabs>
     <TabItem value="A733">
 


### PR DESCRIPTION
## Summary

From GitHub Discussion #1931: when compiling the `vpm_run` example on Cubie (A733), users hit:

```
vpm_run.c:2:10: fatal error: stdio.h: No such file or directory
```

The fix is to install the build toolchain first. This PR adds a tip in both zh/en common MDX noting `sudo apt install build-essential libc6-dev` as a prerequisite before compiling the example.

## Changes
- `docs/common/ai/_cubie_vpm_run.mdx` (zh): add build-essential tip
- `i18n/en/docusaurus-plugin-content-docs/current/common/ai/_cubie_vpm_run.mdx` (en): add build-essential tip

## Related
- https://github.com/radxa-docs/docs/discussions/1931
