### PR TITLE
docs(common/radxa-os): add KDE Plasma autologin session name troubleshooting tip

### DIFF
--- a/docs/common/radxa-os/_autologin.mdx
+++ b/docs/common/radxa-os/_autologin.mdx
@@ -29,6 +29,22 @@
 
 ![ROCK5T_Auto_Login](/img/rock5t/rock5t-autologin-3.webp)
 
+:::tip KDE Plasma 桌面自动登录注意事项
+若您使用的是 KDE Plasma 桌面，通过 `rsetup` 的 GUI 完成自动登录配置后，自动登录仍可能失效（例如重启后卡在登录界面）。
+
+这通常是因为配置中写入的会话名称为 `plasma`，而 KDE Plasma 实际需要的会话名称为 `plasma.desktop`。
+
+可手动编辑自动登录配置文件（KDE Plasma 通常使用 SDDM，配置文件一般位于 `/etc/sddm.conf.d/kde_settings.conf`），将会话名称修改为 `plasma.desktop`，示例：
+
+```ini
+[Autologin]
+Session=plasma.desktop
+User=radxa
+```
+
+修改后重启系统即可正常自动登录。
+:::
+
 </TabItem>
 
 </Tabs>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_autologin.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_autologin.mdx
@@ -29,6 +29,22 @@ Select `gdm.service` by the space, and then select `OK` to complete the automati
 
 ![ROCK5T_Auto_Login](/img/rock5t/rock5t-autologin-3.webp)
 
+:::tip KDE Plasma Desktop Autologin Note
+If you are using the KDE Plasma desktop, autologin may still fail after configuring it via the `rsetup` GUI (e.g. the system gets stuck at the login screen after reboot).
+
+This is usually caused by the session name being written as `plasma`, while KDE Plasma actually requires `plasma.desktop`.
+
+Manually edit the autologin configuration file (KDE Plasma typically uses SDDM, and the config file is usually located at `/etc/sddm.conf.d/kde_settings.conf`) and change the session name to `plasma.desktop`, for example:
+
+```ini
+[Autologin]
+Session=plasma.desktop
+User=radxa
+```
+
+After editing, restart the system — autologin should work normally.
+:::
+
 </TabItem>
 
 </Tabs>


### PR DESCRIPTION
Fixes #624

## Summary

The autologin doc for Debian 12 (configured via `rsetup` → User Settings → Configure auto login) is incomplete for KDE Plasma desktop users. When autologin is configured through the GUI on a KDE Plasma image, the session name is written as `plasma`, but KDE Plasma actually requires `plasma.desktop` — as a result the system stays stuck at the login screen after reboot.

This PR adds a troubleshooting tip to the common autologin page (Debian 12 tab), covering both zh and en:

- Symptom: autologin fails after GUI configuration on KDE Plasma (stuck at login screen)
- Cause: session name `plasma` vs required `plasma.desktop`
- Fix: manually edit the autologin config (typically `/etc/sddm.conf.d/kde_settings.conf` for KDE Plasma with SDDM) and set `Session=plasma.desktop`

## Changes

- `docs/common/radxa-os/_autologin.mdx` (zh): added tip
- `i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_autologin.mdx` (en): added tip

## Test

- `github_pr_guard.py check` passed: 1 commit, 2 files, no missing en/zh counterparts
