### PR TITLE
docs(zero3): fix bold markdown in 3e-poe-hat page

### DIFF
--- a/docs/zero/zero3/accessories/3e-poe-hat.md
+++ b/docs/zero/zero3/accessories/3e-poe-hat.md
@@ -13,7 +13,7 @@ sidebar_position: 3
 
 2. 要求网线另一端的交换机 / 路由器支持 PoE供电。
 
-3. ** 以太网端口的线序，1、2、3 和 6 用于供电和数据传输，而 4、5、7 和 8 仅用于数据传输。**
+3. **以太网端口的线序，1、2、3 和 6 用于供电和数据传输，而 4、5、7 和 8 仅用于数据传输。**
 
 4. Radxa ZERO 3E 的 PoE 功能的实现是涉及螺丝和铜柱的，需要将铜柱和螺丝固定牢固，不装上铜柱和螺丝是不能使用 PoE 功能的。
 
@@ -27,7 +27,7 @@ sidebar_position: 3
 
 ![zero 3e poe hat 02](/img/zero/zero3/zero_3e_poe_hat_02.webp)
 
-- 然后，如图所示，固定 Radxa ZERO 3E PoE 帽上方的螺丝。** 需要将螺丝和铜柱拧紧 **
+- 然后，如图所示，固定 Radxa ZERO 3E PoE 帽上方的螺丝。**需要将螺丝和铜柱拧紧**
 
 ![zero 3e poe hat 03](/img/zero/zero3/zero_3e_poe_hat_03.webp)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/accessories/3e-poe-hat.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/accessories/3e-poe-hat.md
@@ -13,7 +13,7 @@ sidebar_position: 3
 
 2. it requires PoE support from the switch / router at the other end of the ethernet cable.
 
-3. ** In the Ethernet port wiring sequence, pins 1, 2, 3, and 6 are used for both power supply and data transmission, while pins 4, 5, 7, and 8 are exclusively for data transmission. **
+3. **In the Ethernet port wiring sequence, pins 1, 2, 3, and 6 are used for both power supply and data transmission, while pins 4, 5, 7, and 8 are exclusively for data transmission.**
 
 4. The implementation of PoE functionality on Radxa ZERO 3E involves screws and copper pillars, which need to be securely fastened. Without installing the copper pillars and screws, the PoE functionality cannot be utilized.
 
@@ -27,7 +27,7 @@ sidebar_position: 3
 
 ![zero 3e poe hat 02](/img/zero/zero3/zero_3e_poe_hat_02.webp)
 
-- Then, secure screws above the Radxa ZERO 3E PoE HAT, as indicated in the diagram. ** Screws and copper posts need to be tightened **
+- Then, secure screws above the Radxa ZERO 3E PoE HAT, as indicated in the diagram. **Screws and copper posts need to be tightened**
 
 ![zero 3e poe hat 03](/img/zero/zero3/zero_3e_poe_hat_03.webp)
 


### PR DESCRIPTION
Fixes #199

## Summary
The ZERO 3E PoE HAT page had markdown bold syntax with spaces inside the `**` markers (e.g. `** text **`), which Docusaurus does not render as bold. This made the "Precaution" item 3 and the assembly step appear as plain text instead of emphasized text.

## Changes
- Removed spaces inside `**` markers so the text renders as bold
- Updated both Chinese (`docs/`) and English (`i18n/en/`) versions

## Source
GitHub issue #199 (zero/zero3/accessories/3e-poe-hat): bold `**` not recognized + clarification that copper pillars have electrical function and must be installed tightly.

## Impact
Docs-only rendering fix; no content/behavior change.
