### PR TITLE
docs(x/x4): add FAQ on power-in header voltage (12V)

### DIFF
--- a/docs/x/x4/faq.md
+++ b/docs/x/x4/faq.md
@@ -3,3 +3,9 @@ sidebar_position: 70
 ---
 
 # FAQ
+
+## 板载电源输入接口需要多少伏电压？
+
+- Radxa X4 板载电源输入接口（Power In）为 **12V 直流输入**，与 USB Type-C PD 接口的 12V 供电规格一致。
+- 推荐使用支持 USB Type-C PD 协议（12V，电流 ≥ 2.5A）的电源适配器，例如 [Radxa Power PD30W](http://radxa.com/products/accessories/power-pd-30w)。
+- 请勿向该接口输入 5V 电压，否则可能导致系统无法正常启动或供电不足。

--- a/i18n/en/docusaurus-plugin-content-docs/current/x/x4/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/x/x4/faq.md
@@ -3,3 +3,9 @@ sidebar_position: 70
 ---
 
 # FAQ
+
+## What voltage should be supplied to the on-board power-in header?
+
+- The on-board power-in header of Radxa X4 accepts **12V DC input**, consistent with the 12V USB Type-C PD power specification.
+- It is recommended to use a USB Type-C PD power adapter (12V, current ≥ 2.5A), such as the [Radxa Power PD30W](http://radxa.com/products/accessories/power-pd-30w).
+- Do not supply 5V to this header, otherwise the board may fail to boot properly or suffer from insufficient power.


### PR DESCRIPTION
Fixes #600

## 背景 / Background

Issue #600: 用户询问 Radxa X4 板载电源输入接口（Power In header）需要 5V 还是 12V。X4 的 FAQ 页面此前为空。

## 修改 / Changes

- `docs/x/x4/faq.md`（中文）: 新增 FAQ「板载电源输入接口需要多少伏电压？」
- `i18n/en/docusaurus-plugin-content-docs/current/x/x4/faq.md`（English）: Added FAQ "What voltage should be supplied to the on-board power-in header?"

## 依据 / Evidence

- Radxa X4 V1.11 原理图（https://dl.radxa.com/x/x4/radxa_x4_v1.11_schematic.pdf）第 27 页：电源输入接口 J10 网络为 `ADP12V_IN`（12V），与 USB Type-C PD 12V 供电规格一致。
- X4 准备页已写明推荐 USB Type-C PD（12V，≥2.5A），此处补充板载 Power In 接口的电压要求。

## 影响 / Impact

docs-only，无代码影响；消除用户在 5V/12V 之间的疑惑，避免供电不足导致启动异常。
