### PR TITLE
docs(rock5a): add product brief link to download page

### DIFF
--- a/docs/rock5/rock5a/download.md
+++ b/docs/rock5/rock5a/download.md
@@ -10,6 +10,7 @@ import Images from "./\_image.mdx"
 
 Radxa ROCK 5A V1.1 版本
 
+[产品简介 pdf](https://dl.radxa.com/rock5/5a/docs/radxa_rock5a_product_brief.pdf)  
 [v1.1 2D dxf](https://dl.radxa.com/rock5/5a/docs/hw/radxa_rock5a_X1.11_2D.dxf)  
 [v1.1 3D stp](https://dl.radxa.com/rock5/5a/docs/hw/rock_5a_3d_pcba.rar)  
 [v1.1 原理图 pdf](https://dl.radxa.com/rock5/5a/docs/hw/radxa_rock5a_V1.1_sch.pdf)  

--- a/docs/rock5/rock5a/download.md
+++ b/docs/rock5/rock5a/download.md
@@ -10,7 +10,7 @@ import Images from "./\_image.mdx"
 
 Radxa ROCK 5A V1.1 版本
 
-[产品简介 pdf](https://dl.radxa.com/rock5/5a/docs/radxa_rock5a_product_brief.pdf)  
+[产品规格书 pdf](https://dl.radxa.com/rock5/5a/docs/radxa_rock5a_product_brief.pdf)  
 [v1.1 2D dxf](https://dl.radxa.com/rock5/5a/docs/hw/radxa_rock5a_X1.11_2D.dxf)  
 [v1.1 3D stp](https://dl.radxa.com/rock5/5a/docs/hw/rock_5a_3d_pcba.rar)  
 [v1.1 原理图 pdf](https://dl.radxa.com/rock5/5a/docs/hw/radxa_rock5a_V1.1_sch.pdf)  

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/download.md
@@ -10,6 +10,7 @@ import Images from "./\_image.mdx"
 
 Radxa ROCK 5A Version V1.1
 
+[Product brief pdf](https://dl.radxa.com/rock5/5a/docs/radxa_rock5a_product_brief.pdf)  
 [v1.1 2D dxf](https://dl.radxa.com/rock5/5a/docs/hw/radxa_rock5a_X1.11_2D.dxf)  
 [v1.1 3D stp](https://dl.radxa.com/rock5/5a/docs/hw/rock_5a_3d_pcba.rar)  
 [v1.1 Schematic pdf](https://dl.radxa.com/rock5/5a/docs/hw/radxa_rock5a_V1.1_sch.pdf)  


### PR DESCRIPTION
Fixes #586

## Summary

The ROCK 5A download page (`docs/rock5/rock5a/download.md`) previously listed only 2D/3D/schematic/placement-map files under **Hardware Design**, with no datasheet/product brief link. A customer reported in #586 that the datasheet download was missing.

The product brief PDF actually exists at `https://dl.radxa.com/rock5/5a/docs/radxa_rock5a_product_brief.pdf` (verified: HTTP 200, ~532 KB). This PR adds it to the Hardware Design section in both Chinese and English versions.

## Changes

- `docs/rock5/rock5a/download.md`: add `产品简介 pdf` link
- `i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5a/download.md`: add `Product brief pdf` link

## Impact

- Reduces confusion for users looking for ROCK 5A datasheet/spec download.
- Docs-only change, both languages updated.
