### PR TITLE
docs: rock3b: fix GPIO3_C5 for UART7_RX_M1 and mark I2S3 M0 functions

### DIFF
--- a/docs/rock3/rock3b/hardware-design/hardware-interface.md
+++ b/docs/rock3/rock3b/hardware-design/hardware-interface.md
@@ -53,8 +53,8 @@ ROCK 3B 提供一个 40 pin GPIO 扩展座，兼容市场上大多数传感器�
 | 33          | CAN1_TX_M0  | UART3_TX_M0  | I2C3_SCL_M0 |  GPIO1_A1   |  <div className='green'>5</div>  | <div className='black'>6</div>  |    GND    |                                           |             |             |             |
 | 13          |             |   PWM1_M1    | I2C2_SCL_M0 |  GPIO0_B5   |  <div className='green'>7</div>  | <div className='green'>8</div>  | GPIO0_D1  | <div className='orange'>UART2_TX_M0</div> |             |             | 25          |
 |             |             |              |             |     GND     |  <div className='black'>9</div>  | <div className='green'>10</div> | GPIO0_D0  | <div className='orange'>UART2_RX_M0</div> |             |             | 24          |
-| 116         |             | UART7_TX_M1  |  PWM14_M0   |  GPIO3_C4   | <div className='green'>11</div>  | <div className='green'>12</div> | GPIO3_A3  |                                           |             |             | 99          |
-| 117         |             | UART7_RX_M1  | PWM15_IR_M0 |             | <div className='green'>13</div>  | <div className='black'>14</div> |    GND    |                                           |             |             |             |
+| 116         |             | UART7_TX_M1  |  PWM14_M0   |  GPIO3_C4   | <div className='green'>11</div>  | <div className='green'>12</div> | GPIO3_A3  |              I2S3_SCLK_M0               |             |             | 99          |
+| 117         |             | UART7_RX_M1  | PWM15_IR_M0 |  GPIO3_C5   | <div className='green'>13</div>  | <div className='black'>14</div> |    GND    |                                           |             |             |             |
 | 16          |             |   UART0_RX   |   PWM1_M0   |  GPIO0_C0   | <div className='green'>15</div>  | <div className='green'>16</div> | GPIO0_B6  |                I2C2_SDA_M0                |   PWM2_M1   |             | 14          |
 |             |             |              |             |    +3.3V    | <div className='yellow'>17</div> | <div className='green'>18</div> | GPIO3_B2  |                UART4_TX_M1                |   PWM9_M0   |             | 106         |
 | 146         | CAN1_TX_M1  | SPI3_MOSI_M1 | PWM15_IR_M1 |  GPIO4_C3   | <div className='green'>19</div>  | <div className='black'>20</div> |    GND    |                                           |             |             |             |
@@ -65,9 +65,9 @@ ROCK 3B 提供一个 40 pin GPIO 扩展座，兼容市场上大多数传感器�
 | 95          |             |              |             |  GPIO2_D7   | <div className='green'>29</div>  | <div className='black'>30</div> |    GND    |                                           |             |             |             |
 | 96          |             |              |             |  GPIO3_A0   | <div className='green'>31</div>  | <div className='green'>32</div> | GPIO3_C2  |                UART5_TX_M1                |             |             | 114         |
 | 115         |             | UART5_RX_M1  | SPI1_CLK_M1 |  GPIO3_C3   | <div className='green'>33</div>  | <div className='black'>34</div> |    GND    |                                           |             |             |             |
-| 100         |             |              |             |  GPIO3_A4   | <div className='green'>35</div>  | <div className='green'>36</div> | GPIO3_A2  |                                           |             |             | 98          |
-|             |             |              |             | SARADC_VIN5 | <div className='green'>37</div>  | <div className='green'>38</div> | GPIO3_A6  |                                           |             |             | 102         |
-|             |             |              |             |     GND     | <div className='black'>39</div>  | <div className='green'>40</div> | GPIO3_A5  |                                           |             |             | 101         |
+| 100         |             |              | I2S3_LRCK_M0 |  GPIO3_A4   | <div className='green'>35</div>  | <div className='green'>36</div> | GPIO3_A2  |              I2S3_MCLK_M0               |             |             | 98          |
+|             |             |              |             | SARADC_VIN5 | <div className='green'>37</div>  | <div className='green'>38</div> | GPIO3_A6  |              I2S3_SDI_M0                |             |             | 102         |
+|             |             |              |             |     GND     | <div className='black'>39</div>  | <div className='green'>40</div> | GPIO3_A5  |              I2S3_SDO_M0                |             |             | 101         |
 
 </div>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/hardware-design/hardware-interface.md
@@ -53,8 +53,8 @@ Actual compatibility is subject to actual use.
 | 33          | CAN1_TX_M0  | UART3_TX_M0  | I2C3_SCL_M0 |  GPIO1_A1   |  <div className='green'>5</div>  | <div className='black'>6</div>  |    GND    |                                           |             |             |             |
 | 13          |             |   PWM1_M1    | I2C2_SCL_M0 |  GPIO0_B5   |  <div className='green'>7</div>  | <div className='green'>8</div>  | GPIO0_D1  | <div className='orange'>UART2_TX_M0</div> |             |             | 25          |
 |             |             |              |             |     GND     |  <div className='black'>9</div>  | <div className='green'>10</div> | GPIO0_D0  | <div className='orange'>UART2_RX_M0</div> |             |             | 24          |
-| 116         |             | UART7_TX_M1  |  PWM14_M0   |  GPIO3_C4   | <div className='green'>11</div>  | <div className='green'>12</div> | GPIO3_A3  |                                           |             |             | 99          |
-| 117         |             | UART7_RX_M1  | PWM15_IR_M0 |             | <div className='green'>13</div>  | <div className='black'>14</div> |    GND    |                                           |             |             |             |
+| 116         |             | UART7_TX_M1  |  PWM14_M0   |  GPIO3_C4   | <div className='green'>11</div>  | <div className='green'>12</div> | GPIO3_A3  |              I2S3_SCLK_M0               |             |             | 99          |
+| 117         |             | UART7_RX_M1  | PWM15_IR_M0 |  GPIO3_C5   | <div className='green'>13</div>  | <div className='black'>14</div> |    GND    |                                           |             |             |             |
 | 16          |             |   UART0_RX   |   PWM1_M0   |  GPIO0_C0   | <div className='green'>15</div>  | <div className='green'>16</div> | GPIO0_B6  |                I2C2_SDA_M0                |   PWM2_M1   |             | 14          |
 |             |             |              |             |    +3.3V    | <div className='yellow'>17</div> | <div className='green'>18</div> | GPIO3_B2  |                UART4_TX_M1                |   PWM9_M0   |             | 106         |
 | 146         | CAN1_TX_M1  | SPI3_MOSI_M1 | PWM15_IR_M1 |  GPIO4_C3   | <div className='green'>19</div>  | <div className='black'>20</div> |    GND    |                                           |             |             |             |
@@ -65,9 +65,9 @@ Actual compatibility is subject to actual use.
 | 95          |             |              |             |  GPIO2_D7   | <div className='green'>29</div>  | <div className='black'>30</div> |    GND    |                                           |             |             |             |
 | 96          |             |              |             |  GPIO3_A0   | <div className='green'>31</div>  | <div className='green'>32</div> | GPIO3_C2  |                UART5_TX_M1                |             |             | 114         |
 | 115         |             | UART5_RX_M1  | SPI1_CLK_M1 |  GPIO3_C3   | <div className='green'>33</div>  | <div className='black'>34</div> |    GND    |                                           |             |             |             |
-| 100         |             |              |             |  GPIO3_A4   | <div className='green'>35</div>  | <div className='green'>36</div> | GPIO3_A2  |                                           |             |             | 98          |
-|             |             |              |             | SARADC_VIN5 | <div className='green'>37</div>  | <div className='green'>38</div> | GPIO3_A6  |                                           |             |             | 102         |
-|             |             |              |             |     GND     | <div className='black'>39</div>  | <div className='green'>40</div> | GPIO3_A5  |                                           |             |             | 101         |
+| 100         |             |              | I2S3_LRCK_M0 |  GPIO3_A4   | <div className='green'>35</div>  | <div className='green'>36</div> | GPIO3_A2  |              I2S3_MCLK_M0               |             |             | 98          |
+|             |             |              |             | SARADC_VIN5 | <div className='green'>37</div>  | <div className='green'>38</div> | GPIO3_A6  |              I2S3_SDI_M0                |             |             | 102         |
+|             |             |              |             |     GND     | <div className='black'>39</div>  | <div className='green'>40</div> | GPIO3_A5  |              I2S3_SDO_M0                |             |             | 101         |
 
 </div>
 


### PR DESCRIPTION
Fix ROCK 3B 40-pin GPIO table issues reported in #571:

1. **UART7_RX_M1 (pin 13) missing GPIO number** — added `GPIO3_C5` (verified against RK3568 TRM and ROCK 3B V1.51 schematic; consistent with ROCK 3A / ROCK 3 e25 tables).
2. **I2S3 M0 functions not marked** — added per RK3568 TRM Table 21-5 (`i2s3_mclkm0/sclkm0/lrckm0/sdom0/sdim0`, all mux `3'b001`) and ROCK 3B V1.51 schematic:
   - pin 36: `I2S3_MCLK_M0` (GPIO3_A2)
   - pin 12: `I2S3_SCLK_M0` (GPIO3_A3)
   - pin 35: `I2S3_LRCK_M0` (GPIO3_A4)
   - pin 40: `I2S3_SDO_M0` (GPIO3_A5)
   - pin 38: `I2S3_SDI_M0` (GPIO3_A6)

Both zh and en pages updated.

Fixes #571
