### PR TITLE
docs: add UART2_M0 debug serial warning for ZERO 3

### DIFF
--- a/docs/zero/zero3/hardware-design/hardware-interface.md
+++ b/docs/zero/zero3/hardware-design/hardware-interface.md
@@ -16,6 +16,14 @@ sidebar_position: 4
 
 ## 调试串口
 
+ZERO 3 的调试串口使用 **UART2_M0**（40 PIN GPIO 的 Pin 8：TX，Pin 10：RX），默认波特率为 1500000n8。
+
+:::warning 不建议将 UART2_M0 用作普通串口
+UART2_M0 同时也是默认的 U-Boot 控制台。如果通过 rsetup 的 overlay 将 UART2_M0 启用为普通串口，串口上的输入会中断启动过程，导致设备无法正常启动。
+
+如果您确实需要使用 UART2_M0，请先通过 `rsetup` 进行系统更新和 bootloader 更新，然后编辑 `/etc/default/u-boot`，将 `prompt` 和 `timeout` 取消注释并设置为 0，最后运行 `sudo u-boot-update` 重新生成启动配置。
+:::
+
 ## 有线网口
 
 ## 40 PIN GPIO

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/hardware-design/hardware-interface.md
@@ -16,6 +16,14 @@ sidebar_position: 4
 
 ## Debug Serial Port
 
+The debug serial port of ZERO 3 uses **UART2_M0** (40-pin GPIO Pin 8: TX, Pin 10: RX), with a default baud rate of 1500000n8.
+
+:::warning UART2_M0 is not recommended for use as a normal UART
+UART2_M0 is also the default U-Boot console. If you enable UART2_M0 as a normal serial port through the rsetup overlay, input on the serial port will interrupt the boot process and the device may fail to boot.
+
+If you really need to use UART2_M0, first update the system and bootloader via `rsetup`, then edit `/etc/default/u-boot` to uncomment `prompt` and `timeout` and set them to 0, and finally run `sudo u-boot-update` to rebuild the boot configuration.
+:::
+
 ## Ethernet Port
 
 ## 40 PIN GPIO


### PR DESCRIPTION
Fixes #418

## Summary

The debug serial port of Radxa ZERO 3 uses **UART2_M0** (40-pin GPIO Pin 8: TX, Pin 10: RX) at 1500000n8 by default. However, UART2_M0 is also the **default U-Boot console**: if a user enables UART2_M0 as a normal UART through the `rsetup` overlay, serial input during boot interrupts the boot process and the device may fail to boot (see radxa-build/radxa-zero3#19).

This PR fills the previously empty "调试串口 / Debug Serial Port" section of the ZERO 3 hardware-interface page (ZH + EN) with:
- The pin/baudrate mapping for the debug serial port
- A warning that UART2_M0 is not recommended for use as a normal UART
- The workaround steps for users who still need UART2_M0 (system + bootloader update via `rsetup`, edit `/etc/default/u-boot` to set `prompt`/`timeout` to 0, run `sudo u-boot-update`)

## Source

GitHub issue #418 referencing radxa-build/radxa-zero3#19 (comment from RadxaYuntian).

## Changes

- `docs/zero/zero3/hardware-design/hardware-interface.md` (ZH)
- `i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/hardware-design/hardware-interface.md` (EN)

## Checklist

- [x] ZH + EN both updated (bilingual guard passed)
- [x] Small, precise, docs-only change (2 files, 1 commit)
