### PR TITLE
docs(rockpis0): fix broken bold markdown syntax in hardware-interface and getting-started pages

### DIFF
--- a/docs/rockpi/rockpis0/getting-started/preparation.md
+++ b/docs/rockpi/rockpis0/getting-started/preparation.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## 必备线材
 
-** Radxa ROCK Pi S0 必须配置专用线材才可以使用 **
+**Radxa ROCK Pi S0 必须配置专用线材才可以使用**
 
 ### 线材信号定义
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis0/getting-started/antenna-switch.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis0/getting-started/antenna-switch.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 ROCK Pi S0 has AP6212(WiFi&BT) module on board, there is one on-board antenna and one external antenna connector, you can choose to use on-board antenna or external antenna by overlay.
 
-** The default is to use the on-board antenna. **
+**The default is to use the on-board antenna.**
 
 ![rocks0 antenna1](/img/rockpi/s0/rock-s0-antenna.webp)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis0/getting-started/preparation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis0/getting-started/preparation.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## Required Cables
 
-** Radxa ROCK Pi S0 must be configured with a specialized cable in order to be used. **
+**Radxa ROCK Pi S0 must be configured with a specialized cable in order to be used.**
 
 ### Wire Signal Definition
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis0/hardware/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rockpi/rockpis0/hardware/hardware-interface.md
@@ -53,7 +53,7 @@ Can be used as system boot media or storage media
 
 The ROCK Pi S0 provides a 40 pin GPIO socket that is compatible with most SBC accessories on the market.
 
-**Hint: Actual compatibility is subject to usage. **
+**Hint: Actual compatibility is subject to usage.**
 
 <TabItem value="GPIO">
      <div className='gpio_style' style={{ overflow :"auto"}} >


### PR DESCRIPTION
## Description

Fix broken bold markdown syntax (`** text **` -> `**text**`) in the ROCK Pi S0 pages so the bold warning/hint text renders correctly.

Fixes #212

### Changes

- **EN** `rockpis0/hardware/hardware-interface.md`: `**Hint: Actual compatibility is subject to usage. **` did not render as bold (the issue-reported line). The ZH counterpart was already correct, so only EN needed the fix.
- **EN** `rockpis0/getting-started/antenna-switch.md`: `** The default is to use the on-board antenna. **` -> bold. ZH counterpart already correct.
- **EN** `rockpis0/getting-started/preparation.md` and **ZH** `rockpis0/getting-started/preparation.md`: `** Radxa ROCK Pi S0 must be configured ... **` -> bold in both languages (both had the bug).

Same bug class as previously fixed in PR #1998 (ZERO 3E PoE HAT bold markdown).

### Bilingual note

This PR intentionally touches EN-only files for `hardware-interface.md` and `antenna-switch.md` because their ZH counterparts already use correct bold syntax — there is no ZH change needed. `preparation.md` is fixed in both languages since both had the bug.

### Checklist

- [x] docs-only, minimal, precise fix
- [x] ZH + EN verified for each changed page
