### PR TITLE
docs: add Raspberry Pi usage tutorial for LCD 8 HD

### DIFF
--- a/docs/accessories/display/lcd-8-hd/lcd-8-hd-usage.md
+++ b/docs/accessories/display/lcd-8-hd/lcd-8-hd-usage.md
@@ -167,4 +167,68 @@ Step 3：将卡扣向下按紧，固定排线
 6. 重启 SBC 以启用 overlay，显示屏将会输出画面
 
 </TabItem>
+<TabItem value="rpi" label="Raspberry Pi">
+
+瑞莎 8 寸高清触摸屏同样支持在 Raspberry Pi 4B 上使用。完整教程维护在 [radxa-displays-on-raspberry-pi](https://github.com/radxa/radxa-displays-on-raspberry-pi) 仓库中。
+
+### 准备
+
+- Raspberry Pi 4B
+- Radxa Display 8 HD 显示面板
+- 15 pin 转 40 pin FPC 连接线
+
+### 硬件连接
+
+使用 15 pin 转 40 pin FPC 连接线，将额外的 7 pin 排针与 Raspberry Pi 4B 的 40 pin GPIO 按下表连接：
+
+| Radxa Display 8 HD | Raspberry Pi 4B |
+| :----------------- | :-------------- |
+| VCC-5V             | PIN 2: 5V Power |
+| GND                | PIN 6: GND      |
+| BL-PWM             | PIN 1: 3V3 Power |
+| TP-RST             | PIN 11: GPIO 17 |
+| TP-INT             | PIN 7: GPIO 4   |
+| LCD-RESET          | PIN 17: 3V3 Power |
+
+*第七个引脚目前未使用。*
+
+### 软件设置
+
+1. 安装所需软件包：
+
+   ```bash
+   sudo apt update
+   sudo apt install dkms raspberrypi-kernel-headers
+   ```
+
+2. 安装内核驱动（可从 [releases 页面](https://github.com/radxa/radxa-displays-on-raspberry-pi/releases) 下载，或使用 wget）：
+
+   ```bash
+   wget https://github.com/radxa/radxa-displays-on-raspberry-pi/releases/download/1.0.0/panel-radxa-dsi-dkms_1.0.0_all.deb
+   sudo dpkg -i panel-radxa-dsi-dkms_1.0.0_all.deb
+   ```
+
+3. 修改配置文件 `/boot/firmware/config.txt`，在 `[all]` 之后添加以下内容：
+
+   ```
+   [all]
+   display_auto_detect=0
+   dtoverlay=vc4-kms-v3d
+   dtoverlay=vc4-kms-dsi-radxa-panel
+   ```
+
+4. 保存并重启：
+
+   ```bash
+   sync
+   sudo reboot
+   ```
+
+重启后屏幕即可正常显示。
+
+:::note
+最新操作步骤请参考 [radxa-displays-on-raspberry-pi](https://github.com/radxa/radxa-displays-on-raspberry-pi) 仓库。
+:::
+
+</TabItem>
 </Tabs>

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/display/lcd-8-hd/lcd-8-hd-usage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/display/lcd-8-hd/lcd-8-hd-usage.md
@@ -167,4 +167,68 @@ The physical connection diagram is referenced below:
 6. Reboot the SBC to apply overlay and the display will output a screen.
 
 </TabItem>
+<TabItem value="rpi" label="Raspberry Pi">
+
+Radxa Display 8 HD also works with Raspberry Pi 4B. The full guide is maintained in the [radxa-displays-on-raspberry-pi](https://github.com/radxa/radxa-displays-on-raspberry-pi) repository.
+
+### Preparations
+
+- Raspberry Pi 4B
+- Radxa Display 8 HD panel
+- 15-pin to 40-pin FPC cable
+
+### Hardware connection
+
+Use the 15-pin to 40-pin FPC cable and connect the 7-pin holder to the Raspberry Pi 4B 40-pin GPIO as follows:
+
+| Radxa Display 8 HD | Raspberry Pi 4B |
+| :----------------- | :-------------- |
+| VCC-5V             | PIN 2: 5V Power |
+| GND                | PIN 6: GND      |
+| BL-PWM             | PIN 1: 3V3 Power |
+| TP-RST             | PIN 11: GPIO 17 |
+| TP-INT             | PIN 7: GPIO 4   |
+| LCD-RESET          | PIN 17: 3V3 Power |
+
+*The seventh pin is currently unused.*
+
+### Software settings
+
+1. Install the required packages:
+
+   ```bash
+   sudo apt update
+   sudo apt install dkms raspberrypi-kernel-headers
+   ```
+
+2. Install the kernel driver (download from the [releases page](https://github.com/radxa/radxa-displays-on-raspberry-pi/releases) or use wget):
+
+   ```bash
+   wget https://github.com/radxa/radxa-displays-on-raspberry-pi/releases/download/1.0.0/panel-radxa-dsi-dkms_1.0.0_all.deb
+   sudo dpkg -i panel-radxa-dsi-dkms_1.0.0_all.deb
+   ```
+
+3. Modify the configuration file `/boot/firmware/config.txt` and add the following lines after `[all]`:
+
+   ```
+   [all]
+   display_auto_detect=0
+   dtoverlay=vc4-kms-v3d
+   dtoverlay=vc4-kms-dsi-radxa-panel
+   ```
+
+4. Save and reboot:
+
+   ```bash
+   sync
+   sudo reboot
+   ```
+
+After restarting, the display should work normally.
+
+:::note
+For the latest instructions, please refer to the [radxa-displays-on-raspberry-pi](https://github.com/radxa/radxa-displays-on-raspberry-pi) repository.
+:::
+
+</TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

Add a **Raspberry Pi 4B** usage tutorial to the [Radxa Display 8 HD usage page](https://docs.radxa.com/accessories/display/lcd-8-hd/lcd-8-hd-usage) (zh + en), resolving the missing Raspberry Pi documentation reported in #519.

The new tab documents, based on the official [radxa-displays-on-raspberry-pi](https://github.com/radxa/radxa-displays-on-raspberry-pi) repository:

- FPC wiring from the display's 7-pin holder to the Raspberry Pi 4B 40-pin GPIO (VCC-5V / GND / BL-PWM / TP-RST / TP-INT / LCD-RESET)
- DKMS kernel driver install (`panel-radxa-dsi-dkms`)
- `config.txt` overlay configuration (`vc4-kms-dsi-radxa-panel`) and reboot steps

## Why

Users asked how to use Radxa Display 8 HD on Raspberry Pi; the official driver repo already documents this, but the docs page only covered Radxa SBCs (4C+/5A/5B, 3A/3C/4SE). This change closes the gap with a link to the canonical upstream guide.

Fixes #519
