### PR TITLE
docs: add 3D file download link to X4 heatsink page

### DIFF
--- a/docs/x/x4/accessories/heatsink-for-x4.md
+++ b/docs/x/x4/accessories/heatsink-for-x4.md
@@ -46,3 +46,7 @@ sidebar_position: 15
 - 最后，用 6 颗 KM2x4 螺钉固定散热器支架。
 
 ![install_heatsink_05](/img/x/x4/heatsink_for_x4_05.webp)
+
+## 资料下载
+
+- [3D 文件](https://dl.radxa.com/accessories/heatsink-for-x4/radxa_heatsink_for_x4_3d.zip)

--- a/i18n/en/docusaurus-plugin-content-docs/current/x/x4/accessories/heatsink-for-x4.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/x/x4/accessories/heatsink-for-x4.md
@@ -46,3 +46,7 @@ Before adhering the thermal silicone pad, please ensure to remove the protective
 - Finally, secure the heatsink bracket with 6 KM2x4 screws.
 
 ![install_heatsink_05](/img/x/x4/heatsink_for_x4_05.webp)
+
+## Downloads
+
+- [3D Drawings](https://dl.radxa.com/accessories/heatsink-for-x4/radxa_heatsink_for_x4_3d.zip)


### PR DESCRIPTION
Fixes #456

## 问题 / Issue

Issue #456 指出 Radxa X4 散热器页面缺少 3D 文件下载链接。

## 修改 / Change

- 在 X4 Heatsink 页面（中/英文）新增 `资料下载 / Downloads` 一节
- 添加 3D 文件下载链接：https://dl.radxa.com/accessories/heatsink-for-x4/radxa_heatsink_for_x4_3d.zip（已验证可访问，HTTP 200）
- 该配件已在 `x/x4/accessories/` 分类下并已列入配件列表，分类归属无需再调整

## 影响范围 / Scope

- `docs/x/x4/accessories/heatsink-for-x4.md` (zh)
- `i18n/en/.../x/x4/accessories/heatsink-for-x4.md` (en)

中英文同步更新。
