### PR TITLE
docs: fix ZERO 3 Wi-Fi/Bluetooth specs with hardware version differences

### DIFF
--- a/docs/zero/zero3/README.md
+++ b/docs/zero/zero3/README.md
@@ -73,7 +73,7 @@ sidebar_position: 5
     </tr>
     <tr>
         <td align="center">无线通讯</td>
-        <td align="center">Wi-Fi 6 (802.11 b/g/n) BT 5.0 with BLE</td>
+        <td align="center">Wi-Fi 6 (802.11 a/b/g/n/ac/ax) BT 5.4 with BLE</td>
         <td align="center">/</td>
     </tr>
     <tr>

--- a/docs/zero/zero3/faq.md
+++ b/docs/zero/zero3/faq.md
@@ -104,7 +104,9 @@ sudo apt autoremove
 
 是的，Radxa ZERO 3 支持 Wi-Fi 和蓝牙：
 - **Wi-Fi**：支持 2.4GHz 和 5GHz 频段
-- **蓝牙**：支持 Bluetooth 5.0
+- **蓝牙**：支持 Bluetooth 5.4
+
+> **注意**：ZERO 3 系列存在硬件版本差异。早期版本（如 AP6212 模块）仅支持 2.4GHz（802.11 b/g/n）和 Bluetooth 4.0；当前在售版本（V1.12I）已换用双频 Wi-Fi 6 模块（如 BL-M8800DS2 / FCS960KAAMD），硬件支持 2.4GHz / 5GHz 双频和 Bluetooth 5.4。5GHz 下具体信道（如 112 信道）是否可用取决于驱动、固件与监管域（regulatory domain）配置，需结合实测确认。
 
 如果遇到连接问题：
 1. 检查天线是否连接（如有）

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/README.md
@@ -72,7 +72,7 @@ sidebar_position: 5
     </tr>
     <tr>
         <td align="center">Wireless</td>
-        <td align="center">Wi-Fi 6 (802.11 b/g/n) BT 5.0 with BLE</td>
+        <td align="center">Wi-Fi 6 (802.11 a/b/g/n/ac/ax) BT 5.4 with BLE</td>
         <td align="center">/</td>
     </tr>
     <tr>

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/faq.md
@@ -104,7 +104,9 @@ sudo apt autoremove
 
 Yes, Radxa ZERO 3 supports Wi-Fi and Bluetooth:
 - **Wi-Fi**: Supports 2.4GHz and 5GHz bands
-- **Bluetooth**: Supports Bluetooth 5.0
+- **Bluetooth**: Supports Bluetooth 5.4
+
+> **Note**: There are hardware version differences across the ZERO 3 series. Early versions (e.g. the AP6212 module) only support 2.4GHz (802.11 b/g/n) and Bluetooth 4.0; the current shipping version (V1.12I) uses a dual-band Wi-Fi 6 module (e.g. BL-M8800DS2 / FCS960KAAMD) with hardware support for 2.4GHz / 5GHz dual-band and Bluetooth 5.4. Whether a specific 5GHz channel (e.g. channel 112) is usable depends on the driver, firmware and regulatory domain configuration, and should be confirmed by actual testing.
 
 If experiencing connection issues:
 1. Check if antenna is connected (if applicable)


### PR DESCRIPTION
## 背景

GitHub Discussion #1794：用户询问 ZERO 3W 是否支持 5G 112 信道。

内部通过 BOM + 模块 datasheet 核实后确认 ZERO 3 系列存在硬件版本差异：
- 早期版本（AP6212 模块）仅支持 2.4GHz（802.11 b/g/n）+ BT 4.0，不支持 5GHz；
- 当前在售版本（V1.12I）已换用双频 Wi-Fi 6 模块（BL-M8800DS2 / FCS960KAAMD），硬件支持 2.4/5GHz + BT 5.4。

## 修改内容

1. **README 无线规格表**（中/英）：`Wi-Fi 6 (802.11 b/g/n) BT 5.0` → `Wi-Fi 6 (802.11 a/b/g/n/ac/ax) BT 5.4 with BLE`
   - 原表述自相矛盾（Wi-Fi 6 = 802.11ax，不是 b/g/n），且与当前 V1.12I 模块规格不符。
2. **FAQ Q9**（中/英）：补充硬件版本差异说明——早期 AP6212 仅 2.4GHz；当前 V1.12I 双频 Wi-Fi 6 模块；5GHz 具体信道（如 112）可用性取决于驱动/固件/监管域配置，需实测确认。

## 影响范围

仅 docs/zero/zero3 页面（README + faq），中英双语同步修改。

## 关联

- GitHub Discussion: https://github.com/radxa-docs/docs/discussions/1794
- 已按此口径回复讨论区：https://github.com/radxa-docs/docs/discussions/1794#discussioncomment-18021305
