### PR TITLE
docs: rock5c: fix broken accessory links in hardware-interface

### DIFF
--- a/docs/rock5/rock5c/hardware-design/hardware-interface.md
+++ b/docs/rock5/rock5c/hardware-design/hardware-interface.md
@@ -217,7 +217,7 @@ ROCK 5C 提供了一个40pin针脚的GPIO座子，兼容于市面上大部分传
 
 </div>
 
-参考 [摄像头配件](../accessories/camera)
+参考 [摄像头配件](../accessories)
 
 ### MIPI DSI
 
@@ -255,7 +255,7 @@ ROCK 5C 提供了一个40pin针脚的GPIO座子，兼容于市面上大部分传
 
 </div>
 
-参考 [屏幕配件](../accessories/display)
+参考 [屏幕配件](../accessories)
 
 ### microSD
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/hardware-design/hardware-interface.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/hardware-design/hardware-interface.md
@@ -218,7 +218,7 @@ MIPI camera support. Utilizes a 31-pin, 0.3 mm pitch, gold-plated connector, mod
 
 </div>
 
-Refer [Camera accessories](../accessories/camera)
+Refer [Camera accessories](../accessories)
 
 ### MIPI DSI
 
@@ -256,7 +256,7 @@ MIPI screen support. Utilizes a 39-pin, 0.3 mm pitch, gold-plated connector, mod
 
 </div>
 
-Refer [Display accessories](../accessories/display)
+Refer [Display accessories](../accessories)
 
 ### microSD
 


### PR DESCRIPTION
Fixes #297

## Summary

The ROCK 5C hardware-interface page linked to `../accessories/camera` and `../accessories/display`, but ROCK 5C does not have those sub-pages (only the accessories README exists under `rock5c/accessories/`), so both links were broken.

## Change

- Point the "摄像头配件" (Camera accessories) and "屏幕配件" (Display accessories) links in the MIPI CSI / MIPI DSI sections to the existing accessories list page (`../accessories`), matching the pattern used by other products (e.g. ROCK 3A, Zero 3).
- Applied the same fix to both the Chinese source and the English i18n copy.

## Verification

- `github_pr_guard.py check` passes: 1 commit, 2 files, bilingual (zh + en) complete.
