### PR TITLE
docs(rock5itx): add FAQ note for ROOBI not pre-installed boot issue

### DIFF
--- a/docs/rock5/rock5itx/getting-started/quick-start.md
+++ b/docs/rock5/rock5itx/getting-started/quick-start.md
@@ -51,3 +51,7 @@ ROCK 5 ITX 标准包装包括以下物品：
 5. 如果有 2.5/3.5 英寸的 SATA 硬盘，连接 SATA 线和硬盘电源线。
 6. 将 12V DC 适配器插入 ROCK 5 ITX 的 DC 接口。设备会自动上电启动，电源指示灯将亮起。
 7. ROCK 5 ITX 配备了预装的 Radxa 自研 ROOBI OS 的 8GB eMMC。上电后几秒钟，HDMI 显示器将显示 ROOBI OS 的界面。
+
+:::warning 上电后无法启动？
+如果电源指示灯亮起但 HDMI 显示器长时间没有画面，可能是 eMMC 中没有预装 ROOBI OS。此时请参考[手动重装系统](./install-os/README)章节，通过 microSD 启动盘或 Maskrom 模式手动安装系统。
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/quick-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/quick-start.md
@@ -50,4 +50,8 @@ Peripherals that are not required but can enhance the basic functions of the ROC
 <img src="/img/rock5itx/rock5itx-fan-wifi-pcie.webp" width="700" alt="rock 5 itx ssd/wifi-bt" />
 
 6. Plug the 12V DC adapter into the DC socket of the ROCK 5 ITX. The unit will automatically power up and start up, and the power indicator will light up.
-7. The ROCK 5 ITX is equipped with 8GB eMMC with Radxa's own ROOBI OS pre-installed. a few seconds after powering up, the HDMI display will show the ROOBI OS interface.
+7. The ROCK 5 ITX is equipped with 8GB eMMC with Radxa's own ROOBI OS pre-installed. A few seconds after powering up, the HDMI display will show the ROOBI OS interface.
+
+:::warning Cannot boot after powering on?
+If the power indicator lights up but the HDMI display stays blank for a long time, the ROOBI OS may not be pre-installed on the eMMC. In this case, please refer to the [Manual reinstallation](./install-os/README) section to install the system manually via a microSD boot disk or Maskrom mode.
+:::


### PR DESCRIPTION
## Summary

Addresses #504 (ROCK 5 ITX FAQ): if the power LED lights up but the HDMI display stays blank after power-on, the ROOBI OS may not be pre-installed on the eMMC. This can happen on units where ROOBI is missing from eMMC, which prevents the board from booting into a visible interface.

Added a warning callout on the ROCK 5 ITX quick-start page (both zh and en) pointing users to the [Manual reinstallation](./install-os/README) section to install the system via microSD boot disk or Maskrom mode.

## Changes

- `docs/rock5/rock5itx/getting-started/quick-start.md`: add `:::warning` callout after ROOBI boot step
- `i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5itx/getting-started/quick-start.md`: same callout in English

## Impact

Reduces user confusion when a ROCK 5 ITX powers on but shows no display: instead of assuming a hardware fault, users learn that the eMMC may lack the pre-installed ROOBI OS and are directed to the manual reinstallation guide.

Fixes #504
