### PR TITLE
docs: add CM5 power supply specification to README

### DIFF
--- a/docs/som/cm/cm5/README.md
+++ b/docs/som/cm/cm5/README.md
@@ -18,14 +18,14 @@ Radxa CM5 是基于 Rockchip RK3588S 片上系统 (SoC) 的系统模块 (SoM)。
 
 #### 特性
 
-| Features | Description                                                                                                                                                               |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SoC      | Rockchip RK3588S2                                                                                                                                                         |
-| CPU      | Quad Cortex®‑A76 @ 2.2~2.4GHz and a quad Cortex®‑A55 @ 1.8GHz<br/>based on Arm® DynamIQ™ configuration                                                                    |
-| GPU      | Arm Mali™ G610MP4 GPU ‑ OpenGL® ES1.1, ES2.0, and ES3.2 ‑ OpenCL®<br/>1.1, 1.2 and 2.2 ‑ Vulkan® 1.1 and 1.2 ‑ Embedded high performance 2D<br/>image acceleration module |
-| NPU      | NPU supporting INT4 / INT8 / INT16 / FP16 / BF16 and TF32 acceleration<br/>and computing power is up to 6TOPs                                                             |
-| Memory   | 1GB, 2GB, 4GB, 8GB or 16GB LPDDR4X (depending on SKU)                                                                                                                     |
-| Storage  | Optional 4GB / 8GB / 16GB / 32GB, up to 512GB Onboard eMMC Compatible with eMMC 5.1<br />Supports SDMMC interface for data storage and OS booting using<br />SD cards     |
+| 类别                | 规格                                                                                                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 系统级芯片(SoC)     | Rockchip RK3588S2                                                                                                                                                         |
+| 中央处理器(CPU)     | 四核 Cortex®‑A76 @ 2.2~2.4GHz 和四核 Cortex®‑A55 @ 1.8GHz<br/>基于 Arm® DynamIQ™ 配置                                                                                    |
+| 图形处理器(GPU)     | Arm Mali™ G610MP4 GPU ‑ OpenGL® ES1.1、ES2.0 和 ES3.2 ‑ OpenCL®<br/>1.1、1.2 和 2.2 ‑ Vulkan® 1.1 和 1.2 ‑ 嵌入式高性能 2D<br/>图像加速模块                              |
+| 神经网络处理器(NPU) | NPU 支持 INT4 / INT8 / INT16 / FP16 / BF16 和 TF32 加速，<br/>算力高达 6TOPs                                                                                            |
+| 内存                | 1GB、2GB、4GB、8GB 或 16GB LPDDR4X（视 SKU 而定）                                                                                                                         |
+| 存储                | 可选 4GB / 8GB / 16GB / 32GB，最高 512GB 板载 eMMC，兼容 eMMC 5.1<br />支持 SDMMC 接口用于数据存储和<br />通过 SD 卡启动操作系统                                          |
 
 </TabItem>
 

--- a/docs/som/cm/cm5/README.md
+++ b/docs/som/cm/cm5/README.md
@@ -18,14 +18,14 @@ Radxa CM5 是基于 Rockchip RK3588S 片上系统 (SoC) 的系统模块 (SoM)。
 
 #### 特性
 
-| Features | Description                                                                                                                                                                   |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SoC      | Rockchip RK3588S2                                                                                                                                                             |
+| Features | Description                                                                                                                                                               |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SoC      | Rockchip RK3588S2                                                                                                                                                         |
 | CPU      | Quad Cortex®‑A76 @ 2.2~2.4GHz and a quad Cortex®‑A55 @ 1.8GHz<br/>based on Arm® DynamIQ™ configuration                                                                    |
 | GPU      | Arm Mali™ G610MP4 GPU ‑ OpenGL® ES1.1, ES2.0, and ES3.2 ‑ OpenCL®<br/>1.1, 1.2 and 2.2 ‑ Vulkan® 1.1 and 1.2 ‑ Embedded high performance 2D<br/>image acceleration module |
-| NPU      | NPU supporting INT4 / INT8 / INT16 / FP16 / BF16 and TF32 acceleration<br/>and computing power is up to 6TOPs                                                                 |
-| Memory   | 1GB, 2GB, 4GB, 8GB or 16GB LPDDR4X (depending on SKU)                                                                                                                         |
-| Storage  | Optional 4GB / 8GB / 16GB / 32GB, up to 512GB Onboard eMMC Compatible with eMMC 5.1<br />Supports SDMMC interface for data storage and OS booting using<br />SD cards         |
+| NPU      | NPU supporting INT4 / INT8 / INT16 / FP16 / BF16 and TF32 acceleration<br/>and computing power is up to 6TOPs                                                             |
+| Memory   | 1GB, 2GB, 4GB, 8GB or 16GB LPDDR4X (depending on SKU)                                                                                                                     |
+| Storage  | Optional 4GB / 8GB / 16GB / 32GB, up to 512GB Onboard eMMC Compatible with eMMC 5.1<br />Supports SDMMC interface for data storage and OS booting using<br />SD cards     |
 
 </TabItem>
 
@@ -55,6 +55,16 @@ Radxa CM5 是基于 Rockchip RK3588S 片上系统 (SoC) 的系统模块 (SoM)。
 </TabItem>
 
 </Tabs>
+
+### 供电
+
+Radxa CM5 模块输入电压（VCC_SYSIN）范围为 3.6V-5.2V，在 4V 时效率最高。若输入电压达到或超过 5V，电压调节电路可能产生可闻的嗡鸣声。
+
+典型工作电流为 2A。设计载板供电电路时，推荐使用 4V 3A 电源。
+
+:::note
+Rockchip 官方推荐为 RK806 PMU 提供 4V 电源，以确保最佳效率和峰值性能。使用 5V 电源可能降低效率，并可能导致 DC-DC 啸叫问题。
+:::
 
 ### 芯片框图
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm5/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm5/README.md
@@ -16,14 +16,14 @@ The Radxa CM5 is a System on Module (SoM) based on a the Rockchip RK3588S System
 
 #### Features
 
-| Features | Description                                                                                                                                                                   |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SoC      | Rockchip RK3588S/RK3588S2                                                                                                                                                     |
+| Features | Description                                                                                                                                                               |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SoC      | Rockchip RK3588S/RK3588S2                                                                                                                                                 |
 | CPU      | Quad Cortex®‑A76 @ 2.2~2.4GHz and a quad Cortex®‑A55 @ 1.8GHz<br/>based on Arm® DynamIQ™ configuration                                                                    |
 | GPU      | Arm Mali™ G610MP4 GPU ‑ OpenGL® ES1.1, ES2.0, and ES3.2 ‑ OpenCL®<br/>1.1, 1.2 and 2.2 ‑ Vulkan® 1.1 and 1.2 ‑ Embedded high performance 2D<br/>image acceleration module |
-| NPU      | NPU supporting INT4 / INT8 / INT16 / FP16 / BF16 and TF32 acceleration<br/>and computing power is up to 6TOPs                                                                 |
-| Memory   | 1GB, 2GB, 4GB, 8GB or 16GB LPDDR4X (depending on SKU)                                                                                                                         |
-| Storage  | Optional 4GB / 8GB / 16GB / 32GB, up to 512GB Onboard eMMC Compatible with eMMC 5.1<br />Supports SDMMC interface for data storage and OS booting using<br />SD cards         |
+| NPU      | NPU supporting INT4 / INT8 / INT16 / FP16 / BF16 and TF32 acceleration<br/>and computing power is up to 6TOPs                                                             |
+| Memory   | 1GB, 2GB, 4GB, 8GB or 16GB LPDDR4X (depending on SKU)                                                                                                                     |
+| Storage  | Optional 4GB / 8GB / 16GB / 32GB, up to 512GB Onboard eMMC Compatible with eMMC 5.1<br />Supports SDMMC interface for data storage and OS booting using<br />SD cards     |
 
 </TabItem>
 
@@ -51,6 +51,16 @@ The Radxa CM5 is a System on Module (SoM) based on a the Rockchip RK3588S System
 </TabItem>
 
 </Tabs>
+
+### Power Supply
+
+The input voltage range of the Radxa CM5 module (VCC_SYSIN) is 3.6V-5.2V, with the maximum efficiency achieved at 4V. Supplying 5V or above may cause audible humming from the voltage regulating circuit.
+
+Typical current consumption is 2A. For the power supply circuit on your carrier board, we recommend a 4V 3A supply.
+
+:::note
+Rockchip officially recommends a 4V power supply for the RK806 PMU to ensure optimal efficiency and peak performance. Using a 5V supply may result in reduced efficiency and potentially lead to DC-DC whistling issues.
+:::
 
 ### Chip Block Diagram
 


### PR DESCRIPTION
Fixes #267

## Summary

Add the Radxa CM5 power supply specification to the CM5 README (both Chinese and English).

## Changes

- **docs/som/cm/cm5/README.md** (zh): added `### 供电` section
- **i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm5/README.md** (en): added `### Power Supply` section

Content added:
- Input voltage range (VCC_SYSIN): 3.6V-5.2V
- Maximum efficiency at 4V; 5V or above may cause audible humming from the voltage regulating circuit
- Typical current consumption: 2A
- Recommended carrier board supply: 4V 3A
- Note: Rockchip officially recommends 4V for the RK806 PMU to ensure optimal efficiency; a 5V supply may cause reduced efficiency and DC-DC whistling

## Source / Verification

The 4V recommendation and 5V DC-DC whistling behavior are confirmed by the official document `radxa_cm5_carrier_board_design_note.pdf` (§3.1 Power Supply) and the CM5 schematic (`4V Power for RK3588S`). The 3.6-5.2V input range and typical 2A current are consistent with the RK806 PMU-based power design of the CM5 module.

## Checklist

- [x] zh + en both updated
- [x] pre-commit hooks passed (prettier reformat applied)
- [x] Issue #267 will be auto-closed on merge
