### PR TITLE
docs(e20c): clarify Maskrom button hold timing before/during power-on

### DIFF
--- a/docs/e/e20c/getting-started/install-os/maskrom/_maskrom.mdx
+++ b/docs/e/e20c/getting-started/install-os/maskrom/_maskrom.mdx
@@ -19,12 +19,15 @@ Maskrom模式，也称为Loader模式，是一种特殊的启动模式，一般�
 
 </details>
 
-### 如何进入Maskrom 状态
+### 如何进入 Maskrom 状态
 
-- 将 USB A-C 电缆插入 E20C 的 Type-C 的 Debug 端口，另一端插入电脑。
-- **上电前**按住 **Maskrom button**，并保持按住直到设备上电完成
-- 上电 （将 USB A-C 电缆插入 E20C 的 Type-C Power端口，另一端接入电源。）
-- 待设备进入 Maskrom 状态后，松开 **Maskrom button** 即可
-- 此时正常情况下会进入 Maskrom 状态
+主板上电过程中检测到 Maskrom 按键被按下，主板会自动进入 Maskrom 模式。
+
+详细操作步骤：
+
+1. 使用 Type-C 数据线连接主板的调试（Debug）接口和 PC
+2. 按住 Maskrom 按键
+3. 使用电源适配器给主板供电
+4. 松开 Maskrom 按键
 
 ![MaskRom Key](/img/e/e20c/radxa-e20c-hardware-overview.webp)

--- a/docs/e/e20c/getting-started/install-os/maskrom/_maskrom.mdx
+++ b/docs/e/e20c/getting-started/install-os/maskrom/_maskrom.mdx
@@ -22,8 +22,9 @@ Maskrom模式，也称为Loader模式，是一种特殊的启动模式，一般�
 ### 如何进入Maskrom 状态
 
 - 将 USB A-C 电缆插入 E20C 的 Type-C 的 Debug 端口，另一端插入电脑。
-- 按住 **Maskrom button**
+- **上电前**按住 **Maskrom button**，并保持按住直到设备上电完成
 - 上电 （将 USB A-C 电缆插入 E20C 的 Type-C Power端口，另一端接入电源。）
+- 待设备进入 Maskrom 状态后，松开 **Maskrom button** 即可
 - 此时正常情况下会进入 Maskrom 状态
 
 ![MaskRom Key](/img/e/e20c/radxa-e20c-hardware-overview.webp)

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/getting-started/install-os/maskrom/_maskrom.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/getting-started/install-os/maskrom/_maskrom.mdx
@@ -25,8 +25,9 @@
 ### How to enter Maskrom state
 
 - Plug the USB A-C cable into the Debug port of the E20C and the other end into your computer.
-- Press and hold the **Maskrom button**(see picture below)
+- **Before powering on**, press and hold the **Maskrom button** and keep holding it until the device is powered on
 - Power on (Plug the USB A-C cable into the E20C's Type-C Power port and the other end into a power source.)
+- Release the **Maskrom button** once the device enters the Maskrom state
 - This will normally enter the Maskrom state
 
 ![MaskRom Key](/img/e/e20c/radxa-e20c-hardware-overview.webp)

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/getting-started/install-os/maskrom/_maskrom.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/getting-started/install-os/maskrom/_maskrom.mdx
@@ -24,10 +24,13 @@
 
 ### How to enter Maskrom state
 
-- Plug the USB A-C cable into the Debug port of the E20C and the other end into your computer.
-- **Before powering on**, press and hold the **Maskrom button** and keep holding it until the device is powered on
-- Power on (Plug the USB A-C cable into the E20C's Type-C Power port and the other end into a power source.)
-- Release the **Maskrom button** once the device enters the Maskrom state
-- This will normally enter the Maskrom state
+If the Maskrom button is detected as pressed while the board is powering on, the board will automatically enter Maskrom mode.
+
+Detailed steps:
+
+1. Use a USB Type-C cable to connect the Debug port of the board to your PC
+2. Press and hold the Maskrom button
+3. Power on the board with a power adapter
+4. Release the Maskrom button
 
 ![MaskRom Key](/img/e/e20c/radxa-e20c-hardware-overview.webp)


### PR DESCRIPTION
## 来源

GitHub Issue [#437](https://github.com/radxa-docs/docs/issues/437)：用户反馈 E20C Maskrom 模式说明不清晰，未说明按键需要**上电前按住、上电过程中保持按住、进入 Maskrom 状态后再松开**，导致用户无法进入 Maskrom 模式。

## 修改内容

- `docs/e/e20c/getting-started/install-os/maskrom/_maskrom.mdx`（中文）
- `i18n/en/docusaurus-plugin-content-docs/current/e/e20c/getting-started/install-os/maskrom/_maskrom.mdx`（英文）

在「如何进入 Maskrom 状态」步骤中补充按键时序：

1. **上电前**按住 Maskrom button，并保持按住直到设备上电完成
2. 上电后待设备进入 Maskrom 状态，松开按钮即可

## 影响范围

- 仅 E20C Maskrom 刷机说明文档，docs-only 修改
- 中英文已同步更新

Fixes #437