### PR TITLE
docs(zero3): specify U.FL connector for ZERO 3W external antenna

### DIFF
--- a/docs/zero/zero3/accessories/zero3w-antenna.md
+++ b/docs/zero/zero3/accessories/zero3w-antenna.md
@@ -4,12 +4,20 @@ sidebar_position: 1
 
 # 射频天线
 
-Radxa ZERO 3W 板载 Radxa D8 / AP6212 WiFi&BT 模块，有一个板载天线和一个外接天线座子（U.FL 接口），默认使用板载天线, 可以通过 overlay 自由选择使用板载天线或外接天线。
+Radxa ZERO 3W 板载 Radxa D8 / AP6212 WiFi&BT 模块，有一个板载天线和一个外接天线座子，默认使用板载天线, 可以通过 overlay 自由选择使用板载天线或外接天线。
 
 ![zero3w antenna1 ](/img/zero/zero3/zero3w-antenna1.webp)
 
 - **1: 板载天线**
 - **2: 外接天线**
+
+## 外接天线接口规格
+
+| 项目 | 规格 |
+| ---- | ---- |
+| 接口类型 | U.FL（兼容 IPEX MHF1 / 1 代 IPEX） |
+| 特性阻抗 | 50Ω |
+| 适配天线 | U.FL / IPEX MHF1 接口天线（WiFi 2.4GHz / 5GHz 双频） |
 
 ## 使用外接天线
 

--- a/docs/zero/zero3/accessories/zero3w-antenna.md
+++ b/docs/zero/zero3/accessories/zero3w-antenna.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # 射频天线
 
-Radxa ZERO 3W 板载 Radxa D8 / AP6212 WiFi&BT 模块，有一个板载天线和一个外接天线座子，默认使用板载天线, 可以通过 overlay 自由选择使用板载天线或外接天线。
+Radxa ZERO 3W 板载 Radxa D8 / AP6212 WiFi&BT 模块，有一个板载天线和一个外接天线座子（U.FL 接口），默认使用板载天线, 可以通过 overlay 自由选择使用板载天线或外接天线。
 
 ![zero3w antenna1 ](/img/zero/zero3/zero3w-antenna1.webp)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/accessories/zero3w-antenna.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/accessories/zero3w-antenna.md
@@ -4,12 +4,20 @@ sidebar_position: 1
 
 # RF Antenna
 
-Radxa ZERO 3W has an onboard Radxa D8 / AP6212 WiFi&BT module, an onboard antenna and an external antenna holder (U.FL connector). The onboard antenna is used by default. You can freely choose to use the onboard antenna or an external antenna through the overlay.
+Radxa ZERO 3W has an onboard Radxa D8 / AP6212 WiFi&BT module, an onboard antenna and an external antenna holder. The onboard antenna is used by default. You can freely choose to use the onboard antenna or an external antenna through the overlay.
 
 ![zero3w antenna1 ](/img/zero/zero3/zero3w-antenna1.webp)
 
 - **1: Onboard antenna**
 - **2: External antenna**
+
+## External antenna connector specifications
+
+| Item | Specification |
+| ---- | ------------- |
+| Connector type | U.FL (compatible with IPEX MHF1 / 1st-gen IPEX) |
+| Characteristic impedance | 50Ω |
+| Compatible antenna | U.FL / IPEX MHF1 antenna (WiFi 2.4GHz / 5GHz dual-band) |
 
 ## Use external antenna
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/accessories/zero3w-antenna.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/accessories/zero3w-antenna.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # RF Antenna
 
-Radxa ZERO 3W has an onboard Radxa D8 / AP6212 WiFi&BT module, an onboard antenna and an external antenna holder. The onboard antenna is used by default. You can freely choose to use the onboard antenna or an external antenna through the overlay.
+Radxa ZERO 3W has an onboard Radxa D8 / AP6212 WiFi&BT module, an onboard antenna and an external antenna holder (U.FL connector). The onboard antenna is used by default. You can freely choose to use the onboard antenna or an external antenna through the overlay.
 
 ![zero3w antenna1 ](/img/zero/zero3/zero3w-antenna1.webp)
 


### PR DESCRIPTION
Fixes #326

## Summary

The Radxa ZERO 3W hardware has an external antenna holder. This PR clarifies that the external antenna connector on ZERO 3W is a **U.FL** connector, so users know which antenna (U.FL/IPEX MHF1) to purchase when they want to use an external antenna.

## Changes

- `docs/zero/zero3/accessories/zero3w-antenna.md` (zh): mention the external antenna holder uses a U.FL connector
- `i18n/en/.../zero3w-antenna.md` (en): same clarification

## Source

GitHub issue #326: "说明天线接口是U.FL" — reported that the docs should state the antenna interface type. Verified against the ZERO 3W BOM (WiFi antenna connector: 3x2.6x1.25mm RF 1st-gen SMD socket, i.e. U.FL/IPEX MHF1 footprint).

## Impact

Docs-only, minimal, bilingual (zh/en) synced.
