### PR TITLE
docs(mali-gpu): add glxinfo/es2_info renderer verification steps

### DIFF
--- a/docs/common/radxa-os/_mali-gpu.mdx
+++ b/docs/common/radxa-os/_mali-gpu.mdx
@@ -208,3 +208,17 @@ sudo apt list libmali-* --installed
 Listing... Done
 libmali-bifrost-g52-g13p0-x11-wayland-gbm/rk3566-bookworm-test,now 1.9-1 arm64 [installed]
 ```
+
+### 验证 OpenGL 渲染器
+
+运行以下命令，查看当前生效的 OpenGL / OpenGL ES 渲染器：
+
+```bash
+glxinfo | grep "OpenGL renderer"
+es2_info | grep "OpenGL ES renderer"
+```
+
+- 使用 Mali 驱动时，`es2_info` 应显示对应的 Mali GPU 名称，例如 `Mali-G610`（RK3588 系列）或 `Mali-G52`（RK356X/RK3576 系列）。
+- 由于 Mali 驱动不支持桌面 OpenGL（见上文特性表），`glxinfo` 显示 `llvmpipe` 属于正常现象，请以 `es2_info` 的输出为准。
+- 使用 Panfrost/Panthor 驱动时，`glxinfo` 与 `es2_info` 应显示 `Panfrost` 或 `Panthor`。
+- 如果 `es2_info` 显示 `llvmpipe`，说明 GPU 驱动未生效，当前为软件渲染，请检查上述步骤是否完整执行。

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_mali-gpu.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/_mali-gpu.mdx
@@ -210,3 +210,17 @@ sudo apt list libmali-* --installed
 Listing... Done
 libmali-bifrost-g52-g13p0-x11-wayland-gbm/rk3566-bookworm-test,now 1.9-1 arm64 [installed]
 ```
+
+### Verify the OpenGL renderer
+
+Run the following commands to check the currently active OpenGL / OpenGL ES renderer:
+
+```bash
+glxinfo | grep "OpenGL renderer"
+es2_info | grep "OpenGL ES renderer"
+```
+
+- When using the Mali driver, `es2_info` should show the corresponding Mali GPU name, for example `Mali-G610` (RK3588 series) or `Mali-G52` (RK356X/RK3576 series).
+- Since the Mali driver does not support desktop OpenGL (see the feature table above), it is normal for `glxinfo` to show `llvmpipe`; rely on the `es2_info` output instead.
+- When using the Panfrost/Panthor driver, both `glxinfo` and `es2_info` should show `Panfrost` or `Panthor`.
+- If `es2_info` shows `llvmpipe`, the GPU driver is not active and software rendering is in use; check whether all the steps above have been completed.


### PR DESCRIPTION
## Summary

Adds a **Verify the OpenGL renderer** section to the Mali GPU driver switching guide (`_mali-gpu.mdx`, bilingual zh/en).

The guide already covers verifying the kernel driver, the xorg-xserver version, and the user-level driver — but users had no way to quickly confirm the actual OpenGL/OpenGL ES renderer in use. This change adds:

- How to check the active renderer via `glxinfo` and `es2_info`
- Expected output: Mali GPU name (e.g. `Mali-G610` / `Mali-G52`) when the Mali driver is active
- Clarification that `glxinfo` may still show `llvmpipe` with the Mali driver (it does not support desktop OpenGL), so `es2_info` is the reliable check
- `llvmpipe` as a signal that the GPU driver is not active (software rendering)

## Motivation

From GitHub issue #520 (rock5/rock5b/radxa-os/mali-gpu): users wanted the docs to show the expected `glxinfo`/`es2_info` output so they can distinguish `llvmpipe` (software rendering) from the correct driver name.

Fixes #520
