### PR TITLE
docs: add Radxa CM3S mention to CM3 README

### DIFF
--- a/docs/som/cm/cm3/README.md
+++ b/docs/som/cm/cm3/README.md
@@ -6,4 +6,8 @@ sidebar_position: 10
 
 Radxa Compute Module 3(Radxa CM3)是基于 Rockchip RK3566 SoC 所实现的，具有小尺寸和紧凑布局的计算模块。
 
+:::note
+瑞莎 CM3 系列还包括采用 SODIMM 形态的 **Radxa CM3S** 计算模块（同样基于 Rockchip RK3566 SoC），可搭配 [Radxa CM3S IO Board](/accessories/io-board/cm3s-io-board) 进行功能评估与早期产品开发。
+:::
+
 <DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/README.md
@@ -6,4 +6,8 @@ sidebar_position: 10
 
 The Radxa Compute Module 3 (Radxa CM3) is a compact, space-efficient compute module based on the Rockchip RK3566 system-on-chip (SoC).
 
+:::note
+The Radxa CM3 family also includes the **Radxa CM3S** compute module in a SODIMM form factor (also based on the Rockchip RK3566 SoC). It can be used with the [Radxa CM3S IO Board](/accessories/io-board/cm3s-io-board) for feature evaluation and early-stage product development.
+:::
+
 <DocCardList />


### PR DESCRIPTION
## Summary

Closes #351 — the Radxa CM3 page (`/som/cm/cm3/`) is the routing target for **Radxa CM3S** in `docs/productlist.md` (`Radxa CM3 / CM3S` → `/som/cm/cm3/`), but the page never mentioned CM3S.

This PR adds a short note to the CM3 README (zh + en) explaining that:
- The Radxa CM3 family also includes the **CM3S** compute module (SODIMM form factor, same Rockchip RK3566 SoC)
- Links to the [Radxa CM3S IO Board](/accessories/io-board/cm3s-io-board) page for evaluation/early development

## Verification

- CM3S is a real product: official product brief confirms RK3566 SoC, DDR2 SODIMM form factor (67.6mm x 32mm); dl.radxa.com has `cm3s/` resources and compliance pages exist
- `docs/compliance/compute-module/radxa-cm3s.md` and `docs/accessories/io-board/cm3s-io-board.md` already exist (both zh + en)
- Link target verified present in both locales

## Files changed

- `docs/som/cm/cm3/README.md`
- `i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3/README.md`

Fixes #351