### PR TITLE
docs: fix broken rsetup link on canbus pages

### DIFF
--- a/docs/common/dev/_canbus.mdx
+++ b/docs/common/dev/_canbus.mdx
@@ -12,7 +12,7 @@ CANBUS 简介
 
 ### 开启 Overlay
 
-请参照[设备树配置](../../radxa-os/rsetup#overlays) 启用 CANBUS 相关 Overlay, eg: "Enable CAN1-M0"。
+请参照<a href={props.rsetup_link || "../../radxa-os/rsetup#overlays"}>设备树配置</a> 启用 CANBUS 相关 Overlay, eg: "Enable CAN1-M0"。
 
 ### 连接
 

--- a/docs/rock3/e25/app-development/canbus.md
+++ b/docs/rock3/e25/app-development/canbus.md
@@ -11,4 +11,4 @@ imports_resolve_to:
 
 import CANBUS from '../../../common/dev/\_canbus.mdx';
 
-<CANBUS />
+<CANBUS rsetup_link="../system-config/rsetup#overlays" />

--- a/docs/rock3/rock3a/app-development/canbus.md
+++ b/docs/rock3/rock3a/app-development/canbus.md
@@ -11,4 +11,4 @@ imports_resolve_to:
 
 import CANBUS from '../../../common/dev/\_canbus.mdx';
 
-<CANBUS />
+<CANBUS rsetup_link="../system-config/rsetup#overlays" />

--- a/docs/zero/zero3/app-development/canbus.md
+++ b/docs/zero/zero3/app-development/canbus.md
@@ -11,4 +11,4 @@ imports_resolve_to:
 
 import CANBUS from '../../../common/dev/\_canbus.mdx';
 
-<CANBUS />
+<CANBUS rsetup_link="../radxa-os/rsetup#overlays" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_canbus.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_canbus.mdx
@@ -12,7 +12,7 @@ Frames are received by all devices, including by the transmitting device.
 
 ## Enable Overlay
 
-Please refer to [Device Tree Configuration](../../radxa-os/rsetup#overlays) to enable CANBUS-related Overlay, e.g. "Enable CAN1-M0".
+Please refer to <a href={props.rsetup_link || "../../radxa-os/rsetup#overlays"}>Device Tree Configuration</a> to enable CANBUS-related Overlay, e.g. "Enable CAN1-M0".
 
 ## Connection
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/e25/app-development/canbus.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/e25/app-development/canbus.md
@@ -11,4 +11,4 @@ imports_resolve_to:
 
 import CANBUS from '../../../common/dev/\_canbus.mdx';
 
-<CANBUS />
+<CANBUS rsetup_link="../system-config/rsetup#overlays" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/app-development/canbus.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/app-development/canbus.md
@@ -11,4 +11,4 @@ imports_resolve_to:
 
 import CANBUS from '../../../common/dev/\_canbus.mdx';
 
-<CANBUS />
+<CANBUS rsetup_link="../system-config/rsetup#overlays" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/app-development/canbus.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/zero/zero3/app-development/canbus.md
@@ -11,4 +11,4 @@ imports_resolve_to:
 
 import CANBUS from '../../../common/dev/\_canbus.mdx';
 
-<CANBUS />
+<CANBUS rsetup_link="../radxa-os/rsetup#overlays" />


### PR DESCRIPTION
Fixes #273

## Problem

The shared `_canbus.mdx` component used a fixed relative link `../../radxa-os/rsetup#overlays`. Relative links inside an imported MDX component resolve against the importing page's route, so this only worked for pages at `getting-started/interface-usage/` depth (e.g. cm3i, rock3b). On `app-development/` pages the link resolved to a non-existent page:

- `/zero/zero3/app-development/canbus` → `/zero/radxa-os/rsetup` (404)
- `/rock3/rock3a/app-development/canbus` → `/rock3/radxa-os/rsetup` (404)
- `/rock3/e25/app-development/canbus` → `/rock3/radxa-os/rsetup` (404)

## Fix

- `_canbus.mdx` (zh + en) now accepts an optional `rsetup_link` prop; the default keeps the previous working path so `cm3i` / `rock3b` pages are unaffected.
- The affected product pages pass the correct rsetup page for their product:
  - zero3 → `../radxa-os/rsetup#overlays` (`/zero/zero3/radxa-os/rsetup` exists)
  - rock3a / e25 → `../system-config/rsetup#overlays` (their rsetup lives under `system-config/`)

## Verification

- Live 404 confirmed for `/zero/radxa-os/rsetup` and `/rock3/radxa-os/rsetup` before the fix.
- Target pages verified present in the repo: `zero/zero3/radxa-os/rsetup.md`, `rock3/rock3a/system-config/rsetup.md`, `rock3/e25/system-config/rsetup.md`.
- `github_pr_guard.py` bilingual check: no missing zh/en counterparts (single root-cause fix touching the shared component and its consumers; scopes span 4 product dirs by design).
