### PR TITLE
docs: fix balena-etcher version mismatch in _etcher.mdx (zh+en)

### DIFF
--- a/docs/common/general/_etcher.mdx
+++ b/docs/common/general/_etcher.mdx
@@ -13,10 +13,10 @@ Balena Etcher 是一个跨平台且，用户界面友好的镜像文件烧写工
 </TabItem>
 <TabItem value="Linux">
 
-请下载 [balena-etcher_1.18.11_amd64.deb](https://github.com/balena-io/etcher/releases/download/v1.18.11/balena-etcher_1.18.11_amd64.deb)。下载完成后，请在终端执行以下命令进行安装：
+请下载 [balena-etcher_1.19.16_amd64.deb](https://github.com/balena-io/etcher/releases/download/v1.19.16/balena-etcher_1.19.16_amd64.deb)。下载完成后，请在终端执行以下命令进行安装：
 
 ```bash
-sudo dpkg -i balena-etcher_1.18.11_amd64.deb
+sudo dpkg -i balena-etcher_1.19.16_amd64.deb
 ```
 
 </TabItem>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcher.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcher.mdx
@@ -12,10 +12,10 @@ Please download [balenaEtcher-Setup-1.18.11.exe](https://github.com/balena-io/et
 </TabItem>
 <TabItem value="Linux">
 
-Please download [balena-etcher_1.18.11_amd64.deb](https://github.com/balena-io/etcher/releases/download/v1.19.16/balena-etcher_1.19.16_amd64.deb). Once the download is complete, please install it by executing the following command in the terminal:
+Please download [balena-etcher_1.19.16_amd64.deb](https://github.com/balena-io/etcher/releases/download/v1.19.16/balena-etcher_1.19.16_amd64.deb). Once the download is complete, please install it by executing the following command in the terminal:
 
 ```bash
-sudo dpkg -i balena-etcher_1.18.11_amd64.deb
+sudo dpkg -i balena-etcher_1.19.16_amd64.deb
 ```
 
 </TabItem>


### PR DESCRIPTION
Fixes #415

## 客户问题 / Issue
GitHub issue #415 (2024-10): 用户按 `_etcher.mdx` 英文版步骤下载 Etcher 时，页面链接指向 balena-etcher **1.19.16**（`balena-etcher_1.19.16_amd64.deb`），但安装命令仍是 `sudo dpkg -i balena-etcher_1.18.11_amd64.deb`，导致下载的文件名与 dpkg 命令不一致，安装必然失败。

## 根因
英文版 Linux 标签页内版本不一致：链接文字与 URL 指向 1.19.16，但 `dpkg` 安装命令残留 1.18.11。中文版虽然链接/命令一致，但整体停留在旧版本 1.18.11。

## 修改内容
- `docs/common/general/_etcher.mdx`（中文）：Linux 标签页链接与安装命令统一更新为 balena-etcher 1.19.16
- `i18n/en/.../common/general/_etcher.mdx`（英文）：Linux 标签页链接文字与安装命令统一为 1.19.16，与现有 URL 一致

两语言同步修改，均为 docs-only 小改动（4 行变更）。

## 验证
- 1.19.16 下载链接（deb）实测 HTTP 200
- 中文版安装命令现在与下载文件名一致
- github_pr_guard 通过（2 files / 1 scope / bilingual OK）

## 影响范围
`_etcher.mdx` 被多款产品（rock5itx / rock3a / e25 / rockpis0 / zero 系列等）的 install-os 页面引用，本次修复让所有引用页面的 Linux 安装步骤可用。
