### PR TITLE
docs: fix ROCK 5T USB port description (USB 3.0 is HOST-only)

### DIFF
--- a/docs/rock5/rock5t/getting-started/introduction.md
+++ b/docs/rock5/rock5t/getting-started/introduction.md
@@ -114,7 +114,7 @@ ROCK 5T/5T-Industrial 提供了完整的硬件设计原理图和软件源代码�
     </tr>
     <tr>
         <td align="center">USB</td>
-        <td colspan="2" align="center">2x USB 2 端口<br/>2x USB 3 HOST/OTG 端口</td>
+        <td colspan="2" align="center">2x USB 2 端口<br/>2x USB 3 HOST 端口<br/>1x USB Type-C 端口（支持 OTG/DP）</td>
     </tr>
     <tr>
         <td align="center">摄像头</td>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/getting-started/introduction.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/getting-started/introduction.md
@@ -115,7 +115,7 @@ ROCK 5T/5T-Industrial provides complete hardware design schematics and software 
     </tr>
     <tr>
         <td align="center">USB</td>
-        <td colspan="2" align="center">2x USB 2 ports<br/>2x USB 3 HOST/OTG ports</td>
+        <td colspan="2" align="center">2x USB 2 ports<br/>2x USB 3 HOST ports<br/>1x USB Type-C port (OTG/DP)</td>
     </tr>
     <tr>
         <td align="center">Camera</td>


### PR DESCRIPTION
## 背景

售后技术支持反馈（RS139 / ROCK 5T）：文档参数表将 USB 3.0 端口标注为「2x USB 3 HOST/OTG 端口」，但硬件实际为 **USB 3.0 Type-A 端口仅支持 HOST**，OTG 功能只在 USB Type-C 端口上提供。

## 修改

- `docs/rock5/rock5t/getting-started/introduction.md`（中文）
- `i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/getting-started/introduction.md`（英文）

USB 行由：
> 2x USB 2 端口 / 2x USB 3 HOST/OTG 端口

改为：
> 2x USB 2 端口 / 2x USB 3 HOST 端口 / 1x USB Type-C 端口（支持 OTG/DP）

## 依据

- ROCK 5T 官网接口标注图（spec/marked）：2x USB 3.0 Type-A = HOST；USB Type-C Port = USB 3.0 OTG + DP
- 与 FAQ 中「板上的 USB Type-C 接口仅用于 OTG/数据/进入 Maskrom 模式」口径一致

## 影响范围

仅修正 ROCK 5T/5T-Industrial 产品介绍参数表，docs-only，无代码/镜像影响。
