### PR TITLE
docs: align image download links with latest radxa-build releases

### DIFF
--- a/docs/cubie/a5e/getting-started/install-system/emmc-system.md
+++ b/docs/cubie/a5e/getting-started/install-system/emmc-system.md
@@ -10,7 +10,7 @@ import DDUse from '../../../../common/radxa-os/install-system/\_use_dd_emmc.mdx'
 教程适用于 Cubie A5E 板载 eMMC 版本的用户
 :::
 
-<DDUse tag="emmc_board" board="cubie-a5e" download_url="https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-b1/radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz" path_to_image_unxz="radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz" path_to_image="radxa-cubie-a5e_bullseye_kde_b1.output_512.img"  />
+<DDUse tag="emmc_board" board="cubie-a5e" download_url="https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz" path_to_image_unxz="radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz" path_to_image="radxa-cubie-a5e_bullseye_kde_r7.output_512.img"  />
 
 ## 启动系统
 

--- a/docs/cubie/a5e/getting-started/install-system/nvme-system/install-system/no-reader.md
+++ b/docs/cubie/a5e/getting-started/install-system/nvme-system/install-system/no-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../../common/radxa-os/install-system/\_us
 
 # 从 SD 卡安装系统到 NVMe
 
-<InstallSystem tag="m2_2230" board="cubie-a5e" download_url="https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-b1/radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz" path_to_image_unxz="radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz" path_to_image="radxa-cubie-a5e_bullseye_kde_b1.output_512.img" />
+<InstallSystem tag="m2_2230" board="cubie-a5e" download_url="https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz" path_to_image_unxz="radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz" path_to_image="radxa-cubie-a5e_bullseye_kde_r7.output_512.img" />
 
 ## 启动系统
 

--- a/docs/cubie/a7s/getting-started/install-system/emmc-system.md
+++ b/docs/cubie/a7s/getting-started/install-system/emmc-system.md
@@ -10,7 +10,7 @@ import DDUse from '../../../../common/radxa-os/install-system/\_use_dd_emmc.mdx'
 教程适用于 Cubie A7S 板载 eMMC 版本的用户
 :::
 
-<DDUse tag="emmc_board" board="cubie-a7s" download_url="https://github.com/radxa-build/radxa-a733/releases/download/rsdk-t2/radxa-a733_bullseye_kde_t2.output_512.img.xz" path_to_image_unxz="radxa-a733_bullseye_kde_t2.output_512.img.xz" path_to_image="radxa-a733_bullseye_kde_t2.output_512.img"  download_page="../../download"/>
+<DDUse tag="emmc_board" board="cubie-a7s" download_url="https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz" path_to_image_unxz="radxa-a733_bullseye_kde_r6.output_512.img.xz" path_to_image="radxa-a733_bullseye_kde_r6.output_512.img"  download_page="../../download"/>
 
 ## 启动系统
 

--- a/docs/dragon/q6a/getting-started/install-system/emmc-system/no-emmc-reader.md
+++ b/docs/dragon/q6a/getting-started/install-system/emmc-system/no-emmc-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # 从 microSD 卡启动并将系统安装到 eMMC
 
-<InstallSystem tag="emmc_module" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-t4/radxa-dragon-q6a_noble_kde_t4.output_512.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_kde_t4.output_512.img.xz" path_to_image="radxa-dragon-q6a_noble_kde_t4.output_512.img" />
+<InstallSystem tag="emmc_module" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-r2/radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz" path_to_image="radxa-dragon-q6a_noble_gnome_r2.output_512.img" />
 
 ## 启动系统
 

--- a/docs/dragon/q6a/getting-started/install-system/nvme-system/no-nvme-reader.md
+++ b/docs/dragon/q6a/getting-started/install-system/nvme-system/no-nvme-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # 从 microSD 卡启动并将系统安装到 NVMe SSD
 
-<InstallSystem tag="m2_2230" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-t4/radxa-dragon-q6a_noble_kde_t4.output_512.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_kde_t4.output_512.img.xz" path_to_image="radxa-dragon-q6a_noble_kde_t4.output_512.img" />
+<InstallSystem tag="m2_2230" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-r2/radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz" path_to_image="radxa-dragon-q6a_noble_gnome_r2.output_512.img" />
 
 ## 启动系统
 

--- a/docs/dragon/q6a/getting-started/install-system/ufs-system/no-ufs-reader.md
+++ b/docs/dragon/q6a/getting-started/install-system/ufs-system/no-ufs-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # 从 microSD 卡启动并将系统安装到 UFS
 
-<InstallSystem tag="ufs_module" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-t4/radxa-dragon-q6a_noble_kde_t4.output_4096.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_kde_t4.output_4096.img.xz" path_to_image="radxa-dragon-q6a_noble_kde_t4.output_4096.img" />
+<InstallSystem tag="ufs_module" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-r2/radxa-dragon-q6a_noble_gnome_r2.output_4096.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_gnome_r2.output_4096.img.xz" path_to_image="radxa-dragon-q6a_noble_gnome_r2.output_4096.img" />
 
 ## 启动系统
 

--- a/docs/dragon/q6a/getting-started/install-system/usb-system/usb-emmc.md
+++ b/docs/dragon/q6a/getting-started/install-system/usb-system/usb-emmc.md
@@ -21,4 +21,4 @@ import USBSystem from '../../../../../common/radxa-os/install-system/qualcomm/\_
 
 3. 配置 EDL 工具环境 --> 可参考 [使用 EDL 工具](./set-edl-variable.md) 教程
 
-<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="Sdcc --slot 0" start_sector="0" image_file="radxa-dragon-q6a_noble_kde_t4.output_512.img"/>
+<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="Sdcc --slot 0" start_sector="0" image_file="radxa-dragon-q6a_noble_gnome_r2.output_512.img"/>

--- a/docs/dragon/q6a/getting-started/install-system/usb-system/usb-microsd.md
+++ b/docs/dragon/q6a/getting-started/install-system/usb-system/usb-microsd.md
@@ -21,4 +21,4 @@ import USBSystem from '../../../../../common/radxa-os/install-system/qualcomm/\_
 
 3. 配置 EDL 工具环境 --> 可参考 [使用 EDL 工具](./set-edl-variable.md) 教程
 
-<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="Sdcc --slot 1" start_sector="0" image_file="radxa-dragon-q6a_noble_kde_t4.output_512.img"/>
+<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="Sdcc --slot 1" start_sector="0" image_file="radxa-dragon-q6a_noble_gnome_r2.output_512.img"/>

--- a/docs/dragon/q6a/getting-started/install-system/usb-system/usb-nvme.md
+++ b/docs/dragon/q6a/getting-started/install-system/usb-system/usb-nvme.md
@@ -21,4 +21,4 @@ import USBSystem from '../../../../../common/radxa-os/install-system/qualcomm/\_
 
 3. 配置 EDL 工具环境 --> 可参考 [使用 EDL 工具](./set-edl-variable.md) 教程
 
-<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="nvme" start_sector="0" image_file="radxa-dragon-q6a_noble_kde_t4.output_512.img"/>
+<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="nvme" start_sector="0" image_file="radxa-dragon-q6a_noble_gnome_r2.output_512.img"/>

--- a/docs/dragon/q6a/getting-started/install-system/usb-system/usb-ufs.md
+++ b/docs/dragon/q6a/getting-started/install-system/usb-system/usb-ufs.md
@@ -21,4 +21,4 @@ import USBSystem from '../../../../../common/radxa-os/install-system/qualcomm/\_
 
 3. 配置 EDL 工具环境 --> 可参考 [使用 EDL 工具](./set-edl-variable.md) 教程
 
-<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="ufs" start_sector="0" image_file="radxa-dragon-q6a_noble_kde_t4.output_4096.img"/>
+<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="ufs" start_sector="0" image_file="radxa-dragon-q6a_noble_gnome_r2.output_4096.img"/>

--- a/docs/dragon/q8b/download.md
+++ b/docs/dragon/q8b/download.md
@@ -16,8 +16,8 @@ sidebar_position: 150
 
 ### Radxa OS
 
-- [radxa-dragon-midstream_noble_gnome_t2.output_512.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-t2/radxa-dragon-midstream_noble_gnome_t2.output_512.img.xz)：适用于 microSD 卡 / NVMe SSD 启动
-- [radxa-dragon-midstream_noble_gnome_t2.output_4096.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-t2/radxa-dragon-midstream_noble_gnome_t2.output_4096.img.xz)：适用于 UFS 启动
+- [radxa-dragon-midstream_noble_gnome_r4.output_512.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_512.img.xz)：适用于 microSD 卡 / NVMe SSD 启动
+- [radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz)：适用于 UFS 启动
 
 ## 启动固件
 

--- a/docs/dragon/q8b/getting-started/install-system/nvme-system/no-nvme-reader.md
+++ b/docs/dragon/q8b/getting-started/install-system/nvme-system/no-nvme-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # 从 microSD 卡启动并将系统安装到 NVMe SSD
 
-<InstallSystem tag="m2_2280" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-t2/radxa-dragon-midstream_noble_gnome_t2.output_512.img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_t2.output_512.img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_t2.output_512.img" />
+<InstallSystem tag="m2_2280" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_512.img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_r4.output_512.img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_r4.output_512.img" />
 
 ## 启动系统
 

--- a/docs/dragon/q8b/getting-started/install-system/ufs-system/no-ufs-reader.md
+++ b/docs/dragon/q8b/getting-started/install-system/ufs-system/no-ufs-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # 从 microSD 卡启动并将系统安装到 UFS
 
-<InstallSystem tag="ufs_module" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-t2/radxa-dragon-midstream_noble_gnome_t2.output_4096.img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_t2.output_4096.img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_t2.output_4096.img" ufs_module_img="/img/dragon/q8b/dragon-q8b-ufs-module-board.webp" />
+<InstallSystem tag="ufs_module" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_r4.output_4096.img" ufs_module_img="/img/dragon/q8b/dragon-q8b-ufs-module-board.webp" />
 
 ## 启动系统
 

--- a/docs/e/e24c/getting-started/install-os/nvme-system/no-nvme-reader.md
+++ b/docs/e/e24c/getting-started/install-os/nvme-system/no-nvme-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # 从 microSD 卡启动并将系统安装到 NVMe SSD
 
-<InstallSystem boot_device="microSD 卡" board="e24c" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3528/releases/download/rsdk-t2/radxa-rk3528_bookworm_kde_t2.output.img.xz" path_to_image_unxz="radxa-rk3528_bookworm_kde_t2.output.img.xz" path_to_image="radxa-rk3528_bookworm_kde_t2.output.img" />
+<InstallSystem boot_device="microSD 卡" board="e24c" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3528/releases/download/rsdk-r3/radxa-rk3528_bookworm_kde_r3.output_512.img.xz" path_to_image_unxz="radxa-rk3528_bookworm_kde_r3.output_512.img.xz" path_to_image="radxa-rk3528_bookworm_kde_r3.output_512.img" />
 
 ## 启动系统
 

--- a/docs/rock5/rock5t/_image.mdx
+++ b/docs/rock5/rock5t/_image.mdx
@@ -13,9 +13,9 @@ import React, { Fragment } from "react";
 
 <li style={{ display: `${props.rock5t_system_img_61 ? "block" : "none"}` }}>
   {" "}
-  <a href="https://github.com/radxa-build/rock-5t/releases/download/rsdk-r6/rock-5t_bookworm_kde_r6.output_512.img.xz">
+  <a href="https://github.com/radxa-build/rock-5t/releases/download/rsdk-r7/rock-5t_bookworm_kde_r7.output_512.img.xz">
     {" "}
-    ROCK 5T 系统镜像 (6.1 内核) : rock-5t_bookworm_kde_r6{" "}
+    ROCK 5T 系统镜像 (6.1 内核) : rock-5t_bookworm_kde_r7{" "}
   </a>
 </li>
 

--- a/docs/rock5/rock5t/getting-started/install-os/emmc_boot.md
+++ b/docs/rock5/rock5t/getting-started/install-os/emmc_boot.md
@@ -46,7 +46,7 @@ sidebar_position: 3
 sudo apt install wget
 wget [url]
 # 示例
-wget https://github.com/radxa-build/rock-5t/releases/download/rsdk-b2/rock-5t_bookworm_kde_b2.output.img.xz
+wget https://github.com/radxa-build/rock-5t/releases/download/rsdk-r7/rock-5t_bookworm_kde_r7.output_512.img.xz
 ```
 </NewCodeBlock>
 参数解释：其中 `[url]` 需要替换成实际的系统镜像文件下载链接。
@@ -75,7 +75,7 @@ wget https://github.com/radxa-build/rock-5t/releases/download/rsdk-b2/rock-5t_bo
 sudo apt install xz-utils
 unxz [image_path]
 # 示例
-unxz ~/rock-5t_bookworm_kde_b2.output.img.xz
+unxz ~/rock-5t_bookworm_kde_r7.output_512.img.xz
 ```
 
 </NewCodeBlock>
@@ -96,7 +96,7 @@ sudo dd if=[image_path] of=/dev/mmcblk0 bs=4M status=progress
 
 # 示例
 
-sudo dd if=~/rock-5t_bookworm_kde_b2.output.img of=/dev/mmcblk0 bs=4M status=progress
+sudo dd if=~/rock-5t_bookworm_kde_r7.output_512.img of=/dev/mmcblk0 bs=4M status=progress
 ```
 
 </NewCodeBlock>

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/getting-started/install-system/emmc-system.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/getting-started/install-system/emmc-system.md
@@ -10,7 +10,7 @@ import DDUse from '../../../../common/radxa-os/install-system/\_use_dd_emmc.mdx'
 This tutorial is for users with the Cubie A5E onboard eMMC version.
 :::
 
-<DDUse tag="emmc_board" board="cubie-a5e" download_url="https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-b1/radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz" path_to_image_unxz="radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz" path_to_image="radxa-cubie-a5e_bullseye_kde_b1.output_512.img"  />
+<DDUse tag="emmc_board" board="cubie-a5e" download_url="https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz" path_to_image_unxz="radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz" path_to_image="radxa-cubie-a5e_bullseye_kde_r7.output_512.img"  />
 
 ## Boot the System
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/getting-started/install-system/nvme-system/install-system/no-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/getting-started/install-system/nvme-system/install-system/no-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../../common/radxa-os/install-system/\_us
 
 # Install System from SD Card to NVMe
 
-<InstallSystem tag="m2_2230" board="cubie-a5e" download_url="https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-b1/radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz" path_to_image_unxz="radxa-cubie-a5e_bullseye_kde_b1.output_512.img.xz" path_to_image="radxa-cubie-a5e_bullseye_kde_b1.output_512.img" />
+<InstallSystem tag="m2_2230" board="cubie-a5e" download_url="https://github.com/radxa-build/radxa-cubie-a5e/releases/download/rsdk-r7/radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz" path_to_image_unxz="radxa-cubie-a5e_bullseye_kde_r7.output_512.img.xz" path_to_image="radxa-cubie-a5e_bullseye_kde_r7.output_512.img" />
 
 ## Boot the System
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/getting-started/install-system/emmc-system.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/getting-started/install-system/emmc-system.md
@@ -10,7 +10,7 @@ import DDUse from '../../../../common/radxa-os/install-system/\_use_dd_emmc.mdx'
 This guide applies to Cubie A7S variants with onboard eMMC.
 :::
 
-<DDUse tag="emmc_board" board="cubie-a7s" download_url="https://github.com/radxa-build/radxa-a733/releases/download/rsdk-t2/radxa-a733_bullseye_kde_t2.output_512.img.xz" path_to_image_unxz="radxa-a733_bullseye_kde_t2.output_512.img.xz" path_to_image="radxa-a733_bullseye_kde_t2.output_512.img"  download_page="../../download"/>
+<DDUse tag="emmc_board" board="cubie-a7s" download_url="https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz" path_to_image_unxz="radxa-a733_bullseye_kde_r6.output_512.img.xz" path_to_image="radxa-a733_bullseye_kde_r6.output_512.img"  download_page="../../download"/>
 
 ## Boot the system
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/emmc-system/no-emmc-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/emmc-system/no-emmc-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # Booting from microSD Card and Installing System to eMMC
 
-<InstallSystem tag="emmc_module" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-t4/radxa-dragon-q6a_noble_kde_t4.output_512.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_kde_t4.output_512.img.xz" path_to_image="radxa-dragon-q6a_noble_kde_t4.output_512.img" />
+<InstallSystem tag="emmc_module" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-r2/radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz" path_to_image="radxa-dragon-q6a_noble_gnome_r2.output_512.img" />
 
 ## Booting the System
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/nvme-system/no-nvme-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/nvme-system/no-nvme-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # Booting from microSD Card and Installing System to NVMe SSD
 
-<InstallSystem tag="m2_2230" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-t4/radxa-dragon-q6a_noble_kde_t4.output_512.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_kde_t4.output_512.img.xz" path_to_image="radxa-dragon-q6a_noble_kde_t4.output_512.img" />
+<InstallSystem tag="m2_2230" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-r2/radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_gnome_r2.output_512.img.xz" path_to_image="radxa-dragon-q6a_noble_gnome_r2.output_512.img" />
 
 ## Booting the System
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/ufs-system/no-ufs-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/ufs-system/no-ufs-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # Boot from microSD Card and Install System to UFS
 
-<InstallSystem tag="ufs_module" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-t4/radxa-dragon-q6a_noble_kde_t4.output_4096.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_kde_t4.output_4096.img.xz" path_to_image="radxa-dragon-q6a_noble_kde_t4.output_4096.img" />
+<InstallSystem tag="ufs_module" board="dragon-q6a" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-q6a/releases/download/rsdk-r2/radxa-dragon-q6a_noble_gnome_r2.output_4096.img.xz" path_to_image_unxz="radxa-dragon-q6a_noble_gnome_r2.output_4096.img.xz" path_to_image="radxa-dragon-q6a_noble_gnome_r2.output_4096.img" />
 
 ## Booting the System
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/usb-system/usb-emmc.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/usb-system/usb-emmc.md
@@ -21,4 +21,4 @@ This guide explains how to flash an eMMC system image to the board using a USB T
 
 3. Set up the EDL tool environment --> Refer to the [Using EDL Tool](./set-edl-variable) guide
 
-<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="Sdcc --slot 0" start_sector="0" image_file="radxa-dragon-q6a_noble_kde_t4.output_512.img"/>
+<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="Sdcc --slot 0" start_sector="0" image_file="radxa-dragon-q6a_noble_gnome_r2.output_512.img"/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/usb-system/usb-microsd.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/usb-system/usb-microsd.md
@@ -21,4 +21,4 @@ This guide explains how to flash a system image to a microSD card using a USB Ty
 
 3. Set up the EDL tool environment --> Refer to the [Using EDL Tool](./set-edl-variable) guide
 
-<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="Sdcc --slot 1" start_sector="0" image_file="radxa-dragon-q6a_noble_kde_t4.output_512.img"/>
+<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="Sdcc --slot 1" start_sector="0" image_file="radxa-dragon-q6a_noble_gnome_r2.output_512.img"/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/usb-system/usb-nvme.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/usb-system/usb-nvme.md
@@ -21,4 +21,4 @@ This guide explains how to flash a system image to an NVMe SSD using a USB Type-
 
 3. Set up the EDL tool environment --> Refer to the [Using EDL Tool](./set-edl-variable) guide
 
-<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="nvme" start_sector="0" image_file="radxa-dragon-q6a_noble_kde_t4.output_512.img"/>
+<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="nvme" start_sector="0" image_file="radxa-dragon-q6a_noble_gnome_r2.output_512.img"/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/usb-system/usb-ufs.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/getting-started/install-system/usb-system/usb-ufs.md
@@ -21,4 +21,4 @@ This guide explains how to flash a system image to UFS storage using a USB Type-
 
 3. Set up the EDL tool environment --> Refer to the [Using EDL Tool](./set-edl-variable) guide
 
-<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="ufs" start_sector="0" image_file="radxa-dragon-q6a_noble_kde_t4.output_4096.img"/>
+<USBSystem download_page="../../../download" board="dragon-q6a" spi_path="\flat_build\spinor\dragon-q6a\" loader="prog_firehose_ddr.elf" storage_type="ufs" start_sector="0" image_file="radxa-dragon-q6a_noble_gnome_r2.output_4096.img"/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/download.md
@@ -16,8 +16,8 @@ This page publishes the latest stable and test system images. Test releases star
 
 ### Radxa OS
 
-- [radxa-dragon-midstream_noble_gnome_t2.output_512. img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-t2/radxa-dragon-midstream_noble_gnome_t2.output_512.img.xz): Suitable for booting from a microSD card or NVMe SSD
-- [radxa-dragon-midstream_noble_gnome_t2.output_4096.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-t2/radxa-dragon-midstream_noble_gnome_t2.output_4096.img.xz): Suitable for booting from UFS
+- [radxa-dragon-midstream_noble_gnome_t2.output_512. img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_512.img.xz): Suitable for booting from a microSD card or NVMe SSD
+- [radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz): Suitable for booting from UFS
 
 ## Boot Firmware
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/getting-started/install-system/nvme-system/no-nvme-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/getting-started/install-system/nvme-system/no-nvme-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # Booting from MicroSD Card and Installing System to NVMe SSD
 
-<InstallSystem tag="m2_2280" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-t2/radxa-dragon-midstream_noble_gnome_t2.output_512. img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_t2.output_512. img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_t2.output_512. img" />
+<InstallSystem tag="m2_2280" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_512. img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_r4.output_512. img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_r4.output_512. img" />
 
 ## Booting the System
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/getting-started/install-system/ufs-system/no-ufs-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/getting-started/install-system/ufs-system/no-ufs-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # Boot from MicroSD Card and Install System to UFS
 
-<InstallSystem tag="ufs_module" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-t2/radxa-dragon-midstream_noble_gnome_t2.output_4096.img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_t2.output_4096.img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_t2.output_4096.img" ufs_module_img="/en/img/dragon/q8b/dragon-q8b-ufs-module-board.webp" />
+<InstallSystem tag="ufs_module" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_r4.output_4096.img" ufs_module_img="/en/img/dragon/q8b/dragon-q8b-ufs-module-board.webp" />
 
 ## Booting the System
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e24c/getting-started/install-os/nvme-system/no-nvme-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e24c/getting-started/install-os/nvme-system/no-nvme-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # Boot from microSD card and install the system to NVMe SSD
 
-<InstallSystem boot_device="microSD card" board="e24c" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3528/releases/download/rsdk-t2/radxa-rk3528_bookworm_kde_t2.output.img.xz" path_to_image_unxz="radxa-rk3528_bookworm_kde_t2.output.img.xz" path_to_image="radxa-rk3528_bookworm_kde_t2.output.img" />
+<InstallSystem boot_device="microSD card" board="e24c" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-rk3528/releases/download/rsdk-r3/radxa-rk3528_bookworm_kde_r3.output_512.img.xz" path_to_image_unxz="radxa-rk3528_bookworm_kde_r3.output_512.img.xz" path_to_image="radxa-rk3528_bookworm_kde_r3.output_512.img" />
 
 ## Boot the system
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/_image.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/_image.mdx
@@ -11,20 +11,38 @@ import React, { Fragment } from "react";
 
 {" "}
 
-<li style={{ display: `${props.rock5t_system_img_61 ? "block" : "none"}` }}>
+<li style={{ display: `${props.rock5b_system_img ? "block" : "none"}` }}>
   {" "}
-  <a href="https://github.com/radxa-build/rock-5t/releases/download/rsdk-t1/rock-5t_bookworm_kde_t1.output.img.xz">
+  <a href="https://github.com/radxa-build/rock-5b/releases/download/b39/rock-5b_debian_bullseye_kde_b39.img.xz">
     {" "}
-    ROCK 5T Desktop Image (6.1 Kernel) Test version: rock-5t_bookworm_kde_t1{" "}
+    ROCK 5B System Image (5.10 Kernel): rock-5b_debian_bullseye_kde_b39{" "}
   </a>
 </li>
 
 {" "}
 
+<li style={{ display: `${props.rock5b_system_img_61 ? "block" : "none"}` }}>
+  {" "}
+  <a href="https://github.com/radxa-build/rock-5b/releases/download/rsdk-b5/rock-5b_bookworm_kde_b5.output.img.xz">
+    {" "}
+    ROCK 5B System Image (6.1 Kernel): rock-5b_bookworm_kde_b5{" "}
+  </a>
+</li>
+
+{" "}
+
+<li style={{ display: `${props.rock5bp_system_img ? "block" : "none"}` }}>
+  {" "}
+  <a href="https://github.com/radxa-build/rock-5b-plus/releases/download/rsdk-b2/rock-5b-plus_bookworm_kde_b2.output.img.xz">
+    {" "}
+    ROCK 5B+ System Image: rock-5b-plus_bookworm_kde_b2{" "}
+  </a>
+</li>
+
   <li style={{ display: `${props.spi_img ? "block" : "none"}` }}>
     {" "}
     <a
-      href="https://dl.radxa.com/rock5/sw/images/loader/rock-5t/release/rock-5t-spi-image-gd1cf491-20240523.img"
+      href="https://dl.radxa.com/rock5/sw/images/loader/rock-5b/release/rock-5b-spi-image-gd1cf491-20240523.img"
       alt="spi image"
     >
       SPI Image: spi_image.img{" "}

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/_image.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/_image.mdx
@@ -13,9 +13,9 @@ import React, { Fragment } from "react";
 
 <li style={{ display: `${props.rock5t_system_img_61 ? "block" : "none"}` }}>
   {" "}
-  <a href="https://github.com/radxa-build/rock-5t/releases/download/rsdk-r6/rock-5t_bookworm_kde_r6.output_512.img.xz">
+  <a href="https://github.com/radxa-build/rock-5t/releases/download/rsdk-r7/rock-5t_bookworm_kde_r7.output_512.img.xz">
     {" "}
-    ROCK 5T System Image (6.1 Kernel): rock-5t_bookworm_kde_r6{" "}
+    ROCK 5T System Image (6.1 Kernel): rock-5t_bookworm_kde_r7{" "}
   </a>
 </li>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/getting-started/install-os/emmc_boot.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5t/getting-started/install-os/emmc_boot.md
@@ -46,7 +46,7 @@ You can copy the system image file link from the [Resource Download Center](../.
 sudo apt install wget
 wget [url]
 # Example
-wget https://github.com/radxa-build/rock-5t/releases/download/rsdk-b2/rock-5t_bookworm_kde_b2.output.img.xz
+wget https://github.com/radxa-build/rock-5t/releases/download/rsdk-r7/rock-5t_bookworm_kde_r7.output_512.img.xz
 ```
 </NewCodeBlock>
 Parameter explanation: Replace `[url]` with the actual system image download link.
@@ -74,7 +74,7 @@ Use the `unxz` command to extract the system image file.
 sudo apt install xz-utils
 unxz [image_path]
 # Example
-unxz ~/rock-5t_bookworm_kde_b2.output.img.xz
+unxz ~/rock-5t_bookworm_kde_r7.output_512.img.xz
 ```
 </NewCodeBlock>
 Parameter explanation: Replace `[image_path]` with the actual path to the system image file.
@@ -91,7 +91,7 @@ When using the `dd` command, make sure to select the correct device file to avoi
 ```bash
 sudo dd if=[image_path] of=/dev/mmcblk0 bs=4M status=progress
 # Example
-sudo dd if=~/rock-5t_bookworm_kde_b2.output.img of=/dev/mmcblk0 bs=4M status=progress
+sudo dd if=~/rock-5t_bookworm_kde_r7.output_512.img of=/dev/mmcblk0 bs=4M status=progress
 ```
 </NewCodeBlock>
 Parameter explanation:


### PR DESCRIPTION
## Summary

Support review found several docs pages still pointing to **old Radxa OS image releases** even though newer builds were published in `radxa-build`. This PR aligns all affected download links / install guide references with the latest releases (both `docs/` zh and `i18n/en/` en updated in sync).

## Changes

| Product | Page | Old ref | New ref |
|---|---|---|---|
| ROCK 5T | `_image.mdx` (zh/en) | `rsdk-r6` | `rsdk-r7` (Bookworm KDE R7) |
| ROCK 5T | `emmc_boot.md` (zh/en) | `rsdk-b2` | `rsdk-r7` |
| Dragon Q8B | `download.md`, install guides (zh/en) | `rsdk-t2` (test) | `rsdk-r4` (Noble GNOME R4) |
| Dragon Q6A | install guides + USB guides (zh/en) | `rsdk-t4` (test) | `rsdk-r2` (Noble GNOME R2) |
| Cubie A7S | `emmc-system.md` (zh/en) | `rsdk-t2` (test) | `rsdk-r6` |
| Cubie A5E | install guides (zh/en) | `rsdk-b1` | `rsdk-r7` |
| E24C (RK3528) | `no-nvme-reader.md` (zh/en) | `rsdk-t2` (test) | `rsdk-r3` |
| ROCK 5B | `_image.mdx` (en) | ❌ copied ROCK 5T content (rock5t system image / rock-5t spi image) | fixed to ROCK 5B content, matching zh |

## Notes
- Every new link was verified against the actual GitHub release assets (file exists).
- Legacy Debian 11 / 5.10-kernel image entries (e.g. ROCK 4 series) are intentionally kept — they document the older-kernel options, not a stale "latest".
- ROCK 3A was already aligned in a previous commit (`1f3f055ba`).
