### PR TITLE
docs(penta-sata-hat): add I2C7 overlay troubleshooting for ROCK 4 top board

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -34,6 +34,42 @@ wget https://github.com/radxa/rockpi-penta/releases/download/v0.2.2/rockpi-penta
 sudo apt install -y ./rockpi-penta-0.2.2.deb
 ```
 
+### ROCK 4 系列：启用 I2C7 overlay
+
+在较新的 Radxa OS (Debian Bookworm) 镜像上，顶板使用的 **I2C7** 总线默认未启用。安装 `rockpi-penta` 后如果出现以下现象，说明 I2C7 overlay 未启用：
+
+- OLED 一直显示 "ROCKPI SATA HAT loading..."
+- 风扇不转，或一直满速运行
+- 服务日志报错：`FileNotFoundError: /sys/class/pwm/pwmchip1/pwm0/period` 或 `Device or resource busy`
+
+启用方法：
+
+```bash
+sudo rsetup
+```
+
+在 Overlays 菜单中勾选 `I2C7`（若风扇仍异常，同时勾选 `PWM1`），保存后重启。
+
+### 检查顶板挂载在哪条 I2C 总线
+
+顶板 OLED (SSD1306) 的 I2C 地址为 `0x3c`，可用以下命令确认顶板是否被识别、以及挂载在哪条总线上：
+
+```bash
+# 列出系统所有 I2C 总线
+sudo i2cdetect -l
+
+# 依次扫描各总线，出现 0x3c 的那条即为顶板所在总线
+sudo i2cdetect -y <bus_number>
+```
+
+启用 I2C7 overlay 后，扫描对应总线可以看到 OLED 设备（ROCK 4 上通常为 i2c-7，以 `i2cdetect -l` 输出为准）：
+
+```bash
+sudo i2cdetect -y 7
+```
+
+输出中出现 `3c` 即表示顶板 OLED 已被识别。
+
 ### 软件配置
 
 :::note

--- a/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -34,42 +34,6 @@ wget https://github.com/radxa/rockpi-penta/releases/download/v0.2.2/rockpi-penta
 sudo apt install -y ./rockpi-penta-0.2.2.deb
 ```
 
-### ROCK 4 系列：启用 I2C7 overlay
-
-在较新的 Radxa OS (Debian Bookworm) 镜像上，顶板使用的 **I2C7** 总线默认未启用。安装 `rockpi-penta` 后如果出现以下现象，说明 I2C7 overlay 未启用：
-
-- OLED 一直显示 "ROCKPI SATA HAT loading..."
-- 风扇不转，或一直满速运行
-- 服务日志报错：`FileNotFoundError: /sys/class/pwm/pwmchip1/pwm0/period` 或 `Device or resource busy`
-
-启用方法：
-
-```bash
-sudo rsetup
-```
-
-在 Overlays 菜单中勾选 `I2C7`（若风扇仍异常，同时勾选 `PWM1`），保存后重启。
-
-### 检查顶板挂载在哪条 I2C 总线
-
-顶板 OLED (SSD1306) 的 I2C 地址为 `0x3c`，可用以下命令确认顶板是否被识别、以及挂载在哪条总线上：
-
-```bash
-# 列出系统所有 I2C 总线
-sudo i2cdetect -l
-
-# 依次扫描各总线，出现 0x3c 的那条即为顶板所在总线
-sudo i2cdetect -y <bus_number>
-```
-
-启用 I2C7 overlay 后，扫描对应总线可以看到 OLED 设备（ROCK 4 上通常为 i2c-7，以 `i2cdetect -l` 输出为准）：
-
-```bash
-sudo i2cdetect -y 7
-```
-
-输出中出现 `3c` 即表示顶板 OLED 已被识别。
-
 ### 软件配置
 
 :::note
@@ -125,3 +89,41 @@ f-temp = false
 ```
 
 修改配置后，执行 `sudo systemctl restart rockpi-penta.service` 命令，重启服务使配置生效。
+
+## 常见问题
+
+### 顶板 OLED 一直显示 "ROCKPI SATA HAT loading..."，或风扇不转 / 一直满速？
+
+在较新的 Radxa OS (Debian Bookworm) 镜像上，顶板使用的 **I2C7** 总线默认未启用。安装 `rockpi-penta` 后如果出现以下现象，说明 I2C7 overlay 未启用：
+
+- OLED 一直显示 "ROCKPI SATA HAT loading..."
+- 风扇不转，或一直满速运行
+- 服务日志报错：`FileNotFoundError: /sys/class/pwm/pwmchip1/pwm0/period` 或 `Device or resource busy`
+
+启用方法：
+
+```bash
+sudo rsetup
+```
+
+在 Overlays 菜单中勾选 `I2C7`（若风扇仍异常，同时勾选 `PWM1`），保存后重启。
+
+### 如何检查 Penta SATA HAT 顶板挂载在哪条 I2C 总线？
+
+顶板 OLED (SSD1306) 的 I2C 地址为 `0x3c`，可用以下命令确认顶板是否被识别、以及挂载在哪条总线上：
+
+```bash
+# 列出系统所有 I2C 总线
+sudo i2cdetect -l
+
+# 依次扫描各总线，出现 0x3c 的那条即为顶板所在总线
+sudo i2cdetect -y <bus_number>
+```
+
+启用 I2C7 overlay 后，扫描对应总线可以看到 OLED 设备（ROCK 4 上通常为 i2c-7，以 `i2cdetect -l` 输出为准）：
+
+```bash
+sudo i2cdetect -y 7
+```
+
+输出中出现 `3c` 即表示顶板 OLED 已被识别。

--- a/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/docs/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -94,7 +94,7 @@ f-temp = false
 
 ### 顶板 OLED 一直显示 "ROCKPI SATA HAT loading..."，或风扇不转 / 一直满速？
 
-在较新的 Radxa OS (Debian Bookworm) 镜像上，顶板使用的 **I2C7** 总线默认未启用。安装 `rockpi-penta` 后如果出现以下现象，说明 I2C7 overlay 未启用：
+不同产品型号的顶板 I2C 总线不同（见下表），在较新的 Radxa OS (Debian Bookworm) 镜像上，部分型号对应的 I2C overlay 默认未启用。安装 `rockpi-penta` 后如果出现以下现象，说明对应的 I2C overlay 未启用（以下以 ROCK 4 系列为例）：
 
 - OLED 一直显示 "ROCKPI SATA HAT loading..."
 - 风扇不转，或一直满速运行
@@ -106,7 +106,17 @@ f-temp = false
 sudo rsetup
 ```
 
-在 Overlays 菜单中勾选 `I2C7`（若风扇仍异常，同时勾选 `PWM1`），保存后重启。
+在 Overlays 菜单中勾选顶板对应的 I2C overlay（以 ROCK 4 系列为例：勾选 `I2C7`；若风扇仍异常，同时勾选 `PWM1`），保存后重启。
+
+| 产品型号 | 顶板使用的 I2C | 需要启用的 overlay |
+| --- | --- | --- |
+| ROCK 4 系列（含 ROCK Pi 4） | I2C7 | `I2C7`（风扇：`PWM1`） |
+| ROCK 5A | I2C8 (M4) | `I2C8` |
+| ROCK 3A | I2C3 (M0) | `I2C3` |
+| ROCK 3C | GPIO 软件 I2C（GPIO1_A0/A1） | 无需 overlay |
+| Raspberry Pi 4 / 5 | I2C1（GPIO 引脚 3/5） | 系统默认启用，无需额外配置 |
+
+> 注意：上表为 rockpi-penta 软件包中各型号的默认配置。实际总线编号请以 `sudo i2cdetect -l` 输出为准，不要假设固定编号。
 
 ### 如何检查 Penta SATA HAT 顶板挂载在哪条 I2C 总线？
 
@@ -120,10 +130,13 @@ sudo i2cdetect -l
 sudo i2cdetect -y <bus_number>
 ```
 
-启用 I2C7 overlay 后，扫描对应总线可以看到 OLED 设备（ROCK 4 上通常为 i2c-7，以 `i2cdetect -l` 输出为准）：
+以 ROCK 4 系列为例，启用 I2C7 overlay 后，扫描对应总线可以看到 OLED 设备：
 
 ```bash
+# 以 ROCK 4 系列为例，启用 I2C7 overlay 后通常对应 i2c-7
 sudo i2cdetect -y 7
 ```
+
+> 注意：不同产品型号的总线编号不同（例如 ROCK 5A 通常为 i2c-8、ROCK 3A 通常为 i2c-3），请以 `sudo i2cdetect -l` 输出为准，示例中的编号仅供参考。
 
 输出中出现 `3c` 即表示顶板 OLED 已被识别。

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -94,7 +94,7 @@ After modifying the configuration, run the `sudo systemctl restart rockpi-penta.
 
 ### The top board OLED stays on "ROCKPI SATA HAT loading...", or the fan does not spin / always runs at full speed?
 
-On newer Radxa OS (Debian Bookworm) images, the **I2C7** bus used by the top board is not enabled by default. After installing `rockpi-penta`, if you see any of the following symptoms, the I2C7 overlay is likely not enabled:
+Different product models use different I2C buses for the top board (see the table below). On newer Radxa OS (Debian Bookworm) images, the corresponding I2C overlay is not enabled by default on some models. After installing `rockpi-penta`, if you see any of the following symptoms, the corresponding I2C overlay is likely not enabled (using ROCK 4 series as an example):
 
 - The OLED stays on "ROCKPI SATA HAT loading..."
 - The fan does not spin, or always runs at full speed
@@ -106,7 +106,17 @@ To enable it:
 sudo rsetup
 ```
 
-Select `I2C7` in the Overlays menu (also select `PWM1` if the fan still misbehaves), save and reboot.
+Select the I2C overlay for your model in the Overlays menu (using ROCK 4 series as an example: select `I2C7`; also select `PWM1` if the fan still misbehaves), save and reboot.
+
+| Model | I2C used by the top board | Overlay to enable |
+| --- | --- | --- |
+| ROCK 4 series (incl. ROCK Pi 4) | I2C7 | `I2C7` (fan: `PWM1`) |
+| ROCK 5A | I2C8 (M4) | `I2C8` |
+| ROCK 3A | I2C3 (M0) | `I2C3` |
+| ROCK 3C | Software I2C via GPIO (GPIO1_A0/A1) | No overlay needed |
+| Raspberry Pi 4 / 5 | I2C1 (GPIO pins 3/5) | Enabled by default, no extra config needed |
+
+> Note: The table above shows the default configuration in the rockpi-penta package for each model. Always check the actual bus number with `sudo i2cdetect -l` instead of assuming a fixed number.
 
 ### How to check which I2C bus the Penta SATA HAT top board is attached to?
 
@@ -120,10 +130,13 @@ sudo i2cdetect -l
 sudo i2cdetect -y <bus_number>
 ```
 
-After enabling the I2C7 overlay, scanning the corresponding bus should show the OLED device (usually i2c-7 on ROCK 4; check the `i2cdetect -l` output):
+Using ROCK 4 series as an example, after enabling the I2C7 overlay, scanning the corresponding bus should show the OLED device:
 
 ```bash
+# ROCK 4 series example: usually i2c-7 after enabling the I2C7 overlay
 sudo i2cdetect -y 7
 ```
+
+> Note: The bus number differs between models (e.g. usually i2c-8 on ROCK 5A and i2c-3 on ROCK 3A). Always check the `sudo i2cdetect -l` output; the number in the example is for reference only.
 
 Seeing `3c` in the output means the top board OLED is detected.

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -34,6 +34,42 @@ wget https://github.com/radxa/rockpi-penta/releases/download/v0.2.2/rockpi-penta
 sudo apt install -y ./rockpi-penta-0.2.2.deb
 ```
 
+### ROCK 4 series: Enable the I2C7 overlay
+
+On newer Radxa OS (Debian Bookworm) images, the **I2C7** bus used by the top board is not enabled by default. After installing `rockpi-penta`, if you see any of the following symptoms, the I2C7 overlay is likely not enabled:
+
+- The OLED stays on "ROCKPI SATA HAT loading..."
+- The fan does not spin, or always runs at full speed
+- Service logs show errors like `FileNotFoundError: /sys/class/pwm/pwmchip1/pwm0/period` or `Device or resource busy`
+
+To enable it:
+
+```bash
+sudo rsetup
+```
+
+Select `I2C7` in the Overlays menu (also select `PWM1` if the fan still misbehaves), save and reboot.
+
+### Check which I2C bus the top board is on
+
+The top board OLED (SSD1306) uses I2C address `0x3c`. Use the following commands to check whether the top board is detected and which bus it is on:
+
+```bash
+# List all I2C buses
+sudo i2cdetect -l
+
+# Scan each bus; the one showing 0x3c is where the top board is connected
+sudo i2cdetect -y <bus_number>
+```
+
+After enabling the I2C7 overlay, scanning the corresponding bus should show the OLED device (usually i2c-7 on ROCK 4; check the `i2cdetect -l` output):
+
+```bash
+sudo i2cdetect -y 7
+```
+
+Seeing `3c` in the output means the top board OLED is detected.
+
 ### Software configuration
 
 :::note

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/sata-hat-top-board.md
@@ -34,42 +34,6 @@ wget https://github.com/radxa/rockpi-penta/releases/download/v0.2.2/rockpi-penta
 sudo apt install -y ./rockpi-penta-0.2.2.deb
 ```
 
-### ROCK 4 series: Enable the I2C7 overlay
-
-On newer Radxa OS (Debian Bookworm) images, the **I2C7** bus used by the top board is not enabled by default. After installing `rockpi-penta`, if you see any of the following symptoms, the I2C7 overlay is likely not enabled:
-
-- The OLED stays on "ROCKPI SATA HAT loading..."
-- The fan does not spin, or always runs at full speed
-- Service logs show errors like `FileNotFoundError: /sys/class/pwm/pwmchip1/pwm0/period` or `Device or resource busy`
-
-To enable it:
-
-```bash
-sudo rsetup
-```
-
-Select `I2C7` in the Overlays menu (also select `PWM1` if the fan still misbehaves), save and reboot.
-
-### Check which I2C bus the top board is on
-
-The top board OLED (SSD1306) uses I2C address `0x3c`. Use the following commands to check whether the top board is detected and which bus it is on:
-
-```bash
-# List all I2C buses
-sudo i2cdetect -l
-
-# Scan each bus; the one showing 0x3c is where the top board is connected
-sudo i2cdetect -y <bus_number>
-```
-
-After enabling the I2C7 overlay, scanning the corresponding bus should show the OLED device (usually i2c-7 on ROCK 4; check the `i2cdetect -l` output):
-
-```bash
-sudo i2cdetect -y 7
-```
-
-Seeing `3c` in the output means the top board OLED is detected.
-
 ### Software configuration
 
 :::note
@@ -125,3 +89,41 @@ f-temp = false
 ```
 
 After modifying the configuration, run the `sudo systemctl restart rockpi-penta.service` command to restart the service for the configuration to take effect.
+
+## FAQ
+
+### The top board OLED stays on "ROCKPI SATA HAT loading...", or the fan does not spin / always runs at full speed?
+
+On newer Radxa OS (Debian Bookworm) images, the **I2C7** bus used by the top board is not enabled by default. After installing `rockpi-penta`, if you see any of the following symptoms, the I2C7 overlay is likely not enabled:
+
+- The OLED stays on "ROCKPI SATA HAT loading..."
+- The fan does not spin, or always runs at full speed
+- Service logs show errors like `FileNotFoundError: /sys/class/pwm/pwmchip1/pwm0/period` or `Device or resource busy`
+
+To enable it:
+
+```bash
+sudo rsetup
+```
+
+Select `I2C7` in the Overlays menu (also select `PWM1` if the fan still misbehaves), save and reboot.
+
+### How to check which I2C bus the Penta SATA HAT top board is attached to?
+
+The top board OLED (SSD1306) uses I2C address `0x3c`. Use the following commands to check whether the top board is detected and which bus it is on:
+
+```bash
+# List all I2C buses
+sudo i2cdetect -l
+
+# Scan each bus; the one showing 0x3c is where the top board is connected
+sudo i2cdetect -y <bus_number>
+```
+
+After enabling the I2C7 overlay, scanning the corresponding bus should show the OLED device (usually i2c-7 on ROCK 4; check the `i2cdetect -l` output):
+
+```bash
+sudo i2cdetect -y 7
+```
+
+Seeing `3c` in the output means the top board OLED is detected.


### PR DESCRIPTION
## 背景

来自论坛用户反馈（https://forum.radxa.com/t/rock-pi-4b-penta-sata-hat-top-board-problem-rockpi-sata-hat-loading/31317/1）：

- 环境：ROCK Pi 4B + Penta SATA HAT 全套件，`rock-pi-4b_bookworm_kde_r4.output_512` 镜像
- 现象：SATA 硬盘正常识别，但顶板 OLED 一直停在 "ROCKPI SATA HAT loading..."，风扇不转或满速
- 日志：`rockpi-penta` 服务报 `FileNotFoundError: /sys/class/pwm/pwmchip1/pwm0/period`、`Device or resource busy`
- 根因：新 Bookworm 镜像默认未启用 I2C7 overlay（顶板 OLED 走 I2C7，风扇 PWM 依赖 PWM1），用户通过 `rsetup` 启用 I2C7 overlay 后解决

## 本次修改

在 `sata-hat-top-board.md`（中英双语）中新增两节：

1. **ROCK 4 系列：启用 I2C7 overlay** — 描述典型症状（OLED 卡 loading / 风扇异常 / 服务报错），并给出 `sudo rsetup` 启用 I2C7（必要时 PWM1）的解决步骤
2. **检查顶板挂载在哪条 I2C 总线** — 教用户用 `i2cdetect -l` / `i2cdetect -y <bus>` 确认顶板 OLED (SSD1306, 0x3c) 挂载在哪个 I2C 总线

## 影响范围

- docs-only，无代码改动
- 覆盖 ROCK 4A/4B/4A+/4B+/4SE（含 ROCKPi 4 系列）
- 减少用户踩坑：新 Bookworm 镜像下顶板不工作时的排查路径
