### PR TITLE
docs(accessories): fix m2-extension-board zh content to match en

### DIFF
--- a/docs/accessories/storage/m2-extension-board.md
+++ b/docs/accessories/storage/m2-extension-board.md
@@ -1,129 +1,44 @@
 ---
-sidebar_position: 17
+sidebar_position: 20
 ---
 
-# PCIe E Key
+# 瑞莎 M.2 扩展板
 
-## 简介
+Radxa M.2 扩展板是用于扩展嵌入式系统存储容量的解决方案。
 
-PCIe E Key 是用于连接嵌入式设备的接口，通常用于连接存储卡、WiFi 模块、蓝牙模块等设备。
+![Radxa M.2 Extension Board](/img/accessories/storage/m2-extension-1.webp)
 
-## 支持的配件
+## 特征
 
-### WIFI & BT 支持模块列表
+- 全四通道 PCIE 2.0
+- M.2 M 连接器，支持 M key SSD 和 B&M key SSD
+- 支持 2280 / 2260 / 2242 / 2230 M.2 SSD
 
-| NO. | Model                                              | Chip        | WiFi          | BT  | WIFI Throughput                       | Remark                                              |
-| --- | -------------------------------------------------- | ----------- | ------------- | --- | ------------------------------------- | --------------------------------------------------- |
-| 1   | ROCK Pi Wireless Module A1 (SDIO+UART) --- AP6236  | BCM43436B0  | 2.4G          | 4.2 | up:23.5 Mbits/sec down:40.4 Mbits/sec |                                                     |
-| 2   | ROCK Pi Wireless Module A2 (SDIO+UART) --- AP6256  | BCM43456    | 2.4G&5G       | 5.0 | up:196 Mbits/sec down: 187 Mbits/sec  |                                                     |
-| 3   | ROCK Pi Wireless Module A3 (SDIO+UART) --- AP6398S | BCM43598    | 2.4G&5G       | 5.0 | up:336 Mbits/sec down: 315 Mbits/sec  |                                                     |
-| 4   | Radxa wireless A8                                  | RTL8852BE   | 2.4G&5G&WIFI6 | 5.0 | up:600Mbits/sec down:900 Mbits/sec    |                                                     |
-| 5   | Intel 0MHK36 (PCIE+USB)                            | Intel 3165  | 2.4G&5G       | 4.2 | up:283 Mbits/sec down: 334 Mbits/sec  |                                                     |
-| 6   | Intel 7265NGW (PCIE+USB)                           | Intel 7265  | 2.4G&5G       | 4.2 | up:363 Mbits/sec down: 619 Mbits/sec  |                                                     |
-| 7   | Intel AX210 (PCIE+USB)                             | Intel AX210 | WiFi 6        | 5.2 | up: 859 Mbits/sec down: 813 Mbits/sec | Only WIFI is supported currently, BT is not working |
+## 清单
 
-- ROCK 5 ITX 没有板载 WiFi/BT 模块，需要外接模块。以上是支持并测试过的 WITI/BT 卡。
-- 这里演示的 M.2 无线模块是：Radxa 无线模块 A8。
+- 1 x Radxa M.2 扩展板
+- 1 x 固定螺丝
+- 1 x 转接板
+- 1 x IPEX 转接线
 
-#### WIFI 的使用
+**注意꞉ 以下产品需要转接板来支持 Radxa M.2 扩展板。**
 
-- 首先进入 ROOT 用户模式。
+| 适配板            | 适用产品                            |
+| ----------------- | ----------------------------------- |
+| ROCKPI M2 to IPEX | ROCK 4A / 4B / 4A+ / 4B+ / 4SE / 3A |
+| M.2 M Key to IPEX | ROCK 3C                             |
+| M.2 E Key to IPEX | ROCK 5A                             |
 
-```bash
-sudo su
-```
+- **支持 ROCK 5A 的 M.2 扩展板套装**
 
-- 打开 WIFI
+详情请参阅 [在 ROCK 5A 上使用 M.2 E 扩展板](/rock5/rock5a/accessories-guides/m.2-extension-board)
 
-```bash
-nmcli r wifi on
-```
+![Radxa M.2 Extension Board](/img/accessories/storage/m2-extension-2.webp)
 
-- 扫描 WIFI
+- **支持 ROCK 4A / 4B / 4A+ / 4B+ / 4SE / 3A 的 M.2 扩展板套装**
 
-```bash
-nmcli dev wifi
-```
+  ![Radxa M.2 Extension Board](/img/accessories/storage/m2-extension-4.webp)
 
-- 连接 wifi 网络
+- **支持 ROCK 3C 的 M.2 扩展板套装**
 
-```bash
-nmcli dev wifi connect "wifi_name" password "wifi_password"
-```
-
-#### 蓝牙的使用
-
-- 使用 Radxa 无线 A8 模块时，必须添加以下黑名单才能使 BT 正常工作。
-
-```text
-root@rock-5-itx:~# cat /etc/modprobe.d/blacklist.conf
-blacklist pgdrv
-blacklist btusb
-blacklist btrtl
-blacklist btbcm
-blacklist btintel
-
-root@rock-5-itx:~# reboot
-```
-
-- Radxa APT 包括用于 Broadcom 无线模块的 broadcom-wifibt-firmware 软件包和用于 Intel 无线模块的 intel-wifibt-firmware 软件包。需要下载相应的软件包。
-
-```text
-root@rock-5-itx:~# apt-get update -y
-root@rock-5-itx:~# apt-get install -y broadcom-wifibt-firmware intel-wifibt-firmware
-```
-
-- 测试蓝牙模块的状态并检查蓝牙设备。
-
-```text
-root@rock-5-itx:~# systemctl status bluetooth
-```
-
-- 运行蓝牙设备。
-
-```text
-root@rock-5-itx:~# systemctl start bluetooth
-```
-
-- 检测蓝牙设备
-
-```text
-root@rock-5-itx:~# hciconfig
-hci0:   Type: Primary Bus: UART
-       BD Address: 10:2C:6B:49:D5:53 ACL MTU: 1021:8 SCO MTU: 64:1
-       UP RUNNING
-       RX bytes:850 acl:0 sco:0 events:58 errors:0
-       TX bytes:2814 acl:0 sco:0 commands:58 errors:0
-```
-
-- 测试：连接蓝牙音箱，首先安装 pulseaudio
-
-```text
-root@rock-5-itx:~# apt-get install -y pulseaudio-module-bluetooth pulseaudio
-```
-
-- 运行 pulseaudio
-
-```text
-root@rock-5-itx:~# pulseaudio --start
-```
-
-- 使用 pulseaudio 连接
-
-```text
-root@rock-5-itx:~# bluetoothctl
-[bluetooth]# default-agent
-[bluetooth]# power on
-[bluetooth]# scan on
-[bluetooth]# trust 41:42:1A:8D:A9:65       #BT-280
-[bluetooth]# pair 41:42:1A:8D:A9:65
-[bluetooth]# connect 41:42:1A:8D:A9:65
-```
-
-- 现在您可以听音乐了。
-
-### 瑞莎 M.2 E 型转 SATA 板
-
-![M.2 E key to SATA Breakout Board](/img/accessories/storage/m2e-to-sata-1.webp)
-
-- 该拓展版直接插在 M2.E 接口上，然后将 SATA 设备连接到扩展板上即可。
+  ![Radxa M.2 Extension Board](/img/accessories/storage/m2-extension-3.webp)


### PR DESCRIPTION
## 背景

docs.radxa.com/en/accessories/storage/m2-extension-board 页面中英文内容不一致：
- 英文版：Radxa M.2 Extension Board 教程（正确）
- 中文版：错误地变成了 ROCK 5 ITX 的 PCIe E Key 接口使用教程

## 根因

commit `a4e31d2b2`（2025-12-05，feat: move storage docs）迁移 storage 文档时：
- 英文版只是 rename（内容保持正确）
- 中文版被错误复制成了 `docs/rock5/rock5itx/getting-started/interface-usage/pcie-e-key.md` 的内容（copy），同时删掉了原本正确的中文 M.2 Extension Board 教程

后续 `a689f25fe` 只改了代码块类型标注，未纠正内容。

## 修复

- 中文版恢复为与英文版一致的 Radxa M.2 Extension Board 教程翻译
- 图片路径同步为 `/img/accessories/storage/`（storage 目录下的正确路径）
- 英文版本身内容正确，无需改动，故本次仅修改中文文件

## 影响

- 修复 m2-extension-board 页面中英不一致问题
- ROCK 5 ITX 的 PCIe E Key 教程在其原页面 `rock5/rock5itx/getting-started/interface-usage/pcie-e-key.md` 中仍然完整保留，无信息丢失
