### PR TITLE
docs(cubie): keep only latest images on Cubie download pages

### DIFF
--- a/docs/cubie/a7a/download.md
+++ b/docs/cubie/a7a/download.md
@@ -42,15 +42,7 @@ sidebar_position: 150
 
 - [Radxa Cubie A7A Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) （SD / eMMC）
 
-- [Radxa Cubie A7A Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) （SD / eMMC）
-
 - [Radxa Cubie A7A Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) （UFS）
-
-- [Radxa Cubie A7A Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) （UFS）
-
-- [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) （SD / eMMC）
-
-- [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) （UFS）
 
 :::tip 百度网盘下载（备选）
 

--- a/docs/cubie/a7s/download.md
+++ b/docs/cubie/a7s/download.md
@@ -38,12 +38,6 @@ sidebar_position: 8
 
 :::
 
-- Radxa OS
-
-[radxa-a733-bullseye-kde-r6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz)：支持 microSD 卡和板载 eMMC 启动系统。
-
-[radxa-a733-bullseye-kde-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz)：支持 microSD 卡和板载 eMMC 启动系统。
-
 - Radxa OS Lite
 
 :::tip
@@ -55,8 +49,6 @@ Radxa OS Lite 系统镜像不包含图形桌面环境。
 :::
 
 [radxa-a733-bullseye-cli-r6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz)：支持 microSD 卡和板载 eMMC 启动系统。
-
-[radxa-a733-bullseye-cli-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_cli_r2.output_512.img.xz)：支持 microSD 卡和板载 eMMC 启动系统。
 
 :::tip 内置 OpenClaw 环境镜像
 

--- a/docs/cubie/a7z/download.md
+++ b/docs/cubie/a7z/download.md
@@ -42,15 +42,7 @@ sidebar_position: 150
 
 - [Radxa Cubie A7Z Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) （SD / eMMC）
 
-- [Radxa Cubie A7Z Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) （SD / eMMC）
-
 - [Radxa Cubie A7Z Debian 11 KDE R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) （UFS）
-
-- [Radxa Cubie A7Z Debian 11 CLI R6（最新）](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) （UFS）
-
-- [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) （SD / eMMC）
-
-- [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) （UFS）
 
 :::tip Cubie A7Z 旧版镜像
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/download.md
@@ -42,15 +42,7 @@ Currently supports booting from microSD cards, eMMC modules, and UFS modules. NV
 
 - [Radxa Cubie A7A Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) (SD / eMMC)
 
-- [Radxa Cubie A7A Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) (SD / eMMC)
-
 - [Radxa Cubie A7A Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) (UFS)
-
-- [Radxa Cubie A7A Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) (UFS)
-
-- [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) (SD / eMMC)
-
-- [Radxa Cubie A7A Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) (UFS)
 
 :::tip Baidu Netdisk Download (Alternative)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/download.md
@@ -38,12 +38,6 @@ This page publishes the latest stable and test images. Test versions start with 
 
 :::
 
-- Radxa OS
-
-[radxa-a733-bullseye-kde-r6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz): supports booting from microSD and onboard eMMC.
-
-[radxa-a733-bullseye-kde-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz): supports booting from microSD and onboard eMMC.
-
 - Radxa OS Lite
 
 :::tip
@@ -55,8 +49,6 @@ If you need a monitor UI or graphical applications, use the full Radxa OS image.
 :::
 
 [radxa-a733-bullseye-cli-r6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz): supports booting from microSD and onboard eMMC.
-
-[radxa-a733-bullseye-cli-r2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_cli_r2.output_512.img.xz): supports booting from microSD and onboard eMMC.
 
 :::tip Built-in OpenClaw environment image
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/download.md
@@ -42,15 +42,7 @@ Currently supports booting from microSD cards, eMMC modules, and UFS modules. NV
 
 - [Radxa Cubie A7Z Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_512.img.xz) (SD / eMMC)
 
-- [Radxa Cubie A7Z Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_512.img.xz) (SD / eMMC)
-
 - [Radxa Cubie A7Z Debian 11 KDE R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_kde_r6.output_4096.img.xz) (UFS)
-
-- [Radxa Cubie A7Z Debian 11 CLI R6 (Latest)](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r6/radxa-a733_bullseye_cli_r6.output_4096.img.xz) (UFS)
-
-- [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_512.img.xz) (SD / eMMC)
-
-- [Radxa Cubie A7Z Debian 11 KDE R2](https://github.com/radxa-build/radxa-a733/releases/download/rsdk-r2/radxa-a733_bullseye_kde_r2.output_4096.img.xz) (UFS)
 
 :::tip Cubie A7Z Legacy Images
 


### PR DESCRIPTION
## Summary

Clean up the Debian image lists on the Cubie download pages to keep only the latest images, per internal request from the after-sales support group.

- **Cubie A7A / A7Z Debian**: keep only the latest KDE R6 images (SD/eMMC + UFS), remove CLI R6 and KDE R2 images
- **Cubie A7S Debian**: keep only the latest CLI R6 image, remove KDE R6 / KDE R2 / CLI R2 images

The removed images remain available on the unified [radxa-a733 releases page](https://github.com/radxa-build/radxa-a733/releases), so no access is lost — this only reduces clutter on the docs download pages.

## Changes

- `docs/cubie/a7a/download.md` + `i18n/en/.../a7a/download.md`
- `docs/cubie/a7s/download.md` + `i18n/en/.../a7s/download.md`
- `docs/cubie/a7z/download.md` + `i18n/en/.../a7z/download.md`

Bilingual (zh/en) updated in sync. Verified with `github_pr_guard.py` (bilingual coverage complete).
