### PR TITLE
docs(penta-sata-hat): add ROCK 4D to supported products list

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/README.md
+++ b/docs/accessories/storage/penta-sata-hat/README.md
@@ -16,6 +16,7 @@ sidebar_position: 1
 - ROCK 3C
 - ROCK 4A / 4B
 - ROCK 4A+ / 4B+
+- ROCK 4D
 - ROCK 4SE
 - ROCK 5A
 - ROCK 5C

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/README.md
@@ -16,6 +16,7 @@ Currently supported Radxa ROCK Series products:
 - ROCK 3C
 - ROCK 4A / 4B
 - ROCK 4A+ / 4B+
+- ROCK 4D
 - ROCK 4SE
 - ROCK 5A
 - ROCK 5C


### PR DESCRIPTION
## Summary

The ROCK 4D accessories page already lists **Penta SATA HAT** as a compatible accessory, but the Penta SATA HAT supported products list was missing ROCK 4D. Customers visiting the Penta SATA HAT page could not find a matching model for ROCK 4D.

Confirmed by the Radxa hardware team: ROCK 4D works with the same Penta kit as ROCK 5C (RA006FFC) and supports up to 5 drives.

## Change

- Add `ROCK 4D` to the supported ROCK Series products list in `docs/accessories/storage/penta-sata-hat/README.md` (zh)
- Add `ROCK 4D` to the supported products list in `i18n/en/.../penta-sata-hat/README.md` (en)

## Source

Internal support: customer reported ROCK 4D could not find a matching Penta SATA HAT model on the accessory page; hardware team confirmed compatibility.
