### PR TITLE
docs(dragon-q8b): add other-system section with Armbian guide

### DIFF
--- a/docs/dragon/q8b/other-system/README.md
+++ b/docs/dragon/q8b/other-system/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 6
+---
+
+# 其他系统
+
+<DocCardList />

--- a/docs/dragon/q8b/other-system/armbian.md
+++ b/docs/dragon/q8b/other-system/armbian.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 1
+---
+
+# Armbian
+
+Armbian 是一个面向 ARM 主板的轻量级 Linux 发行版，以稳定性、高性能和良好的硬件支持而闻名。它提供了针对各种 ARM 主板优化的 Debian 和 Ubuntu 基础系统。
+
+Radxa Dragon Q8B 基于高通骁龙 8cx Gen 3（高通 SC8280XP）计算平台，支持运行 Armbian 系统。
+
+## 系统镜像下载
+
+Armbian 为 Radxa Dragon Q8B 提供多个版本的系统镜像，提供 Linux 内核 **vendor 7.0.11**（稳定版）与 **edge 7.1.8**（滚动版）两种内核线：
+
+### 稳定版镜像
+
+Armbian 官方推荐、经过充分测试的稳定版镜像（Stable）：
+
+- **Armbian 26.8.1 - Ubuntu 26.04 (Gnome 桌面版)**：基于 vendor 7.0.11 内核，完整桌面环境，适合日常使用
+- **Armbian 26.8.1 - Debian 13 (最小化版)**：基于 vendor 7.0.11 内核，轻量级系统，适合物联网应用
+
+### 其他版本
+
+除稳定版外，Armbian 还提供以下版本：
+
+- **桌面版**：Ubuntu 26.04 的 Cinnamon / Gnome / KDE Plasma 桌面环境
+- **最小化版**：Ubuntu 26.04 / Debian 13 最小化系统（含支持 UFS 存储的版本）
+- **专用版本**：Kali Linux、Home Assistant、OpenMediaVault 等
+
+:::tip
+- 推荐使用 [Armbian Imager](https://www.armbian.com/imager/) 下载并烧录镜像。
+- 滚动版（edge 内核）仅适合有经验的 Linux 用户，不推荐在生产环境中使用。
+:::
+
+下载地址：[Armbian Radxa Dragon Q8B 下载页面](https://armbian.com/boards/radxa-dragon-q8b)
+
+## 烧录系统
+
+Armbian 镜像的烧录方法与 Radxa OS 一致，可以参考以下页面：
+
+- [安装系统到 microSD 卡](../getting-started/install-system/sd-system)
+- [安装系统到 UFS](../getting-started/install-system/ufs-system/)
+- [安装系统到 NVMe](../getting-started/install-system/nvme-system/)
+
+## 首次启动配置
+
+首次启动时，系统会引导您完成基本配置：
+
+1. 设置 root 密码
+2. 创建普通用户账户
+3. 确认语言设置
+4. （可选）将系统转移到内部存储
+
+您也可以使用 `armbian-config` 工具进行系统配置，包括：
+
+- 网络设置（静态/动态 IP、热点）
+- 更换登录 Shell（ZSH）
+- 启用 SSH 双因素认证
+- 安装常用软件
+- 系统优化等
+
+## 相关资源
+
+- [官方文档](https://docs.armbian.com/)
+- [技术支持论坛](https://forum.armbian.com/)
+- [问题反馈](https://www.armbian.com/bugs/)
+- [常见问题](https://docs.armbian.com/User-Guide_FAQ/)

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/other-system/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/other-system/README.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 6
+---
+
+# Other OS
+
+<DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/other-system/armbian.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/other-system/armbian.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 1
+---
+
+# Armbian
+
+Armbian is a lightweight Linux distribution for ARM motherboards, known for its stability, high performance, and excellent hardware support. It provides Debian and Ubuntu-based systems optimized for various ARM single-board computers.
+
+The Radxa Dragon Q8B is based on the Qualcomm Snapdragon 8cx Gen 3 (Qualcomm SC8280XP) compute platform and supports running Armbian.
+
+## System Image Downloads
+
+Armbian provides multiple system images for the Radxa Dragon Q8B, offering two kernel lines: **vendor 7.0.11** (stable) and **edge 7.1.8** (rolling):
+
+### Stable Release Images
+
+Official Armbian images that are hand-selected and well-tested (Stable):
+
+- **Armbian 26.8.1 - Ubuntu 26.04 (Gnome Desktop)**: Based on the vendor 7.0.11 kernel, full desktop environment for daily use
+- **Armbian 26.8.1 - Debian 13 (Minimal)**: Based on the vendor 7.0.11 kernel, lightweight system for IoT applications
+
+### Other Images
+
+In addition to the stable releases, Armbian also provides:
+
+- **Desktop**: Ubuntu 26.04 with Cinnamon / Gnome / KDE Plasma desktop environments
+- **Minimal**: Ubuntu 26.04 / Debian 13 minimal systems (including versions supporting UFS storage)
+- **Dedicated applications**: Kali Linux, Home Assistant, OpenMediaVault, and more
+
+:::tip
+- It is recommended to use [Armbian Imager](https://www.armbian.com/imager/) to download and flash images.
+- Rolling releases (edge kernel) are only suitable for experienced Linux users and not recommended for production environments.
+:::
+
+Download: [Armbian Radxa Dragon Q8B Download Page](https://armbian.com/boards/radxa-dragon-q8b)
+
+## Flashing the System
+
+The Armbian images are flashed in the same way as Radxa OS. Please refer to the following pages:
+
+- [Install system to microSD card](../getting-started/install-system/sd-system)
+- [Install system to UFS](../getting-started/install-system/ufs-system/)
+- [Install system to NVMe](../getting-started/install-system/nvme-system/)
+
+## First Boot Configuration
+
+On first boot, the system will guide you through basic configuration:
+
+1. Set root password
+2. Create a regular user account
+3. Confirm language settings
+4. (Optional) Transfer system to internal storage
+
+You can also use the `armbian-config` tool for system configuration, including:
+
+- Network settings (static/dynamic IP, hotspot)
+- Change login shell (ZSH)
+- Enable SSH two-factor authentication
+- Install common software
+- System optimization, etc.
+
+## Related Resources
+
+- [Official Documentation](https://docs.armbian.com/)
+- [Technical Support Forum](https://forum.armbian.com/)
+- [Bug Reports](https://www.armbian.com/bugs/)
+- [FAQ](https://docs.armbian.com/User-Guide_FAQ/)


### PR DESCRIPTION
## Summary

Add the **Other OS (其他系统)** section for **Radxa Dragon Q8B**, initially covering **Armbian**.

This is triggered by a support docs request (项泽龙, 2026-08-19) and follows the existing structure of `docs/dragon/q6a/other-system/`.

## Changes

- `docs/dragon/q8b/other-system/README.md` (zh) — Other OS section index
- `docs/dragon/q8b/other-system/armbian.md` (zh) — Armbian guide:
  - Official Armbian board page: https://armbian.com/boards/radxa-dragon-q8b
  - Stable images (Armbian 26.8.1 Ubuntu 26.04 Gnome / Debian 13 Minimal, vendor kernel 7.0.11)
  - Other image variants (desktop / minimal / dedicated apps, UFS variants)
  - Flashing instructions linking to existing Q8B install-system pages (SD / UFS / NVMe)
  - First boot configuration and related resources
- `i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/other-system/README.md` (en) — English index
- `i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/other-system/armbian.md` (en) — English Armbian guide

Chinese and English versions are added in sync.
