### PR TITLE
docs(rkdevtool): add Windows USB driver note for Maskrom mode

### DIFF
--- a/docs/common/radxa-os/rkdevtool/_maskrom.mdx
+++ b/docs/common/radxa-os/rkdevtool/_maskrom.mdx
@@ -43,6 +43,12 @@ Maskrom 模式是 Rockchip 芯片内置的底层恢复模式，当设备无法�
 
 若主板进入 Maskrom 模式，软件左下角会显示 `Found One MASKROM Device`。
 
+:::tip
+如果 RKDevTool 提示 `没有发现设备`，且 Windows 设备管理器中显示为“未知设备”，说明电脑尚未安装 Rockchip USB 驱动。
+
+请先安装驱动：下载并解压 [DriverAssistant v5.14](https://dl.radxa.com/tools/windows/DriverAssitant_v5.14.zip)，右键以管理员身份运行 `DriverInstall.exe`，点击 `Install Driver`。安装完成后重新插拔 USB 数据线（或重新进入 Maskrom 模式），再打开 RKDevTool 即可识别设备。
+:::
+
 <div style={{ textAlign: "center" }}>
   <img
     src="/img/common/tools/rkdevtool/maskrom-mode.webp"

--- a/docs/common/radxa-os/rkdevtool/_maskrom_two_device.mdx
+++ b/docs/common/radxa-os/rkdevtool/_maskrom_two_device.mdx
@@ -68,6 +68,12 @@ Maskrom 模式是 Rockchip 芯片内置的底层恢复模式，当设备无法�
 
 若主板进入 Maskrom 模式，软件左下角会显示 `Found One MASKROM Device`。
 
+:::tip
+如果 RKDevTool 提示 `没有发现设备`，且 Windows 设备管理器中显示为“未知设备”，说明电脑尚未安装 Rockchip USB 驱动。
+
+请先安装驱动：下载并解压 [DriverAssistant v5.14](https://dl.radxa.com/tools/windows/DriverAssitant_v5.14.zip)，右键以管理员身份运行 `DriverInstall.exe`，点击 `Install Driver`。安装完成后重新插拔 USB 数据线（或重新进入 Maskrom 模式），再打开 RKDevTool 即可识别设备。
+:::
+
 <div style={{ textAlign: "center" }}>
   <img
     src="/img/common/tools/rkdevtool/maskrom-mode.webp"

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/rkdevtool/_maskrom.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/rkdevtool/_maskrom.mdx
@@ -43,6 +43,12 @@ On Windows, open the RKDevTool. The software will automatically detect if the bo
 
 If the board is in Maskrom mode, the bottom left corner of the software will display `Found One MASKROM Device`.
 
+:::tip
+If RKDevTool reports `No Device Found` and Windows Device Manager shows an "Unknown device", the Rockchip USB driver has not been installed on your computer.
+
+Install the driver first: download and extract [DriverAssistant v5.14](https://dl.radxa.com/tools/windows/DriverAssitant_v5.14.zip), right-click `DriverInstall.exe` and run it as administrator, then click `Install Driver`. After the driver is installed, reconnect the USB cable (or re-enter Maskrom mode) and reopen RKDevTool — the device should then be detected.
+:::
+
 <div style={{ textAlign: "center" }}>
   <img
     src="/en/img/common/tools/rkdevtool/maskrom-mode.webp"

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/rkdevtool/_maskrom_two_device.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/radxa-os/rkdevtool/_maskrom_two_device.mdx
@@ -68,6 +68,12 @@ On Windows, open the RKDevTool application. The software will automatically dete
 
 If the board is in Maskrom mode, the bottom left corner of the software will display `Found One MASKROM Device`.
 
+:::tip
+If RKDevTool reports `No Device Found` and Windows Device Manager shows an "Unknown device", the Rockchip USB driver has not been installed on your computer.
+
+Install the driver first: download and extract [DriverAssistant v5.14](https://dl.radxa.com/tools/windows/DriverAssitant_v5.14.zip), right-click `DriverInstall.exe` and run it as administrator, then click `Install Driver`. After the driver is installed, reconnect the USB cable (or re-enter Maskrom mode) and reopen RKDevTool — the device should then be detected.
+:::
+
 <div style={{ textAlign: "center" }}>
   <img
     src="/en/img/common/tools/rkdevtool/maskrom-mode.webp"


### PR DESCRIPTION
## Summary

Fixes #2035

User reported that on the [Rock 5B Maskrom mode page](https://docs.radxa.com/rock5/rock5b/low-level-dev/install-os/rkdevtool_maskrom), RKDevTool shows "没有发现设备" (No Device Found) and Windows Device Manager shows an unknown device when the board enters Maskrom mode.

## Root cause

This is not a board fault — the Rockchip USB driver is simply not installed on the Windows host. The Maskrom verification section only said the tool "automatically detects" the device, with no guidance on what to do when the device shows up as an unknown device.

## Change

Added a tip in the Windows tab of the "Verifying Maskrom Mode" section (in the shared `_maskrom.mdx` / `_maskrom_two_device.mdx` common files, zh + en):

- If RKDevTool reports no device and Device Manager shows an "Unknown device", the Rockchip USB driver is not installed
- Install DriverAssistant v5.14 and run `DriverInstall.exe` as administrator, click `Install Driver`
- Reconnect the USB cable (or re-enter Maskrom mode) and reopen RKDevTool

This applies to all pages importing these common files (Rock 5B, CM4, NX4, NX5, etc.), preventing the same question on other product pages.

## Test

- `github_pr_guard.py check` passes (single scope, bilingual pairs complete)