### PR TITLE
docs(dragon-q8b): add accessories usage page

### DIFF
--- a/docs/dragon/q8b/accessories/README.md
+++ b/docs/dragon/q8b/accessories/README.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 99
+---
+
+# 配件使用
+
+本页面列出了与 Dragon Q8B 兼容的官方配件。
+
+## 配件列表
+
+| 类别     | 配件名称             | 描述                                                             | 产品链接                                                                   |
+| -------- | -------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 网络     | 瑞莎无线模块 A8      | 标准 M.2 2230 无线模块，支持 Wi-Fi 6 和蓝牙 5.2，安装于 M.2 E Key 插槽 | [查看详情](https://radxa.com/products/accessories/wireless-module-a8)      |
+| 电源     | Power PD 65W         | 推荐使用的 USB Type-C PD 电源适配器，20V/3.25A 输出，提供稳定的 65W 供电 | [查看详情](https://radxa.com/products/accessories/power-pd-65w)            |
+| 存储扩展 | Radxa UFS Module     | 高性能 UFS 存储模块，配合 Q8B 的 UFS 模块接口使用                 | [查看详情](https://radxa.com/products/accessories/ufs-module)              |
+| 存储扩展 | Radxa M.2 扩展板     | M.2 M Key 扩展板，支持 2280 / 2260 / 2242 / 2230 规格 M.2 SSD     | [查看详情](https://radxa.com/products/accessories/m2-extension-board)      |

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/accessories/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/accessories/README.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 99
+---
+
+# Accessories Usage
+
+This page lists the official accessories compatible with Dragon Q8B.
+
+## Accessories list
+
+| Category       | Accessory             | Description                                                                        | Product link                                                                          |
+| -------------- | --------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Network        | Radxa Wireless Module A8 | Standard M.2 2230 wireless module with Wi-Fi 6 and Bluetooth 5.2, installed in the M.2 E Key slot | [Learn more](https://radxa.com/products/accessories/wireless-module-a8) |
+| Power          | Power PD 65W          | Recommended USB Type-C PD power adapter with 20V/3.25A output, providing stable 65 W power | [Learn more](https://radxa.com/products/accessories/power-pd-65w)            |
+| Storage        | Radxa UFS Module      | High-performance UFS storage module for the UFS module connector on Q8B             | [Learn more](https://radxa.com/products/accessories/ufs-module)              |
+| Storage        | Radxa M.2 Extension Board | M.2 M Key extension board supporting 2280 / 2260 / 2242 / 2230 M.2 SSDs           | [Learn more](https://radxa.com/products/accessories/m2-extension-board)      |


### PR DESCRIPTION
## Summary

Dragon Q8B documentation had no accessories section, unlike Dragon Q6A which has an `accessories` page.

This gap was identified in the internal support group (2026-08-19): customers asked which WiFi module the M.2 E Key slot supports and which accessories are compatible with Q8B. The docs owner confirmed the supported accessories list.

## Change

Added `docs/dragon/q8b/accessories/README.md` (zh) + `i18n/en/.../q8b/accessories/README.md` (en), following the existing Q6A accessories page pattern:

- Radxa Wireless Module A8 (M.2 E Key 2230, Wi-Fi 6 / BT 5.2)
- Power PD 65W
- Radxa UFS Module
- Radxa M.2 Extension Board

## Impact

- Reduces customer confusion about which WiFi module / accessories work with Dragon Q8B
- Closes the missing-documentation gap flagged by the docs owner in the internal support group
- Docs-only change, zh + en synced, 1 commit / 2 files
