### PR TITLE
docs(rock3/rock3b): remove trailing blank lines in android tutorial code blocks

### DIFF
--- a/docs/rock3/rock3b/other-os/android/low-level-dev.md
+++ b/docs/rock3/rock3b/other-os/android/low-level-dev.md
@@ -18,7 +18,6 @@ lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache \
 libgl1-mesa-dev libxml2-utils xsltproc unzip mtools u-boot-tools \
 htop iotop sysstat iftop pigz bc device-tree-compiler lunzip \
 dosfstools vim-common parted udev libssl-dev python3 python-pip lzop swig
-
 ```
 
 ### Repo
@@ -32,7 +31,6 @@ Repo 是 Android 开发中用于管理多个 Git 仓库的工具，它是一个P
 wget https://storage.googleapis.com/git-repo-downloads/repo -P ~/bin/
 or
 curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
-
 ```
 
 ## 源码下载
@@ -41,7 +39,6 @@ curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
 
 $ repo init -u https://github.com/radxa/manifests.git -b Android11_Radxa_rk12 -m rockchip-r-release.xml
 $ repo sync -d --no-tags -j4
-
 ```
 
 ## 镜像编译
@@ -59,7 +56,6 @@ radxa:rock-android11 $ source build/envsetup.sh
 radxa:rock-android11 $ lunch rk356x_rock_3b_r-userdebug
 
 radxa:rock-android11 $ ./build.sh -UACKu
-
 ```
 
 等待编译完成就可以在 IMAGE 目录找到镜像

--- a/docs/rock3/rock3b/other-os/android/remote-login.md
+++ b/docs/rock3/rock3b/other-os/android/remote-login.md
@@ -33,7 +33,6 @@ adb（调试桥）安装：
 ```bash
 
 set HTTP_PROXY=myserver:1981
-
 ```
 
 方式二：打开系统设置，修改环境变量：![3b adb](/img/nx5/adb_config.webp)
@@ -47,7 +46,6 @@ set HTTP_PROXY=myserver:1981
 ```bash
 
 sudo apt install adb
-
 ```
 
 </TabItem>
@@ -60,7 +58,6 @@ sudo apt install adb
 ```bash
 
 export PATH=${path}:~/platform-tools('~'代表解压出来的工具包路径)
-
 ```
 
 </TabItem>
@@ -90,7 +87,6 @@ $ adb devices
 
 $ adb shell
   radxa:rock-android11:/ $
-
 ```
 
 </TabItem>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/other-os/android/low-level-dev.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/other-os/android/low-level-dev.md
@@ -18,7 +18,6 @@ lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache \
 libgl1-mesa-dev libxml2-utils xsltproc unzip mtools u-boot-tools \
 htop iotop sysstat iftop pigz bc device-tree-compiler lunzip \
 dosfstools vim-common parted udev libssl-dev python3 python-pip lzop swig
-
 ```
 
 ### Repo
@@ -32,7 +31,6 @@ Repo is a tool used in Android development to manage multiple Git repositories. 
 wget https://storage.googleapis.com/git-repo-downloads/repo -P ~/bin/
 or
 curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
-
 ```
 
 ## code download
@@ -41,7 +39,6 @@ curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
 
 $ repo init -u https://github.com/radxa/manifests.git -b Android11_Radxa_rk12 -m rockchip-r-release.xml
 $ repo sync -d --no-tags -j4
-
 ```
 
 ## build

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/other-os/android/remote-login.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3b/other-os/android/remote-login.md
@@ -29,7 +29,6 @@ Method 1:Enter the following command in the terminal window:
 ```bash
 
 set HTTP_PROXY=myserver:1981
-
 ```
 
 Method 2:Open system settings and modify environment variables:![rock3b adb](/img/nx5/adb_config_en.webp)
@@ -43,7 +42,6 @@ Use the following command to install:
 ```bash
 
 sudo apt install adb
-
 ```
 
 </TabItem>
@@ -83,7 +81,6 @@ $ adb devices
 
 $ adb shell
   RadxaRock3B:/ $
-
 ```
 
 </TabItem>
@@ -110,7 +107,6 @@ Wireless ADB is supported on Android 11 and later.
 $ adb connect 10.0.0.16:45613
 $ adb shell
   RadxaRock3B:/ $
-
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary

Remove trailing blank lines inside fenced code blocks in the ROCK 3B Android tutorials (`other-os/android/low-level-dev.md`, `other-os/android/remote-login.md`). Code blocks had an extra empty line right before the closing ``` fence; this cleanup removes those stray blank lines in both the Chinese and English versions.

## Background

Found while checking `docs.radxa.com/rock3/rock3b` tutorials per internal request — code blocks rendered with an unexpected trailing empty line inside the fence.

## Changes

- `docs/rock3/rock3b/other-os/android/low-level-dev.md`: 4 trailing blank lines removed
- `docs/rock3/rock3b/other-os/android/remote-login.md`: 4 trailing blank lines removed
- English counterparts updated in sync

Whitespace-only change; no content/command modifications.
