### PR TITLE
docs(common/accessories): fix extra blank line in wifi-bt code blocks

### DIFF
--- a/docs/common/accessories/_wifi-bt.mdx
+++ b/docs/common/accessories/_wifi-bt.mdx
@@ -22,10 +22,8 @@
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# nmcli dev wifi connect "wifi_name" password
-    "wifi_password"
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# nmcli dev wifi connect "wifi_name" password
+"wifi_password"`}</pre>
 
 - 蓝牙的使用
 
@@ -33,20 +31,16 @@
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# cat /etc/modprobe.d/blacklist.conf blacklist
-    pgdrv blacklist btusb blacklist btrtl blacklist btbcm blacklist btintel
-    root@{props.model}:~# reboot
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# cat /etc/modprobe.d/blacklist.conf blacklist
+pgdrv blacklist btusb blacklist btrtl blacklist btbcm blacklist btintel
+root@${props.model}:~# reboot`}</pre>
 
   2. Radxa APT 包括用于Broadcom无线模块的broadcom-wifibt-firmware软件包和用于Intel无线模块的intel-wifibt-firmware软件包。需要下载相应的软件包
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# apt-get update -y root@{props.model}
-    :/home/radxa# apt-get install -y broadcom-wifibt-firmware intel-wifibt-firmware
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# apt-get update -y root@${props.model}
+:/home/radxa# apt-get install -y broadcom-wifibt-firmware intel-wifibt-firmware`}</pre>
 
   3. 测试蓝牙模块的状态并检查蓝牙设备
 
@@ -64,21 +58,17 @@
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# hciconfig hci0: Type: Primary Bus: UART BD
-    Address: 10:2C:6B:49:D5:53 ACL MTU: 1021:8 SCO MTU: 64:1 UP RUNNING RX
-    bytes:850 acl:0 sco:0 events:58 errors:0 TX bytes:2814 acl:0 sco:0
-    commands:58 errors:0
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# hciconfig hci0: Type: Primary Bus: UART BD
+Address: 10:2C:6B:49:D5:53 ACL MTU: 1021:8 SCO MTU: 64:1 UP RUNNING RX
+bytes:850 acl:0 sco:0 events:58 errors:0 TX bytes:2814 acl:0 sco:0
+commands:58 errors:0`}</pre>
 
   6. 测试：连接蓝牙音箱，首先安装 pulseaudio
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# apt-get install -y
-    pulseaudio-module-bluetooth pulseaudio
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# apt-get install -y
+pulseaudio-module-bluetooth pulseaudio`}</pre>
 
   7. 运行 pulseaudio
 
@@ -90,11 +80,9 @@
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# bluetoothctl [bluetooth]# default-agent
-    [bluetooth]# power on [bluetooth]# scan on [bluetooth]# trust
-    41:42:1A:8D:A9:65 #BT-280 [bluetooth]# pair 41:42:1A:8D:A9:65 [bluetooth]#
-    connect 41:42:1A:8D:A9:65
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# bluetoothctl [bluetooth]# default-agent
+[bluetooth]# power on [bluetooth]# scan on [bluetooth]# trust
+41:42:1A:8D:A9:65 #BT-280 [bluetooth]# pair 41:42:1A:8D:A9:65 [bluetooth]#
+connect 41:42:1A:8D:A9:65`}</pre>
 
   9. 现在您可以听音乐了

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_wifi-bt.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_wifi-bt.mdx
@@ -22,10 +22,8 @@
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# nmcli dev wifi connect "wifi_name" password
-    "wifi_password"
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# nmcli dev wifi connect "wifi_name" password
+"wifi_password"`}</pre>
 
 - Bluetooth Usage
 
@@ -33,20 +31,16 @@
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# cat /etc/modprobe.d/blacklist.conf blacklist
-    pgdrv blacklist btusb blacklist btrtl blacklist btbcm blacklist btintel
-    root@{props.model}:~# reboot
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# cat /etc/modprobe.d/blacklist.conf blacklist
+pgdrv blacklist btusb blacklist btrtl blacklist btbcm blacklist btintel
+root@${props.model}:~# reboot`}</pre>
 
   2. Radxa APT includes the broadcom-wifibt-firmware package for Broadcom wireless modules and the intel-wifibt-firmware package for Intel wireless modules. The corresponding packages need to be downloaded
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# apt-get update -y root@{props.model}
-    :/home/radxa# apt-get install -y broadcom-wifibt-firmware intel-wifibt-firmware
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# apt-get update -y root@${props.model}
+:/home/radxa# apt-get install -y broadcom-wifibt-firmware intel-wifibt-firmware`}</pre>
 
   3. Test the status of the Bluetooth module and check the Bluetooth device
 
@@ -64,21 +58,17 @@
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# hciconfig hci0: Type: Primary Bus: UART BD
-    Address: 10:2C:6B:49:D5:53 ACL MTU: 1021:8 SCO MTU: 64:1 UP RUNNING RX
-    bytes:850 acl:0 sco:0 events:58 errors:0 TX bytes:2814 acl:0 sco:0
-    commands:58 errors:0
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# hciconfig hci0: Type: Primary Bus: UART BD
+Address: 10:2C:6B:49:D5:53 ACL MTU: 1021:8 SCO MTU: 64:1 UP RUNNING RX
+bytes:850 acl:0 sco:0 events:58 errors:0 TX bytes:2814 acl:0 sco:0
+commands:58 errors:0`}</pre>
 
   6. Test: Connect the Bluetooth speaker, first install pulseaudio
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# apt-get install -y
-    pulseaudio-module-bluetooth pulseaudio
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# apt-get install -y
+pulseaudio-module-bluetooth pulseaudio`}</pre>
 
   7. Run pulseaudio
 
@@ -90,11 +80,9 @@
 
   {" "}
 
-  <pre>
-    root@{props.model}:/home/radxa# bluetoothctl [bluetooth]# default-agent
-    [bluetooth]# power on [bluetooth]# scan on [bluetooth]# trust
-    41:42:1A:8D:A9:65 #BT-280 [bluetooth]# pair 41:42:1A:8D:A9:65 [bluetooth]#
-    connect 41:42:1A:8D:A9:65
-  </pre>
+  <pre>{`root@${props.model}:/home/radxa# bluetoothctl [bluetooth]# default-agent
+[bluetooth]# power on [bluetooth]# scan on [bluetooth]# trust
+41:42:1A:8D:A9:65 #BT-280 [bluetooth]# pair 41:42:1A:8D:A9:65 [bluetooth]#
+connect 41:42:1A:8D:A9:65`}</pre>
 
   9. Now you can listen to music


### PR DESCRIPTION
## Summary

Fix code blocks on pages rendered from the shared `common/accessories/_wifi-bt.mdx` template (e.g. `rock3/rock3b/getting-started/interface-usage/pcie-e-key`) showing an extra blank line inside the code block.

## Root cause

Multi-line `<pre>` blocks in the MDX template were parsed by MDX into `<pre><p>...</pre>` (the inner text got wrapped in a `<p>` paragraph), and the `<p>` default margin renders as a visible blank line inside the code block. Single-line `<pre>` blocks were unaffected.

## Change

Convert the 6 multi-line `<pre>` blocks to template-literal form `<pre>{`...`}</pre>` in both the Chinese (`docs/common/accessories/_wifi-bt.mdx`) and English (`i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_wifi-bt.mdx`) versions. No content/command changes.

Affected rendered pages include (not exhaustive): `rock3/rock3b`, `rock5/rock5a`, `rock5/rock5b`, `som/cm/cm3i` interface-usage pcie-e-key, `rock4/rock4ab-se` witibt.

Whitespace/markup-only change.
