### PR TITLE
docs(common/accessories): convert multiline pre blocks to standard code block format

### DIFF
--- a/docs/common/accessories/_fan.mdx
+++ b/docs/common/accessories/_fan.mdx
@@ -44,10 +44,10 @@
 
   2. 通过以下命令找到风扇设备
 
-  <pre>
-    ls /sys/class/thermal/cooling_device*/type <br />
-    cat /sys/class/thermal/cooling_device*/type
-  </pre>
+  ```text
+  ls /sys/class/thermal/cooling_device*/type
+  cat /sys/class/thermal/cooling_device*/type
+  ```
 
   <img
     src={props.pwm_fan_result_img}

--- a/docs/common/accessories/_m.2-extension-board.mdx
+++ b/docs/common/accessories/_m.2-extension-board.mdx
@@ -60,11 +60,9 @@
 
   1. 可以通过`lsblk`查看SSD卡是否被识别。
 
-  <pre>
-    radxa@{props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT mmcblk0
-    179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part /config └─mmcblk0p2
-    179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk mmcblk0boot1 179:64 0
-    4M 1 disk zram0 254:0 0 3.8G 0 disk [SWAP] nvme0n1 259:0 0 238.5G 0 disk
-  </pre>
+  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT mmcblk0
+179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part /config └─mmcblk0p2
+179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk mmcblk0boot1 179:64 0
+4M 1 disk zram0 254:0 0 3.8G 0 disk [SWAP] nvme0n1 259:0 0 238.5G 0 disk`}</pre>
 
   2. 这时你可以看到，系统已经识别出 SSD(**nvme0n1**)。

--- a/docs/common/accessories/_m.2-extension-board.mdx
+++ b/docs/common/accessories/_m.2-extension-board.mdx
@@ -60,9 +60,6 @@
 
   1. 可以通过`lsblk`查看SSD卡是否被识别。
 
-  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT mmcblk0
-179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part /config └─mmcblk0p2
-179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk mmcblk0boot1 179:64 0
-4M 1 disk zram0 254:0 0 3.8G 0 disk [SWAP] nvme0n1 259:0 0 238.5G 0 disk`}</pre>
+  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT mmcblk0\n179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part /config └─mmcblk0p2\n179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk mmcblk0boot1 179:64 0\n4M 1 disk zram0 254:0 0 3.8G 0 disk [SWAP] nvme0n1 259:0 0 238.5G 0 disk`}</pre>
 
   2. 这时你可以看到，系统已经识别出 SSD(**nvme0n1**)。

--- a/docs/common/accessories/_m.2-sata-break-board.mdx
+++ b/docs/common/accessories/_m.2-sata-break-board.mdx
@@ -39,12 +39,10 @@
 
   通过 `lsblk` 命令查看SSD是否被识别到
 
-  <pre>
-    radxa@{props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT sda 8:0
-    0 476.9G 0 disk mmcblk0 179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part
-    /config └─mmcblk0p2 179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk
-    mmcblk0boot1 179:64 0 4M 1 disk zram0 254:0 0 3.9G 0 disk [SWAP]
-  </pre>
+  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT sda 8:0
+0 476.9G 0 disk mmcblk0 179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part
+/config └─mmcblk0p2 179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk
+mmcblk0boot1 179:64 0 4M 1 disk zram0 254:0 0 3.9G 0 disk [SWAP]`}</pre>
 
   当系统识别到 SATA 时，可以查看到 **sda**
 

--- a/docs/common/accessories/_m.2-sata-break-board.mdx
+++ b/docs/common/accessories/_m.2-sata-break-board.mdx
@@ -39,10 +39,7 @@
 
   通过 `lsblk` 命令查看SSD是否被识别到
 
-  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT sda 8:0
-0 476.9G 0 disk mmcblk0 179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part
-/config └─mmcblk0p2 179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk
-mmcblk0boot1 179:64 0 4M 1 disk zram0 254:0 0 3.9G 0 disk [SWAP]`}</pre>
+  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT sda 8:0\n0 476.9G 0 disk mmcblk0 179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part\n/config └─mmcblk0p2 179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk\nmmcblk0boot1 179:64 0 4M 1 disk zram0 254:0 0 3.9G 0 disk [SWAP]`}</pre>
 
   当系统识别到 SATA 时，可以查看到 **sda**
 

--- a/docs/common/accessories/_mobile-lte-em05-ce.mdx
+++ b/docs/common/accessories/_mobile-lte-em05-ce.mdx
@@ -32,8 +32,7 @@
 
 你可以通过以下命令检查设备是否已连接：
 
-<pre>{`radxa@${props.model}:~$ lsusb | grep -i Quectel Bus 002 Device 002: ID
-2c7c:0125 Quectel Wireless Solutions Co., Ltd. EC25 LTE modem`}</pre>
+<pre>{`radxa@${props.model}:~$ lsusb | grep -i Quectel Bus 002 Device 002: ID\n2c7c:0125 Quectel Wireless Solutions Co., Ltd. EC25 LTE modem`}</pre>
 
 调制解调器通常是通过串口和宿主机进行通信。请检查系统是否正确枚举出对应的串口设备：
 

--- a/docs/common/accessories/_mobile-lte-em05-ce.mdx
+++ b/docs/common/accessories/_mobile-lte-em05-ce.mdx
@@ -32,10 +32,8 @@
 
 你可以通过以下命令检查设备是否已连接：
 
-<pre>
-  radxa@{props.model}:~$ lsusb | grep -i Quectel Bus 002 Device 002: ID
-  2c7c:0125 Quectel Wireless Solutions Co., Ltd. EC25 LTE modem
-</pre>
+<pre>{`radxa@${props.model}:~$ lsusb | grep -i Quectel Bus 002 Device 002: ID
+2c7c:0125 Quectel Wireless Solutions Co., Ltd. EC25 LTE modem`}</pre>
 
 调制解调器通常是通过串口和宿主机进行通信。请检查系统是否正确枚举出对应的串口设备：
 

--- a/docs/common/accessories/_usb.mdx
+++ b/docs/common/accessories/_usb.mdx
@@ -4,38 +4,36 @@
 
   1. 识别鼠标键盘
 
-  <pre>
-    lsusb Bus 008 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 007
-    Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 006 Device 001:
-    ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 005 Device 001: ID 1d6b:0002
-    Linux Foundation 2.0 root hub
-    <strong>Bus 004 Device 002: ID c0f4:04c0 SZH usb keyboard</strong>
-    Bus 004 Device 001: ID 1d6b:0001 Linux Foundation 1.1 root hub Bus 002
-    Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 003 Device 001:
-    ID 1d6b:0001 Linux Foundation 1.1 root hub
-    <strong>Bus 001 Device 003: ID 0000:3825 USB OPTICAL MOUSE</strong>
-    Bus 001 Device 002: ID 1a40:0101 Terminus Technology Inc. Hub Bus 001 Device
-    001: ID 1d6b:0002 Linux Foundation 2.0 root hub
-  </pre>
+  ```bash
+  lsusb Bus 008 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 007
+  Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 006 Device 001:
+  ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 005 Device 001: ID 1d6b:0002
+  Linux Foundation 2.0 root hub
+  Bus 004 Device 002: ID c0f4:04c0 SZH usb keyboard
+  Bus 004 Device 001: ID 1d6b:0001 Linux Foundation 1.1 root hub Bus 002
+  Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 003 Device 001:
+  ID 1d6b:0001 Linux Foundation 1.1 root hub
+  Bus 001 Device 003: ID 0000:3825 USB OPTICAL MOUSE
+  Bus 001 Device 002: ID 1a40:0101 Terminus Technology Inc. Hub Bus 001 Device
+  001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+  ```
 
   如上所示，这里已经成功识别到了鼠标（USB OPTICAL MOUSE）和键盘（usb keyboard）。
 
   2. 识别存储设备
 
-  <pre>
-    lsusb Bus 008 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 007
-    Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
-    <strong>
-      Bus 006 Device 002: ID 067b:2731 Prolific Technology, Inc. USB SD Card
-      Reader
-    </strong>
-    Bus 006 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 005
-    Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 004 Device 001:
-    ID 1d6b:0001 Linux Foundation 1.1 root hub Bus 002 Device 001: ID 1d6b:0002
-    Linux Foundation 2.0 root hub Bus 003 Device 001: ID 1d6b:0001 Linux
-    Foundation 1.1 root hub Bus 001 Device 002: ID 1a40:0101 Terminus Technology
-    Inc. Hub Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
-  </pre>
+  ```bash
+  lsusb Bus 008 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 007
+  Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+    Bus 006 Device 002: ID 067b:2731 Prolific Technology, Inc. USB SD Card
+    Reader
+  Bus 006 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 005
+  Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 004 Device 001:
+  ID 1d6b:0001 Linux Foundation 1.1 root hub Bus 002 Device 001: ID 1d6b:0002
+  Linux Foundation 2.0 root hub Bus 003 Device 001: ID 1d6b:0001 Linux
+  Foundation 1.1 root hub Bus 001 Device 002: ID 1a40:0101 Terminus Technology
+  Inc. Hub Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+  ```
 
   如上所示，这里已经成功识别到了 Micro-SD Card Reader
 
@@ -65,20 +63,16 @@
 
   2. 读取测试
 
-  <pre>
-    radxa@{props.model}:~$ sudo dd if=/dev/{props.usb_dev} of=/dev/null bs=1M
-    count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
-    MiB) copied, {props.usb_dev_sd_read_time}, {props.usb_dev_sd_read_speed}
-  </pre>
+  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/${props.usb_dev} of=/dev/null bs=1M
+count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
+MiB) copied, ${props.usb_dev_sd_read_time}, ${props.usb_dev_sd_read_speed}`}</pre>
 
   这个命令将会从 USB 设备读取数据，并将其写入 /dev/null，以便测试读取速度。这里指定了写入的块的大小为 1M，指定了读取 100 个块，因此总共读取了 100 MB 的数据，读取速度为 {props.usb_dev_sd_read_speed}
 
   3. 写入测试
 
-  <pre>
-    radxa@{props.model}:~$ sudo dd if=/dev/zero of=/dev/{props.usb_dev} bs=1M
-    count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
-    MiB) copied, {props.usb_dev_sd_write_time}, {props.usb_dev_sd_write_speed}
-  </pre>
+  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/zero of=/dev/${props.usb_dev} bs=1M
+count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
+MiB) copied, ${props.usb_dev_sd_write_time}, ${props.usb_dev_sd_write_speed}`}</pre>
 
   这里指定了写入的块的大小为 1M，写入了 100 个块，总共写入了 100 M 的数据，写入速度为 {props.usb_dev_sd_write_speed}

--- a/docs/common/accessories/_usb.mdx
+++ b/docs/common/accessories/_usb.mdx
@@ -63,16 +63,12 @@
 
   2. 读取测试
 
-  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/${props.usb_dev} of=/dev/null bs=1M
-count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
-MiB) copied, ${props.usb_dev_sd_read_time}, ${props.usb_dev_sd_read_speed}`}</pre>
+  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/${props.usb_dev} of=/dev/null bs=1M\ncount=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100\nMiB) copied, ${props.usb_dev_sd_read_time}, ${props.usb_dev_sd_read_speed}`}</pre>
 
   这个命令将会从 USB 设备读取数据，并将其写入 /dev/null，以便测试读取速度。这里指定了写入的块的大小为 1M，指定了读取 100 个块，因此总共读取了 100 MB 的数据，读取速度为 {props.usb_dev_sd_read_speed}
 
   3. 写入测试
 
-  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/zero of=/dev/${props.usb_dev} bs=1M
-count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
-MiB) copied, ${props.usb_dev_sd_write_time}, ${props.usb_dev_sd_write_speed}`}</pre>
+  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/zero of=/dev/${props.usb_dev} bs=1M\ncount=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100\nMiB) copied, ${props.usb_dev_sd_write_time}, ${props.usb_dev_sd_write_speed}`}</pre>
 
   这里指定了写入的块的大小为 1M，写入了 100 个块，总共写入了 100 M 的数据，写入速度为 {props.usb_dev_sd_write_speed}

--- a/docs/common/accessories/_waveshare-35-display.mdx
+++ b/docs/common/accessories/_waveshare-35-display.mdx
@@ -33,9 +33,7 @@ sudo mv /usr/share/X11/xorg.conf.d/20-modesetting.conf /usr/share/X11/xorg.conf.
 
 - 在 `/etc/X11/xorg.conf.d` 下添加一个配置文件 `20-modesetting.conf`，内容如下：
 
-<pre>{`Section "Device"     Identifier "Rockchip Graphics"
-    Driver "fbdev"     Option "fbdev"
-"/dev/${props.fbdev}"     Option "DRI" "2" EndSection`}</pre>
+<pre>{`Section "Device"     Identifier "Rockchip Graphics"\n    Driver "fbdev"     Option "fbdev"\n"/dev/${props.fbdev}"     Option "DRI" "2" EndSection`}</pre>
 
 - 配置触摸
 

--- a/docs/common/accessories/_waveshare-35-display.mdx
+++ b/docs/common/accessories/_waveshare-35-display.mdx
@@ -33,22 +33,20 @@ sudo mv /usr/share/X11/xorg.conf.d/20-modesetting.conf /usr/share/X11/xorg.conf.
 
 - 在 `/etc/X11/xorg.conf.d` 下添加一个配置文件 `20-modesetting.conf`，内容如下：
 
-<pre>
-  Section "Device" &nbsp;&nbsp;&nbsp;&nbsp;Identifier "Rockchip Graphics"
-  &nbsp;&nbsp;&nbsp;&nbsp;Driver "fbdev" &nbsp;&nbsp;&nbsp;&nbsp;Option "fbdev"
-  "/dev/{props.fbdev}" &nbsp;&nbsp;&nbsp;&nbsp;Option "DRI" "2" EndSection
-</pre>
+<pre>{`Section "Device"     Identifier "Rockchip Graphics"
+    Driver "fbdev"     Option "fbdev"
+"/dev/${props.fbdev}"     Option "DRI" "2" EndSection`}</pre>
 
 - 配置触摸
 
 在 /etc/X11/xorg.conf.d 下添加一个配置文件 99-touchscreen-calibration.conf，内容如下：
 
-<pre>
-  Section "InputClass" &nbsp;&nbsp;&nbsp;&nbsp;Identifier "calibration"
-  &nbsp;&nbsp;&nbsp;&nbsp;MatchProduct "ADS7846 Touchscreen"
-  &nbsp;&nbsp;&nbsp;&nbsp;Option "TransformationMatrix" "-1 0 1 0 1 0 0 0 1"
-  EndSection
-</pre>
+```text
+Section "InputClass"     Identifier "calibration"
+    MatchProduct "ADS7846 Touchscreen"
+    Option "TransformationMatrix" "-1 0 1 0 1 0 0 0 1"
+EndSection
+```
 
 - 重启系统
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_fan.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_fan.mdx
@@ -44,10 +44,10 @@
 
   2. Locate the fan device with the following command.
 
-  <pre>
-    ls /sys/class/thermal/cooling_device*/type <br />
-    cat /sys/class/thermal/cooling_device*/type
-  </pre>
+  ```text
+  ls /sys/class/thermal/cooling_device*/type
+  cat /sys/class/thermal/cooling_device*/type
+  ```
 
   <img
     src={props.pwm_fan_result_img}

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_m.2-extension-board.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_m.2-extension-board.mdx
@@ -60,9 +60,6 @@
 
   1. You can check if the SSD card is recognised by `lsblk`.
 
-  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT mmcblk0
-179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part /config └─mmcblk0p2
-179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk mmcblk0boot1 179:64 0
-4M 1 disk zram0 254:0 0 3.8G 0 disk [SWAP] nvme0n1 259:0 0 238.5G 0 disk`}</pre>
+  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT mmcblk0\n179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part /config └─mmcblk0p2\n179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk mmcblk0boot1 179:64 0\n4M 1 disk zram0 254:0 0 3.8G 0 disk [SWAP] nvme0n1 259:0 0 238.5G 0 disk`}</pre>
 
   2. At this point you can see that the system has recognised the SSD (**nvme0n1**).

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_m.2-extension-board.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_m.2-extension-board.mdx
@@ -60,11 +60,9 @@
 
   1. You can check if the SSD card is recognised by `lsblk`.
 
-  <pre>
-    radxa@{props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT mmcblk0
-    179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part /config └─mmcblk0p2
-    179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk mmcblk0boot1 179:64 0
-    4M 1 disk zram0 254:0 0 3.8G 0 disk [SWAP] nvme0n1 259:0 0 238.5G 0 disk
-  </pre>
+  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT mmcblk0
+179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part /config └─mmcblk0p2
+179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk mmcblk0boot1 179:64 0
+4M 1 disk zram0 254:0 0 3.8G 0 disk [SWAP] nvme0n1 259:0 0 238.5G 0 disk`}</pre>
 
   2. At this point you can see that the system has recognised the SSD (**nvme0n1**).

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_m.2-sata-break-board.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_m.2-sata-break-board.mdx
@@ -39,12 +39,10 @@
 
   See if the SSD is recognised with the `lsblk` command
 
-  <pre>
-    radxa@{props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT sda 8:0
-    0 476.9G 0 disk mmcblk0 179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part
-    /config └─mmcblk0p2 179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk
-    mmcblk0boot1 179:64 0 4M 1 disk zram0 254:0 0 3.9G 0 disk [SWAP]
-  </pre>
+  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT sda 8:0
+0 476.9G 0 disk mmcblk0 179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part
+/config └─mmcblk0p2 179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk
+mmcblk0boot1 179:64 0 4M 1 disk zram0 254:0 0 3.9G 0 disk [SWAP]`}</pre>
 
   When SATA is recognised by the system, it can be viewed as **sda**
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_m.2-sata-break-board.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_m.2-sata-break-board.mdx
@@ -39,10 +39,7 @@
 
   See if the SSD is recognised with the `lsblk` command
 
-  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT sda 8:0
-0 476.9G 0 disk mmcblk0 179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part
-/config └─mmcblk0p2 179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk
-mmcblk0boot1 179:64 0 4M 1 disk zram0 254:0 0 3.9G 0 disk [SWAP]`}</pre>
+  <pre>{`radxa@${props.model}:~$ lsblk NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT sda 8:0\n0 476.9G 0 disk mmcblk0 179:0 0 14.5G 0 disk ├─mmcblk0p1 179:1 0 16M 0 part\n/config └─mmcblk0p2 179:2 0 14.4G 0 part / mmcblk0boot0 179:32 0 4M 1 disk\nmmcblk0boot1 179:64 0 4M 1 disk zram0 254:0 0 3.9G 0 disk [SWAP]`}</pre>
 
   When SATA is recognised by the system, it can be viewed as **sda**
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_mobile-lte-em05-ce.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_mobile-lte-em05-ce.mdx
@@ -32,10 +32,8 @@ First of all, you need to plug the Quectel LTE EM05-CE into the B-key connector 
 
 You can check if the device is connected with the following command:
 
-<pre>
-  radxa@{props.model}:~$ lsusb | grep -i Quectel Bus 002 Device 002: ID
-  2c7c:0125 Quectel Wireless Solutions Co. EC25 LTE modem
-</pre>
+<pre>{`radxa@${props.model}:~$ lsusb | grep -i Quectel Bus 002 Device 002: ID
+2c7c:0125 Quectel Wireless Solutions Co. EC25 LTE modem`}</pre>
 
 The modem usually communicates with the host via the serial port. Please check that the system enumerates the corresponding serial devices correctly:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_mobile-lte-em05-ce.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_mobile-lte-em05-ce.mdx
@@ -32,8 +32,7 @@ First of all, you need to plug the Quectel LTE EM05-CE into the B-key connector 
 
 You can check if the device is connected with the following command:
 
-<pre>{`radxa@${props.model}:~$ lsusb | grep -i Quectel Bus 002 Device 002: ID
-2c7c:0125 Quectel Wireless Solutions Co. EC25 LTE modem`}</pre>
+<pre>{`radxa@${props.model}:~$ lsusb | grep -i Quectel Bus 002 Device 002: ID\n2c7c:0125 Quectel Wireless Solutions Co. EC25 LTE modem`}</pre>
 
 The modem usually communicates with the host via the serial port. Please check that the system enumerates the corresponding serial devices correctly:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_usb.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_usb.mdx
@@ -4,38 +4,36 @@
 
   1. Identify the mouse and keyboard
 
-  <pre>
-    lsusb Bus 008 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 007
-    Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 006 Device 001:
-    ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 005 Device 001: ID 1d6b:0002
-    Linux Foundation 2.0 root hub
-    <strong>Bus 004 Device 002: ID c0f4:04c0 SZH usb keyboard</strong>
-    Bus 004 Device 001: ID 1d6b:0001 Linux Foundation 1.1 root hub Bus 002
-    Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 003 Device 001:
-    ID 1d6b:0001 Linux Foundation 1.1 root hub
-    <strong>Bus 001 Device 003: ID 0000:3825 USB OPTICAL MOUSE</strong>
-    Bus 001 Device 002: ID 1a40:0101 Terminus Technology Inc. Hub Bus 001 Device
-    001: ID 1d6b:0002 Linux Foundation 2.0 root hub
-  </pre>
+  ```bash
+  lsusb Bus 008 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 007
+  Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 006 Device 001:
+  ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 005 Device 001: ID 1d6b:0002
+  Linux Foundation 2.0 root hub
+  Bus 004 Device 002: ID c0f4:04c0 SZH usb keyboard
+  Bus 004 Device 001: ID 1d6b:0001 Linux Foundation 1.1 root hub Bus 002
+  Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 003 Device 001:
+  ID 1d6b:0001 Linux Foundation 1.1 root hub
+  Bus 001 Device 003: ID 0000:3825 USB OPTICAL MOUSE
+  Bus 001 Device 002: ID 1a40:0101 Terminus Technology Inc. Hub Bus 001 Device
+  001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+  ```
 
   As shown above, the mouse (USB OPTICAL MOUSE) and keyboard (usb keyboard) have been successfully recognised here.
 
   2. Identify the storage device.
 
-  <pre>
-    lsusb Bus 008 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 007
-    Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
-    <strong>
-      Bus 006 Device 002: ID 067b:2731 Prolific Technology, Inc. USB SD Card
-      Reader
-    </strong>
-    Bus 006 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 005
-    Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 004 Device 001:
-    ID 1d6b:0001 Linux Foundation 1.1 root hub Bus 002 Device 001: ID 1d6b:0002
-    Linux Foundation 2.0 root hub Bus 003 Device 001: ID 1d6b:0001 Linux
-    Foundation 1.1 root hub Bus 001 Device 002: ID 1a40:0101 Terminus Technology
-    Inc. Hub Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
-  </pre>
+  ```bash
+  lsusb Bus 008 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 007
+  Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+    Bus 006 Device 002: ID 067b:2731 Prolific Technology, Inc. USB SD Card
+    Reader
+  Bus 006 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub Bus 005
+  Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub Bus 004 Device 001:
+  ID 1d6b:0001 Linux Foundation 1.1 root hub Bus 002 Device 001: ID 1d6b:0002
+  Linux Foundation 2.0 root hub Bus 003 Device 001: ID 1d6b:0001 Linux
+  Foundation 1.1 root hub Bus 001 Device 002: ID 1a40:0101 Terminus Technology
+  Inc. Hub Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+  ```
 
   As shown above, the Micro-SD Card Reader has been successfully recognised here.
 
@@ -65,20 +63,16 @@
 
   2. Read test
 
-  <pre>
-    radxa@{props.model}:~$ sudo dd if=/dev/{props.usb_dev} of=/dev/null bs=1M
-    count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
-    MiB) copied, {props.usb_dev_sd_read_time}, {props.usb_dev_sd_read_speed}
-  </pre>
+  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/${props.usb_dev} of=/dev/null bs=1M
+count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
+MiB) copied, ${props.usb_dev_sd_read_time}, ${props.usb_dev_sd_read_speed}`}</pre>
 
   This command will read data from the USB device and write it to /dev/null in order to test the read speed. The block size specified here is 1M, and 100 blocks are specified to be read, so a total of 100 MB of data is read at {props.usb_dev_sd_read_speed}.
 
   3. Write Test
 
-  <pre>
-    radxa@{props.model}:~$ sudo dd if=/dev/zero of=/dev/{props.usb_dev} bs=1M
-    count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
-    MiB) copied, {props.usb_dev_sd_write_time}, {props.usb_dev_sd_write_speed}
-  </pre>
+  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/zero of=/dev/${props.usb_dev} bs=1M
+count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
+MiB) copied, ${props.usb_dev_sd_write_time}, ${props.usb_dev_sd_write_speed}`}</pre>
 
   The block size specified here is 1M, 100 blocks were written, a total of 100 M of data was written, and the write speed was {props.usb_dev_sd_write_speed}.

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_usb.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_usb.mdx
@@ -63,16 +63,12 @@
 
   2. Read test
 
-  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/${props.usb_dev} of=/dev/null bs=1M
-count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
-MiB) copied, ${props.usb_dev_sd_read_time}, ${props.usb_dev_sd_read_speed}`}</pre>
+  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/${props.usb_dev} of=/dev/null bs=1M\ncount=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100\nMiB) copied, ${props.usb_dev_sd_read_time}, ${props.usb_dev_sd_read_speed}`}</pre>
 
   This command will read data from the USB device and write it to /dev/null in order to test the read speed. The block size specified here is 1M, and 100 blocks are specified to be read, so a total of 100 MB of data is read at {props.usb_dev_sd_read_speed}.
 
   3. Write Test
 
-  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/zero of=/dev/${props.usb_dev} bs=1M
-count=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100
-MiB) copied, ${props.usb_dev_sd_write_time}, ${props.usb_dev_sd_write_speed}`}</pre>
+  <pre>{`radxa@${props.model}:~$ sudo dd if=/dev/zero of=/dev/${props.usb_dev} bs=1M\ncount=100 100+0 records in 100+0 records out 104857600 bytes (105 MB, 100\nMiB) copied, ${props.usb_dev_sd_write_time}, ${props.usb_dev_sd_write_speed}`}</pre>
 
   The block size specified here is 1M, 100 blocks were written, a total of 100 M of data was written, and the write speed was {props.usb_dev_sd_write_speed}.

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_waveshare-35-display.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_waveshare-35-display.mdx
@@ -33,22 +33,20 @@ sudo mv /usr/share/X11/xorg.conf.d/20-modesetting.conf /usr/share/X11/xorg.conf.
 
 - Add a configuration file `20-modesetting.conf` under `/etc/X11/xorg.conf.d` with the following contents:
 
-<pre>
-  Section "Device" &nbsp;&nbsp;&nbsp;&nbsp;Identifier "Rockchip Graphics"
-  &nbsp;&nbsp;&nbsp;&nbsp;Driver "fbdev" &nbsp;&nbsp;&nbsp;&nbsp;Option "fbdev"
-  "/dev/{props.fbdev}" &nbsp;&nbsp;&nbsp;&nbsp;Option "DRI" "2" EndSection
-</pre>
+<pre>{`Section "Device"     Identifier "Rockchip Graphics"
+    Driver "fbdev"     Option "fbdev"
+"/dev/${props.fbdev}"     Option "DRI" "2" EndSection`}</pre>
 
 -
 
 Add a configuration file 99-touchscreen-calibration.conf under /etc/X11/xorg.conf.d with the following contents:
 
-<pre>
-  Section "InputClass" &nbsp;&nbsp;&nbsp;&nbsp;Identifier "calibration"
-  &nbsp;&nbsp;&nbsp;&nbsp;MatchProduct "ADS7846 Touchscreen"
-  &nbsp;&nbsp;&nbsp;&nbsp;Option "TransformationMatrix" "-1 0 1 0 1 0 0 0 1"
-  EndSection
-</pre>
+```text
+Section "InputClass"     Identifier "calibration"
+    MatchProduct "ADS7846 Touchscreen"
+    Option "TransformationMatrix" "-1 0 1 0 1 0 0 0 1"
+EndSection
+```
 
 - Reboot
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_waveshare-35-display.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_waveshare-35-display.mdx
@@ -33,9 +33,7 @@ sudo mv /usr/share/X11/xorg.conf.d/20-modesetting.conf /usr/share/X11/xorg.conf.
 
 - Add a configuration file `20-modesetting.conf` under `/etc/X11/xorg.conf.d` with the following contents:
 
-<pre>{`Section "Device"     Identifier "Rockchip Graphics"
-    Driver "fbdev"     Option "fbdev"
-"/dev/${props.fbdev}"     Option "DRI" "2" EndSection`}</pre>
+<pre>{`Section "Device"     Identifier "Rockchip Graphics"\n    Driver "fbdev"     Option "fbdev"\n"/dev/${props.fbdev}"     Option "DRI" "2" EndSection`}</pre>
 
 -
 


### PR DESCRIPTION
## Summary

Convert multi-line `<pre>` code blocks in the shared `common/accessories/` templates to standard code block format, fixing an extra blank line rendered inside code blocks on all pages that use these templates (e.g. `interface-usage` pages across products).

## Root cause

Multi-line `<pre>` blocks in MDX are parsed into `<pre><p>...</pre>` (inner text wrapped in `<p>`), and the `<p>` default margin renders as a visible blank line inside the code block. Single-line `<pre>` blocks were unaffected.

## Change

- Blocks containing JSX props (e.g. `{props.model}`) → `<pre>{`...`}</pre>` template-literal form so dynamic values still render.
- Plain text blocks (commands/output) → standard ``` fence (bash/text) with HTML tags (`<strong>`, `<br />`) removed and `&nbsp;` normalized.
- Both Chinese (`docs/common/accessories/`) and English (`i18n/en/.../common/accessories/`) versions updated. No command/content changes.

Files: `_fan.mdx`, `_usb.mdx`, `_waveshare-35-display.mdx`, `_m.2-extension-board.mdx`, `_m.2-sata-break-board.mdx`, `_mobile-lte-em05-ce.mdx` (+ en counterparts).

Whitespace/markup-only change.
