### PR TITLE
docs(common/dev): convert multiline pre blocks to standard code block format

### DIFF
--- a/docs/common/dev/_erase-emmc.mdx
+++ b/docs/common/dev/_erase-emmc.mdx
@@ -25,13 +25,9 @@
 
     3. 刷入 Loader
 
-    <pre>
+    <pre>{`Download the loader file `}<a href={props.loader}> Loader </a>{`, then installll the downloaded loader file (replace xxx_loader.bin with the downloaded file name in the following command)
 
-    Download the loader file <a href={props.loader}> Loader </a>, then installll the downloaded loader file (replace xxx_loader.bin with the downloaded file name in the following command)
-
-    sudo rkdeveloptool db xxx_loader.bin
-
-    </pre>
+sudo rkdeveloptool db xxx_loader.bin`}</pre>
 
     4. 清空 eMMC
 

--- a/docs/common/dev/_erase-emmc.mdx
+++ b/docs/common/dev/_erase-emmc.mdx
@@ -25,9 +25,7 @@
 
     3. 刷入 Loader
 
-    <pre>{`Download the loader file `}<a href={props.loader}> Loader </a>{`, then installll the downloaded loader file (replace xxx_loader.bin with the downloaded file name in the following command)
-
-sudo rkdeveloptool db xxx_loader.bin`}</pre>
+    <pre>{`Download the loader file `}<a href={props.loader}> Loader </a>{`, then installll the downloaded loader file (replace xxx_loader.bin with the downloaded file name in the following command)\n\nsudo rkdeveloptool db xxx_loader.bin`}</pre>
 
     4. 清空 eMMC
 

--- a/docs/common/dev/_erase-spi-emmc.mdx
+++ b/docs/common/dev/_erase-spi-emmc.mdx
@@ -25,9 +25,7 @@
 
     3. 刷入 Loader
 
-    <pre>
-    sudo rkdeveloptool db <a href={props.loader}> {props.loader_name} </a>
-    </pre>
+    <pre>{`sudo rkdeveloptool db `}<a href={props.loader}> {props.loader_name} </a></pre>
 
     4. 清空 eMMC
 
@@ -77,9 +75,7 @@
 
     2. 刷入 Loader
 
-    <pre>
-    sudo rkdeveloptool db <a href={props.loader}> {props.loader_name} </a>
-    </pre>
+    <pre>{`sudo rkdeveloptool db `}<a href={props.loader}> {props.loader_name} </a></pre>
 
     3. 清空 SPI Flash
 

--- a/docs/common/dev/_pico2-riscv32-toolchain.mdx
+++ b/docs/common/dev/_pico2-riscv32-toolchain.mdx
@@ -88,17 +88,13 @@ git clone https://github.com/raspberrypi/pico-examples.git --branch master
 
 - 编译
 
-<pre>
-  export PICO_SDK_PATH=path/to/pico-sdk
-  <!-- prettier-ignore -->
-  cd pico-examples
-  <!-- prettier-ignore -->
-  mkdir build
-  <!-- prettier-ignore -->
-  cd build
-  <!-- prettier-ignore -->
-  cmake .. -DPICO_PLATFORM=<b>rp2350-riscv</b> && make -j4
-</pre>
+```bash
+export PICO_SDK_PATH=path/to/pico-sdk
+cd pico-examples
+mkdir build
+cd build
+cmake .. -DPICO_PLATFORM=rp2350-riscv && make -j4
+```
 
 - 验证编译出来的程序是否为 riscv 32 的程序
 

--- a/docs/common/dev/_rkdeveloptoolV2.mdx
+++ b/docs/common/dev/_rkdeveloptoolV2.mdx
@@ -62,11 +62,9 @@ rkdeveloptool 可以被认为是[开源版本](https://opensource.rock-chips.com
           </strong>
         </TabItem>
         <TabItem value="ArchLinux">
-          <pre>
-            可从{" "}
-            <a href="https://aur.archlinux.org/packages/rkdeveloptool"> AUR </a>{" "}
-            安装 rkdeveloptool。
-          </pre>
+          <pre>{`可从 `}
+<a href="https://aur.archlinux.org/packages/rkdeveloptool"> AUR </a>{` `}
+{`安装 rkdeveloptool。`}</pre>
         </TabItem>
       </Tabs>{" "}
     </div>

--- a/docs/common/dev/_rkdeveloptoolV2.mdx
+++ b/docs/common/dev/_rkdeveloptoolV2.mdx
@@ -62,9 +62,7 @@ rkdeveloptool 可以被认为是[开源版本](https://opensource.rock-chips.com
           </strong>
         </TabItem>
         <TabItem value="ArchLinux">
-          <pre>{`可从 `}
-<a href="https://aur.archlinux.org/packages/rkdeveloptool"> AUR </a>{` `}
-{`安装 rkdeveloptool。`}</pre>
+          <pre>{`可从 `}<a href="https://aur.archlinux.org/packages/rkdeveloptool"> AUR </a>{` 安装 rkdeveloptool。`}</pre>
         </TabItem>
       </Tabs>{" "}
     </div>

--- a/docs/common/dev/_rkdeveloptoolV3.mdx
+++ b/docs/common/dev/_rkdeveloptoolV3.mdx
@@ -64,9 +64,7 @@ rkdeveloptool 可以被认为是[开源版本](https://opensource.rock-chips.com
           </strong>
         </TabItem>
         <TabItem value="ArchLinux">
-          <pre>{`可从 `}
-<a href="https://aur.archlinux.org/packages/rkdeveloptool"> AUR </a>{` `}
-{`安装 rkdeveloptool。`}</pre>
+          <pre>{`可从 `}<a href="https://aur.archlinux.org/packages/rkdeveloptool"> AUR </a>{` 安装 rkdeveloptool。`}</pre>
         </TabItem>
       </Tabs>{" "}
     </div>

--- a/docs/common/dev/_rkdeveloptoolV3.mdx
+++ b/docs/common/dev/_rkdeveloptoolV3.mdx
@@ -64,11 +64,9 @@ rkdeveloptool 可以被认为是[开源版本](https://opensource.rock-chips.com
           </strong>
         </TabItem>
         <TabItem value="ArchLinux">
-          <pre>
-            可从{" "}
-            <a href="https://aur.archlinux.org/packages/rkdeveloptool"> AUR </a>{" "}
-            安装 rkdeveloptool。
-          </pre>
+          <pre>{`可从 `}
+<a href="https://aur.archlinux.org/packages/rkdeveloptool"> AUR </a>{` `}
+{`安装 rkdeveloptool。`}</pre>
         </TabItem>
       </Tabs>{" "}
     </div>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_erase-emmc.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_erase-emmc.mdx
@@ -25,13 +25,9 @@
 
     3. Flash Loader
 
-    <pre>
+    <pre>{`Download the loader file `}<a href={props.loader}> Loader </a>{`, then installll the downloaded loader file (replace xxx_loader.bin with the downloaded file name in the following command)
 
-    Download the loader file <a href={props.loader}> Loader </a>, then installll the downloaded loader file (replace xxx_loader.bin with the downloaded file name in the following command)
-
-    sudo rkdeveloptool db xxx_loader.bin
-
-    </pre>
+sudo rkdeveloptool db xxx_loader.bin`}</pre>
 
     4. Erase eMMC
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_erase-emmc.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_erase-emmc.mdx
@@ -25,9 +25,7 @@
 
     3. Flash Loader
 
-    <pre>{`Download the loader file `}<a href={props.loader}> Loader </a>{`, then installll the downloaded loader file (replace xxx_loader.bin with the downloaded file name in the following command)
-
-sudo rkdeveloptool db xxx_loader.bin`}</pre>
+    <pre>{`Download the loader file `}<a href={props.loader}> Loader </a>{`, then installll the downloaded loader file (replace xxx_loader.bin with the downloaded file name in the following command)\n\nsudo rkdeveloptool db xxx_loader.bin`}</pre>
 
     4. Erase eMMC
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_erase-spi-emmc.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_erase-spi-emmc.mdx
@@ -25,9 +25,7 @@
 
     3. Flash Loader
 
-    <pre>
-    sudo rkdeveloptool db <a href={props.loader}> {props.loader_name} </a>
-    </pre>
+    <pre>{`sudo rkdeveloptool db `}<a href={props.loader}> {props.loader_name} </a></pre>
 
     4. Erase eMMC
 
@@ -77,9 +75,7 @@
 
     2. Flash Loader
 
-    <pre>
-    sudo rkdeveloptool db <a href={props.loader}> rk3588_spl_loader_v1.15.113.bin </a>
-    </pre>
+    <pre>{`sudo rkdeveloptool db `}<a href={props.loader}> rk3588_spl_loader_v1.15.113.bin </a></pre>
 
     3. Erase SPI Flash
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_pico2-riscv32-toolchain.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_pico2-riscv32-toolchain.mdx
@@ -88,17 +88,13 @@ git clone https://github.com/raspberrypi/pico-examples.git --branch master
 
 - Compile
 
-<pre>
-  export PICO_SDK_PATH=path/to/pico-sdk
-  <!-- prettier-ignore -->
-  cd pico-examples
-  <!-- prettier-ignore -->
-  mkdir build
-  <!-- prettier-ignore -->
-  cd build
-  <!-- prettier-ignore -->
-  cmake .. -DPICO_PLATFORM=<b>rp2350-riscv</b> && make -j4
-</pre>
+```bash
+export PICO_SDK_PATH=path/to/pico-sdk
+cd pico-examples
+mkdir build
+cd build
+cmake .. -DPICO_PLATFORM=rp2350-riscv && make -j4
+```
 
 - Verify that the compiled program is for riscv 32
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV2.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV2.mdx
@@ -62,11 +62,7 @@ If your operating system does not provide rkdeveloptool, you will need to compil
           </strong>
         </TabItem>
         <TabItem value="ArchLinux">
-          <pre>{`rkdeveloptool can be installed from the `}
-<a href="https://aur.archlinux.org/packages/rkdeveloptool">
-{`   `}
-{`  AUR .`}
-{`</a> `}</pre>
+          <pre>{`rkdeveloptool can be installed from the `}<a href="https://aur.archlinux.org/packages/rkdeveloptool">{`   `}{`  AUR .`}{`</a> `}</pre>
         </TabItem>
       </Tabs>{" "}
     </div>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV2.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV2.mdx
@@ -62,13 +62,11 @@ If your operating system does not provide rkdeveloptool, you will need to compil
           </strong>
         </TabItem>
         <TabItem value="ArchLinux">
-          <pre>
-            rkdeveloptool can be installed from the{" "}
-            <a href="https://aur.archlinux.org/packages/rkdeveloptool">
-              {" "}
-              AUR .
-            </a>{" "}
-          </pre>
+          <pre>{`rkdeveloptool can be installed from the `}
+<a href="https://aur.archlinux.org/packages/rkdeveloptool">
+{`   `}
+{`  AUR .`}
+{`</a> `}</pre>
         </TabItem>
       </Tabs>{" "}
     </div>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV3.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV3.mdx
@@ -62,11 +62,7 @@ If your operating system does not provide rkdeveloptool, you will need to compil
           </strong>
         </TabItem>
         <TabItem value="ArchLinux">
-          <pre>{`rkdeveloptool can be installed from the `}
-<a href="https://aur.archlinux.org/packages/rkdeveloptool">
-{`   `}
-{`  AUR .`}
-{`</a> `}</pre>
+          <pre>{`rkdeveloptool can be installed from the `}<a href="https://aur.archlinux.org/packages/rkdeveloptool">{`   `}{`  AUR .`}{`</a> `}</pre>
         </TabItem>
       </Tabs>{" "}
     </div>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV3.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/dev/_rkdeveloptoolV3.mdx
@@ -62,13 +62,11 @@ If your operating system does not provide rkdeveloptool, you will need to compil
           </strong>
         </TabItem>
         <TabItem value="ArchLinux">
-          <pre>
-            rkdeveloptool can be installed from the{" "}
-            <a href="https://aur.archlinux.org/packages/rkdeveloptool">
-              {" "}
-              AUR .
-            </a>{" "}
-          </pre>
+          <pre>{`rkdeveloptool can be installed from the `}
+<a href="https://aur.archlinux.org/packages/rkdeveloptool">
+{`   `}
+{`  AUR .`}
+{`</a> `}</pre>
         </TabItem>
       </Tabs>{" "}
     </div>


### PR DESCRIPTION
## Summary

Convert multi-line `<pre>` code blocks in the shared `common/dev/` templates (`_erase-emmc.mdx`, `_erase-spi-emmc.mdx`, `_rkdeveloptoolV2.mdx`, `_rkdeveloptoolV3.mdx`, `_pico2-riscv32-toolchain.mdx`) to standard code block format, fixing an extra blank line rendered inside code blocks on pages using these templates.

## Root cause

Multi-line `<pre>` blocks in MDX are parsed into `<pre><p>...</pre>` (inner text wrapped in `<p>`), and the `<p>` default margin renders as a visible blank line inside the code block.

## Change

- Blocks containing links (`<a href={props.loader}>`) → mixed JSX template-literal form `<pre>{`...`}<a ...>...</a>{`...`}</pre>` so links and dynamic props still render.
- Plain command blocks → standard ``` bash fence; removed `<!-- prettier-ignore -->` comments and `<b>` tags.
- Both Chinese (`docs/common/dev/`) and English (`i18n/en/.../common/dev/`) versions updated. No command/content changes.

Whitespace/markup-only change.
