### PR TITLE
docs(common/general): convert multiline pre block to standard format in etcher template

### DIFF
--- a/docs/common/general/_etcher.mdx
+++ b/docs/common/general/_etcher.mdx
@@ -71,9 +71,7 @@ sudo dpkg -i balena-etcher_1.19.16_amd64.deb
 
 7. 启动系统
 
-<pre>{`按照上述步骤成功烧录 microSD 卡后， 将 microSD 卡插入 ${props.product} 的
-MicroSD 插槽内（如下图所示）， 使用 ${props.power_supply}
-电源适配器上电，然后系统开始启动，HDMI显示桌面。`}</pre>
+<pre>{`按照上述步骤成功烧录 microSD 卡后， 将 microSD 卡插入 ${props.product} 的\nMicroSD 插槽内（如下图所示）， 使用 ${props.power_supply}\n电源适配器上电，然后系统开始启动，HDMI显示桌面。`}</pre>
 
 <div style={{display: `${props.pwr_tip ?"block": "none"}`}}>
 

--- a/docs/common/general/_etcher.mdx
+++ b/docs/common/general/_etcher.mdx
@@ -71,11 +71,9 @@ sudo dpkg -i balena-etcher_1.19.16_amd64.deb
 
 7. 启动系统
 
-<pre>
-  按照上述步骤成功烧录 microSD 卡后， 将 microSD 卡插入 {props.product} 的
-  MicroSD 插槽内（如下图所示）， 使用 {props.power_supply}{" "}
-  电源适配器上电，然后系统开始启动，HDMI显示桌面。
-</pre>
+<pre>{`按照上述步骤成功烧录 microSD 卡后， 将 microSD 卡插入 ${props.product} 的
+MicroSD 插槽内（如下图所示）， 使用 ${props.power_supply}
+电源适配器上电，然后系统开始启动，HDMI显示桌面。`}</pre>
 
 <div style={{display: `${props.pwr_tip ?"block": "none"}`}}>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcher.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcher.mdx
@@ -70,12 +70,10 @@ The downloaded system image is in compressed format. You must decompress it firs
 
 7. Starting the system
 
-<pre>
-  After successfully burning the microSD card according to the above steps,
-  insert the microSD card into the MicroSD slot of {props.product}(as shown
-  below), power on the system with the {props.power_supply} power adapter, and
-  then the system will start booting and HDMI will display the desktop.
-</pre>
+<pre>{`After successfully burning the microSD card according to the above steps,
+insert the microSD card into the MicroSD slot of ${props.product}(as shown
+below), power on the system with the ${props.power_supply} power adapter, and
+then the system will start booting and HDMI will display the desktop.`}</pre>
 
 <div style={{display: `${props.pwr_tip ?"block": "none"}`}}>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcher.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/general/_etcher.mdx
@@ -70,10 +70,7 @@ The downloaded system image is in compressed format. You must decompress it firs
 
 7. Starting the system
 
-<pre>{`After successfully burning the microSD card according to the above steps,
-insert the microSD card into the MicroSD slot of ${props.product}(as shown
-below), power on the system with the ${props.power_supply} power adapter, and
-then the system will start booting and HDMI will display the desktop.`}</pre>
+<pre>{`After successfully burning the microSD card according to the above steps,\ninsert the microSD card into the MicroSD slot of ${props.product}(as shown\nbelow), power on the system with the ${props.power_supply} power adapter, and\nthen the system will start booting and HDMI will display the desktop.`}</pre>
 
 <div style={{display: `${props.pwr_tip ?"block": "none"}`}}>
 


### PR DESCRIPTION
## Summary

Convert the multi-line `<pre>` block in the shared `common/general/_etcher.mdx` template to standard format, fixing an extra blank line rendered inside the code block on all pages using this template.

## Root cause

Multi-line `<pre>` blocks in MDX are parsed into `<pre><p>...</pre>` (inner text wrapped in `<p>`), and the `<p>` default margin renders as a visible blank line inside the code block.

## Change

Converted to `<pre>{`...`}</pre>` template-literal form (JSX props preserved as `${props.*}`) in both Chinese (`docs/common/general/_etcher.mdx`) and English (`i18n/en/.../common/general/_etcher.mdx`). No content changes.

Whitespace/markup-only change.
