### PR TITLE
docs(e/e20c): convert multiline pre blocks to standard code block format in interface-usage

### DIFF
--- a/docs/e/e20c/getting-started/interface-usage.md
+++ b/docs/e/e20c/getting-started/interface-usage.md
@@ -78,12 +78,10 @@ Maskrom 按键，用以进入 Maskrom 模式完成刷机。
 
   识别存储设备
 
-  <pre>
-    $ lsusb
-    <strong>
-      Bus 001 Device 003: ID 067b:2731 Prolific Technology, Inc. USB SD Card Reader
-    </strong>
-  </pre>
+  ```bash
+  $ lsusb
+    Bus 001 Device 003: ID 067b:2731 Prolific Technology, Inc. USB SD Card Reader
+  ```
 
   如上所示，这里已经成功识别到了 Micro-SD Card Reader
 
@@ -103,23 +101,23 @@ Maskrom 按键，用以进入 Maskrom 模式完成刷机。
 
   2. 读取测试
 
-  <pre>
-    $ sudo dd if=/dev/sda of=/dev/null bs=1M count=100
-    100+0 records in
-    100+0 records out
-    104857600 bytes (105 MB, 100 MiB) copied, 3.35508 s, 31.3 MB/s
-  </pre>
+  ```bash
+  $ sudo dd if=/dev/sda of=/dev/null bs=1M count=100
+  100+0 records in
+  100+0 records out
+  104857600 bytes (105 MB, 100 MiB) copied, 3.35508 s, 31.3 MB/s
+  ```
 
   这个命令将会从 USB 设备读取数据，并将其写入 /dev/null，以便测试读取速度。这里指定了写入的块的大小为 1M，指定了读取 100 个块，因此总共读取了 100 MB 的数据，读取速度为 31.3 MB/s
 
   3. 写入测试
 
-  <pre>
-    $ sudo dd if=/dev/zero of=/dev/sda bs=1M count=100
-    100+0 records in
-    100+0 records out
-    104857600 bytes (105 MB, 100 MiB) copied, 5.12891 s, 20.4 MB/s
-  </pre>
+  ```bash
+  $ sudo dd if=/dev/zero of=/dev/sda bs=1M count=100
+  100+0 records in
+  100+0 records out
+  104857600 bytes (105 MB, 100 MiB) copied, 5.12891 s, 20.4 MB/s
+  ```
 
   这里指定了写入的块的大小为 1M，写入了 100 个块，总共写入了 100 M 的数据，写入速度为 20.4 MB/s
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/getting-started/interface-usage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/e/e20c/getting-started/interface-usage.md
@@ -78,12 +78,10 @@ Maskrom button to enter Maskrom mode to complete the flashing.
 
   Identifying storage devices
 
-  <pre>
-    $ lsusb
-    <strong>
-      Bus 001 Device 003: ID 067b:2731 Prolific Technology, Inc. USB SD Card Reader
-    </strong>
-  </pre>
+  ```bash
+  $ lsusb
+    Bus 001 Device 003: ID 067b:2731 Prolific Technology, Inc. USB SD Card Reader
+  ```
 
   As you can see above, the Micro-SD Card Reader has been successfully recognised here.
 
@@ -103,23 +101,23 @@ Maskrom button to enter Maskrom mode to complete the flashing.
 
   2. Read Test
 
-  <pre>
-    $ sudo dd if=/dev/sda of=/dev/null bs=1M count=100
-    100+0 records in
-    100+0 records out
-    104857600 bytes (105 MB, 100 MiB) copied, 3.35508 s, 31.3 MB/s
-  </pre>
+  ```bash
+  $ sudo dd if=/dev/sda of=/dev/null bs=1M count=100
+  100+0 records in
+  100+0 records out
+  104857600 bytes (105 MB, 100 MiB) copied, 3.35508 s, 31.3 MB/s
+  ```
 
   This command will read data from the USB device and write it to /dev/null to test the read speed. The block size specified here is 1M, and 100 blocks are specified to be read, so a total of 100 MB of data is read, and the read speed is 31.3 MB/s.
 
   3. Write test
 
-  <pre>
-    $ sudo dd if=/dev/zero of=/dev/sda bs=1M count=100
-    100+0 records in
-    100+0 records out
-    104857600 bytes (105 MB, 100 MiB) copied, 5.12891 s, 20.4 MB/s
-  </pre>
+  ```bash
+  $ sudo dd if=/dev/zero of=/dev/sda bs=1M count=100
+  100+0 records in
+  100+0 records out
+  104857600 bytes (105 MB, 100 MiB) copied, 5.12891 s, 20.4 MB/s
+  ```
 
   The block size specified here is 1M, 100 blocks were written, a total of 100M of data was written, and the write speed was 20.4 MB/s.
 


### PR DESCRIPTION
## Summary

Convert multi-line `<pre>` code blocks in `e/e20c/getting-started/interface-usage.md` to standard code block format, fixing an extra blank line rendered inside code blocks.

## Root cause

Multi-line `<pre>` blocks in MDX are parsed into `<pre><p>...</pre>`, and the `<p>` default margin renders as a visible blank line inside the code block.

## Change

Converted to standard ``` bash fences, removed `<strong>` tags. Both Chinese and English versions updated. No command/content changes.

Whitespace/markup-only change.