### PR TITLE
docs(rock4/rock4ab-se): convert multiline pre blocks to standard code block format in boot-from-emmc

### DIFF
--- a/docs/rock4/rock4ab-se/other-os/android/getting-started/install-os/boot-from-emmc.md
+++ b/docs/rock4/rock4ab-se/other-os/android/getting-started/install-os/boot-from-emmc.md
@@ -61,17 +61,17 @@ import UPGRADE_TOOL from "../../../../../../common/dev/\_upgrade-tool.mdx";
             <br />
             <li>确认瑞莎 ROCK 4AB SE已经进入 Maskrom 模式</li>
             <br />
-            <pre>
-                $ sudo upgrade_tool ld
-                Program Log will save in the /root/upgrade_tool/log/
-                List of rockusb connected(1)
-                DevNo=1	Vid=0x2207,Pid=0x330c,LocationID=19	Mode=Maskrom
-                            </pre>
+            ```bash
+            $ sudo upgrade_tool ld
+            Program Log will save in the /root/upgrade_tool/log/
+            List of rockusb connected(1)
+            DevNo=1	Vid=0x2207,Pid=0x330c,LocationID=19	Mode=Maskrom
+            ```
                             <li>烧录 update 系统镜像</li>
                             <br />
-                            <pre>
-                $ sudo upgrade_tool uf rock4xx-android-xx-update.img
-            </pre>
+                            ```bash
+                            $ sudo upgrade_tool uf rock4xx-android-xx-update.img
+                            ```
             <li>烧录完成后系统会自动启动</li>
         </ul>
     </TabItem>

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4ab-se/other-os/android/getting-started/install-os/boot-from-emmc.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4ab-se/other-os/android/getting-started/install-os/boot-from-emmc.md
@@ -57,17 +57,17 @@ Download the [ROCK 4A/4B/4SE system images](../../../../download) from the resou
             <br />
             <li>Confirm that the Radxa ROCK 4AB SE has entered Maskrom mode</li>
             <br />
-            <pre>
-                $ sudo upgrade_tool ld
-                Program Log will save in the /root/upgrade_tool/log/
-                List of rockusb connected(1)
-                DevNo=1	Vid=0x2207,Pid=0x330c,LocationID=19	Mode=Maskrom
-                            </pre>
+            ```bash
+            $ sudo upgrade_tool ld
+            Program Log will save in the /root/upgrade_tool/log/
+            List of rockusb connected(1)
+            DevNo=1	Vid=0x2207,Pid=0x330c,LocationID=19	Mode=Maskrom
+            ```
                             <li>Flash the update system image</li>
                             <br />
-                            <pre>
-                $ sudo upgrade_tool uf rock4xx-android-xx-update.img
-            </pre>
+                            ```bash
+                            $ sudo upgrade_tool uf rock4xx-android-xx-update.img
+                            ```
             <li>The system will automatically boot after flashing is complete</li>
         </ul>
     </TabItem>


### PR DESCRIPTION
## Summary

Convert multi-line `<pre>` code blocks in `rock4/rock4ab-se/.../install-os/boot-from-emmc.md` to standard code block format, fixing an extra blank line rendered inside code blocks.

## Root cause

Multi-line `<pre>` blocks in MDX are parsed into `<pre><p>...</pre>`, and the `<p>` default margin renders as a visible blank line inside the code block.

## Change

Converted to standard ``` bash fences. Both Chinese and English versions updated. No command/content changes.

Whitespace/markup-only change.