### PR TITLE
docs(som/cm/cm3j): convert multiline pre blocks to standard code block format

### DIFF
--- a/docs/som/cm/cm3j/getting-started/install-os/erase.md
+++ b/docs/som/cm/cm3j/getting-started/install-os/erase.md
@@ -30,9 +30,9 @@ import Maskrom from "./maskrom/\_maskrom.mdx"
 
     3. 刷入 Loader
 
-        <pre>
+        ```bash
         sudo rkdeveloptool db rk356x_spl_loader_ddr1056_v1.12.109_no_check_todly.bin
-        </pre>
+        ```
 
     4. 清空 eMMC
 
@@ -84,9 +84,9 @@ import Maskrom from "./maskrom/\_maskrom.mdx"
 
     3. 刷入 Loader
 
-        <pre>
+        ```bash
         sudo rkdeveloptool db rk356x_spl_loader_ddr1056_v1.12.109_no_check_todly.bin
-        </pre>
+        ```
 
     4. 清空 SPI Flash
 

--- a/docs/som/cm/cm3j/getting-started/interface-usage/cm3j-rpi-cm4-io/fun.md
+++ b/docs/som/cm/cm3j/getting-started/interface-usage/cm3j-rpi-cm4-io/fun.md
@@ -54,24 +54,22 @@ sidebar_position: 8
 
   - 通过以下命令找到风扇设备
 
-    <pre>
-        ls /sys/class/thermal/cooling_device*/type <br />
-        cat /sys/class/thermal/cooling_device*/type
-    </pre>
+    ```text
+    ls /sys/class/thermal/cooling_device*/type
+    cat /sys/class/thermal/cooling_device*/type
+    ```
 
 - 关闭风扇
 
-  <pre style={{ whiteSpace: "nowrap" }}>
-    <!-- prettier-ignore -->
-    echo 0 | sudo tee /sys/class/thermal/cooling_device1/cur_state  
-  </pre>
+  ```bash
+  echo 0 | sudo tee /sys/class/thermal/cooling_device1/cur_state
+  ```
 
 - 将风扇调至最高档
 
-  <pre style={{ whiteSpace: "nowrap" }}>
-    <!-- prettier-ignore -->
-    sudo cp /sys/class/thermal/cooling_device1/max_state /sys/class/thermal/cooling_device1/cur_state  
-  </pre>
+  ```bash
+  sudo cp /sys/class/thermal/cooling_device1/max_state /sys/class/thermal/cooling_device1/cur_state
+  ```
 
 - step_wise
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3j/getting-started/install-os/erase.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3j/getting-started/install-os/erase.md
@@ -30,9 +30,9 @@ import Maskrom from "./maskrom/\_maskrom.mdx"
 
     3. Flash the Loader
 
-        <pre>
+        ```bash
         sudo rkdeveloptool db rk356x_spl_loader_ddr1056_v1.12.109_no_check_todly.bin
-        </pre>
+        ```
 
     4. Erase eMMC
 
@@ -84,9 +84,9 @@ import Maskrom from "./maskrom/\_maskrom.mdx"
 
     3. Flash the Loader
 
-        <pre>
+        ```bash
         sudo rkdeveloptool db rk356x_spl_loader_ddr1056_v1.12.109_no_check_todly.bin
-        </pre>
+        ```
 
     4. Erase SPI Flash
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3j/getting-started/interface-usage/cm3j-rpi-cm4-io/fun.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/som/cm/cm3j/getting-started/interface-usage/cm3j-rpi-cm4-io/fun.md
@@ -54,24 +54,22 @@ As shown in the figure, connect the fan to the Raspberry Pi Compute Module 4 IO 
 
   - Locate the fan device with the following command.
 
-    <pre>
-        ls /sys/class/thermal/cooling_device*/type <br />
-        cat /sys/class/thermal/cooling_device*/type
-    </pre>
+    ```text
+    ls /sys/class/thermal/cooling_device*/type
+    cat /sys/class/thermal/cooling_device*/type
+    ```
 
 - Turn off the fan
 
-  <pre style={{ whiteSpace: "nowrap" }}>
-    <!-- prettier-ignore -->
-    echo 0 | sudo tee /sys/class/thermal/cooling_device1/cur_state  
-  </pre>
+  ```bash
+  echo 0 | sudo tee /sys/class/thermal/cooling_device1/cur_state
+  ```
 
 - Set the fan to the highest setting.
 
-  <pre style={{ whiteSpace: "nowrap" }}>
-    <!-- prettier-ignore -->
-    sudo cp /sys/class/thermal/cooling_device1/max_state /sys/class/thermal/cooling_device1/cur_state  
-  </pre>
+  ```bash
+  sudo cp /sys/class/thermal/cooling_device1/max_state /sys/class/thermal/cooling_device1/cur_state
+  ```
 
 - step_wise
 


### PR DESCRIPTION
## Summary

Convert multi-line `<pre>` code blocks in cm3j pages (`install-os/erase.md`, `interface-usage/cm3j-rpi-cm4-io/fun.md`) to standard code block format, fixing an extra blank line rendered inside code blocks.

## Root cause

Multi-line `<pre>` blocks in MDX are parsed into `<pre><p>...</pre>`, and the `<p>` default margin renders as a visible blank line inside the code block.

## Change

- `erase.md`: `sudo rkdeveloptool db ...` blocks → standard ``` bash fences.
- `fun.md`: fan device commands → ``` text/bash fences; removed `<!-- prettier-ignore -->` comments, `<br />`, and trailing spaces.
- Both Chinese and English versions updated. No command/content changes.

Whitespace/markup-only change.