### PR TITLE
docs(rock5/rock5b): convert link-list pre blocks to markdown list in download page

### DIFF
--- a/docs/rock5/rock5b/download.md
+++ b/docs/rock5/rock5b/download.md
@@ -18,27 +18,17 @@ SPI Image:
 
 Linux：
 
-<pre>
-    ROCK 5B 系统镜像 (5.10 内核): [rock-5b_debian_bullseye_kde_b39](https://github.com/radxa-build/rock-5b/releases/download/b39/rock-5b_debian_bullseye_kde_b39.img.xz)
-
-    ROCK 5B 系统镜像 (6.1 内核): [rock-5b_bookworm_kde_b5](https://github.com/radxa-build/rock-5b/releases/download/rsdk-b5/rock-5b_bookworm_kde_b5.output.img.xz)
-
-    ROCK 5B+ 系统镜像: [rock-5b-plus_bookworm_kde_b2](https://github.com/radxa-build/rock-5b-plus/releases/download/rsdk-b2/rock-5b-plus_bookworm_kde_b2.output.img.xz)
-</pre>
+- ROCK 5B 系统镜像 (5.10 内核): [rock-5b_debian_bullseye_kde_b39](https://github.com/radxa-build/rock-5b/releases/download/b39/rock-5b_debian_bullseye_kde_b39.img.xz)
+- ROCK 5B 系统镜像 (6.1 内核): [rock-5b_bookworm_kde_b5](https://github.com/radxa-build/rock-5b/releases/download/rsdk-b5/rock-5b_bookworm_kde_b5.output.img.xz)
+- ROCK 5B+ 系统镜像: [rock-5b-plus_bookworm_kde_b2](https://github.com/radxa-build/rock-5b-plus/releases/download/rsdk-b2/rock-5b-plus_bookworm_kde_b2.output.img.xz)
 
 Android：
 
-<pre>
-    Loader: [MiniLoader.bin](https://dl.radxa.com/rock5/5itx/images/MiniLoaderAll.bin)
-
-    [ROCK 5B Android 12_gpt](https://github.com/radxa/manifests/releases/download/Android12_rkr14_20240419/Rock5B_Android12_rkr14_20240419-gpt.zip)(用于 sdcard/emmc 启动)
-
-    [ROCK 5B Android 12_update](https://github.com/radxa/manifests/releases/download/Rock-android12-20221104/ROCK-5B-Android12-rkr10-20221103-spi-nvme-rkupdate.zip)(用于 nvme 启动)
-
-    [ROCK_5B+_Android12_gpt](https://github.com/radxa/manifests/releases/download/android12-radxa-20240708/Rock5BPlus-Android12-rkr14-SD-or-eMMC-20240705-1-gpt.zip)(用于 sdcard/emmc 启动)
-
-    [ROCK_5B+_Android12_update](https://github.com/radxa/manifests/releases/download/android12-radxa-20240708/Rock5BPlus-Android12-rkr14-SPI_NVME-20240705-update.zip)(用于 SPI-NVME 启动)
-</pre>
+- Loader: [MiniLoader.bin](https://dl.radxa.com/rock5/5itx/images/MiniLoaderAll.bin)
+- [ROCK 5B Android 12_gpt](https://github.com/radxa/manifests/releases/download/Android12_rkr14_20240419/Rock5B_Android12_rkr14_20240419-gpt.zip)(用于 sdcard/emmc 启动)
+- [ROCK 5B Android 12_update](https://github.com/radxa/manifests/releases/download/Rock-android12-20221104/ROCK-5B-Android12-rkr10-20221103-spi-nvme-rkupdate.zip)(用于 nvme 启动)
+- [ROCK_5B+_Android12_gpt](https://github.com/radxa/manifests/releases/download/android12-radxa-20240708/Rock5BPlus-Android12-rkr14-SD-or-eMMC-20240705-1-gpt.zip)(用于 sdcard/emmc 启动)
+- [ROCK_5B+_Android12_update](https://github.com/radxa/manifests/releases/download/android12-radxa-20240708/Rock5BPlus-Android12-rkr14-SPI_NVME-20240705-update.zip)(用于 SPI-NVME 启动)
 
 ### 第三方镜像
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/download.md
@@ -18,27 +18,17 @@ SPI Image:
 
 Linux：
 
-<pre>
-    ROCK 5B Debian (kernel 5.10): [rock-5b_debian_bullseye_kde_b39](https://github.com/radxa-build/rock-5b/releases/download/b39/rock-5b_debian_bullseye_kde_b39.img.xz)
-
-    ROCK 5B Debian (kernel 6.1): [rock-5b_bookworm_kde_b5](https://github.com/radxa-build/rock-5b/releases/download/rsdk-b5/rock-5b_bookworm_kde_b5.output.img.xz)
-
-    ROCK 5B+ Debian(kernel 6.1): [rock-5b-plus_bookworm_kde_b2](https://github.com/radxa-build/rock-5b-plus/releases/download/rsdk-b2/rock-5b-plus_bookworm_kde_b2.output.img.xz)
-</pre>
+- ROCK 5B Debian (kernel 5.10): [rock-5b_debian_bullseye_kde_b39](https://github.com/radxa-build/rock-5b/releases/download/b39/rock-5b_debian_bullseye_kde_b39.img.xz)
+- ROCK 5B Debian (kernel 6.1): [rock-5b_bookworm_kde_b5](https://github.com/radxa-build/rock-5b/releases/download/rsdk-b5/rock-5b_bookworm_kde_b5.output.img.xz)
+- ROCK 5B+ Debian(kernel 6.1): [rock-5b-plus_bookworm_kde_b2](https://github.com/radxa-build/rock-5b-plus/releases/download/rsdk-b2/rock-5b-plus_bookworm_kde_b2.output.img.xz)
 
 Android：
 
-<pre>
-    Loader: [MiniLoader.bin](https://dl.radxa.com/rock5/5itx/images/MiniLoaderAll.bin)
-
-    [ROCK 5B Android 12_gpt](https://github.com/radxa/manifests/releases/download/Android12_rkr14_20240419/Rock5B_Android12_rkr14_20240419-gpt.zip)(used for booting from sdcard/emmc)
-
-    [ROCK 5B Android 12 RKupdate Image](https://github.com/radxa/manifests/releases/download/Rock-android12-20221104/ROCK-5B-Android12-rkr10-20221103-spi-nvme-rkupdate.zip)(used for booting from SPI-NVME)
-
-    [ROCK_5B+_Android12_gpt](https://github.com/radxa/manifests/releases/download/android12-radxa-20240708/Rock5BPlus-Android12-rkr14-SD-or-eMMC-20240705-1-gpt.zip)(used for booting from sdcard/emmc)
-
-    [ROCK_5B+_Android12_update](https://github.com/radxa/manifests/releases/download/android12-radxa-20240708/Rock5BPlus-Android12-rkr14-SPI_NVME-20240705-update.zip)(used for booting from SPI-NVME)
-</pre>
+- Loader: [MiniLoader.bin](https://dl.radxa.com/rock5/5itx/images/MiniLoaderAll.bin)
+- [ROCK 5B Android 12_gpt](https://github.com/radxa/manifests/releases/download/Android12_rkr14_20240419/Rock5B_Android12_rkr14_20240419-gpt.zip)(used for booting from sdcard/emmc)
+- [ROCK 5B Android 12 RKupdate Image](https://github.com/radxa/manifests/releases/download/Rock-android12-20221104/ROCK-5B-Android12-rkr10-20221103-spi-nvme-rkupdate.zip)(used for booting from SPI-NVME)
+- [ROCK_5B+_Android12_gpt](https://github.com/radxa/manifests/releases/download/android12-radxa-20240708/Rock5BPlus-Android12-rkr14-SD-or-eMMC-20240705-1-gpt.zip)(used for booting from sdcard/emmc)
+- [ROCK_5B+_Android12_update](https://github.com/radxa/manifests/releases/download/android12-radxa-20240708/Rock5BPlus-Android12-rkr14-SPI_NVME-20240705-update.zip)(used for booting from SPI-NVME)
 
 ### Third-party Image
 


### PR DESCRIPTION
## Summary

Convert multi-line `<pre>` link-list blocks in `rock5/rock5b/download.md` to standard markdown lists, fixing an extra blank line rendered inside the pre block.

## Root cause

Multi-line `<pre>` blocks in MDX are parsed into `<pre><p>...</pre>`, and the `<p>` default margin renders as a visible blank line inside the block. These blocks contain download links (not code), so they are converted to markdown lists to keep the links clickable.

## Change

- Linux/Android image download lists → markdown `-` lists (links preserved).
- Both Chinese and English versions updated. No link/content changes.

Whitespace/markup-only change.