### PR TITLE
docs(dragon/q6a-q8b): update EDL-NG tool download links with release page tip

### DIFF
--- a/docs/dragon/q6a/download.md
+++ b/docs/dragon/q6a/download.md
@@ -101,7 +101,16 @@ Dragon Q6A 出厂默认烧录 SPI 启动固件，正常情况下无需烧录启�
 
 - EDL 工具
 
-  - [EDL-NG](https://dl.radxa.com/q6a/images/edl-ng-dist.zip)
+  :::info 最新 EDL 工具发布页面
+
+  - [EDL-NG](https://github.com/strongtz/edl-ng/releases)
+
+  该页面会发布最新版本的 EDL-NG 工具。
+
+  :::
+
+  - [EDL-NG v1.6.0（GitHub）](https://github.com/strongtz/edl-ng/releases/tag/v1.6.0)
+  - [EDL-NG v1.6.0（dl.radxa.com）](https://dl.radxa.com/q6a/images/edl-ng-dist-v1.6.0.zip)
 
 - SPI 启动固件
 

--- a/docs/dragon/q8b/download.md
+++ b/docs/dragon/q8b/download.md
@@ -27,7 +27,17 @@ Dragon Q8B 出厂默认烧录 SPI 启动固件，正常情况下无需烧录启�
   - [高通设备驱动](https://dl.radxa.com/dragon/q6a/images/QUD_CustomInst_1.00.91.7.zip)
 
 - EDL 工具
-  - [EDL-NG](https://dl.radxa.com/q6a/images/edl-ng-dist.zip)
+
+  :::info 最新 EDL 工具发布页面
+
+  - [EDL-NG](https://github.com/strongtz/edl-ng/releases)
+
+  该页面会发布最新版本的 EDL-NG 工具。
+
+  :::
+
+  - [EDL-NG v1.6.0（GitHub）](https://github.com/strongtz/edl-ng/releases/tag/v1.6.0)
+  - [EDL-NG v1.6.0（dl.radxa.com）](https://dl.radxa.com/q6a/images/edl-ng-dist-v1.6.0.zip)
 
 - SPI 启动固件（BIOS）
   - [启动固件（BIOS）](https://dl.radxa.com/dragon/q8b/images/)

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/download.md
@@ -101,7 +101,16 @@ For detailed steps on flashing the SPI boot firmware, please refer to the [Flash
 
 - EDL Tools
 
-  - [EDL-NG](https://dl.radxa.com/q6a/images/edl-ng-dist.zip)
+  :::info Latest EDL Tool Release Page
+
+  - [EDL-NG](https://github.com/strongtz/edl-ng/releases)
+
+  This page releases the latest versions of the EDL-NG tool.
+
+  :::
+
+  - [EDL-NG v1.6.0 (GitHub)](https://github.com/strongtz/edl-ng/releases/tag/v1.6.0)
+  - [EDL-NG v1.6.0 (dl.radxa.com)](https://dl.radxa.com/q6a/images/edl-ng-dist-v1.6.0.zip)
 
 - SPI Boot Firmware
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/download.md
@@ -27,7 +27,17 @@ Dragon Q8B ships with SPI boot firmware preinstalled. Normally you do not need t
   - [Qualcomm Device Driver](https://dl.radxa.com/dragon/q6a/images/QUD_CustomInst_1.00.91.7.zip)
 
 - EDL Tool
-  - [EDL-NG](https://dl.radxa.com/q6a/images/edl-ng-dist.zip)
+
+  :::info Latest EDL Tool Release Page
+
+  - [EDL-NG](https://github.com/strongtz/edl-ng/releases)
+
+  This page releases the latest versions of the EDL-NG tool.
+
+  :::
+
+  - [EDL-NG v1.6.0 (GitHub)](https://github.com/strongtz/edl-ng/releases/tag/v1.6.0)
+  - [EDL-NG v1.6.0 (dl.radxa.com)](https://dl.radxa.com/q6a/images/edl-ng-dist-v1.6.0.zip)
 
 - SPI Boot Firmware (BIOS)
   - [Boot Firmware (BIOS)](https://dl.radxa.com/dragon/q8b/images/)


### PR DESCRIPTION
## 变更说明

更新 Dragon Q6A / Q8B 下载页面的 EDL 工具部分：

- 增加「最新 EDL 工具发布页面」提示，指向 EDL-NG 官方发布页 `https://github.com/strongtz/edl-ng/releases`
- EDL 工具下载链接提供两个版本：
  - GitHub Releases 页面：`https://github.com/strongtz/edl-ng/releases/tag/v1.6.0`
  - dl.radxa.com 镜像：`https://dl.radxa.com/q6a/images/edl-ng-dist-v1.6.0.zip`
- 中英文（docs/ 与 i18n/en/）同步更新

## 背景

由售后技术支持团队（吴闽龙）提出：原链接 `edl-ng-dist.zip` 为未版本化的通用链接，需要提示用户前往最新发布页，并提供明确的 v1.6.0 双通道下载入口。
