### PR TITLE
docs(taco): specify RTC battery model CR1220 in spec table

### DIFF
--- a/docs/accessories/storage/taco/README.md
+++ b/docs/accessories/storage/taco/README.md
@@ -55,7 +55,7 @@ sidebar_position: 1
 | USB        | 2x USB 3.2 Gen1 Type-A 端口<br />1x USB Type-C 端口，用于烧录系统                                                               |
 | 供电       | 12V DC 供电插孔或 12V DC 供电排针                                                                                               |
 | 风扇       | 1x 风扇接口，支持 PWM 转速控制                                                                                                  |
-| RTC        | 1x RTC 纽扣电池座，断电时间保持                                                                                                 |
+| RTC        | 1x RTC 纽扣电池座（CR1220），断电时间保持                                                                                   |
 | 其他       | 1x 8-Pin 1.25mm GPIO 排针（GPIO、I2C 和 PWM）<br />1x 电源按键<br />1x 电源指示灯<br />5x SATA 状态指示灯<br />1x RPI BOOT 按键 |
 | 兼容核心板 | 树莓派 CM5                                                                                                                      |
 | 连接器     | 2x 100-Pin B2B 接口                                                                                                             |

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/taco/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/taco/README.md
@@ -55,7 +55,7 @@ Note: Image shows only the Taco package contents. 12V DC power adapter is packag
 | USB               | 2x USB 3.2 Gen1 Type-A ports<br />1x USB Type-C port for system flashing                                                                |
 | Power             | 12V DC power jack or 12V DC power header                                                                                                |
 | Fan               | 1x fan header with PWM speed control                                                                                                    |
-| RTC               | 1x RTC coin cell holder for time retention                                                                                              |
+| RTC               | 1x RTC coin cell holder (CR1220) for time retention                                                                                    |
 | Other             | 1x 8-Pin 1.25mm GPIO header (GPIO, I2C and PWM)<br />1x power button<br />1x power LED<br />5x SATA status LEDs<br />1x RPI BOOT button |
 | Compatible Module | Raspberry Pi CM5                                                                                                                        |
 | Connectors        | 2x 100-Pin B2B interfaces                                                                                                               |


### PR DESCRIPTION
## Summary

Specify the RTC battery model for Radxa Taco in the product spec table.

- The dedicated RTC battery page already lists `CR1220` (`accessories/rtc.md`).
- The main product README spec table only said "1x RTC coin cell holder" without the battery model, which caused ambiguity.
- This PR adds `(CR1220)` to the RTC row in both Chinese and English READMEs so the battery model is visible on the main product page.

## Background

Triggered by an internal support discussion: customer/colleague asked about the Taco RTC battery specification. The confirmed battery model is **CR1220** (3V coin cell).

## Changes

- `docs/accessories/storage/taco/README.md`: RTC row now reads "1x RTC 纽扣电池座（CR1220），断电时间保持"
- `i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/taco/README.md`: RTC row now reads "1x RTC coin cell holder (CR1220) for time retention"

Bilingual change (zh + en) included.
