### PR TITLE
docs(common/accessories): fix MDX lazy-line build error in _wifi-bt template

### DIFF
--- a/docs/common/accessories/_wifi-bt.mdx
+++ b/docs/common/accessories/_wifi-bt.mdx
@@ -22,8 +22,7 @@
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# nmcli dev wifi connect "wifi_name" password
-"wifi_password"`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# nmcli dev wifi connect "wifi_name" password\n"wifi_password"`}</pre>
 
 - 蓝牙的使用
 
@@ -31,16 +30,13 @@
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# cat /etc/modprobe.d/blacklist.conf blacklist
-pgdrv blacklist btusb blacklist btrtl blacklist btbcm blacklist btintel
-root@${props.model}:~# reboot`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# cat /etc/modprobe.d/blacklist.conf blacklist\npgdrv blacklist btusb blacklist btrtl blacklist btbcm blacklist btintel\nroot@${props.model}:~# reboot`}</pre>
 
   2. Radxa APT 包括用于Broadcom无线模块的broadcom-wifibt-firmware软件包和用于Intel无线模块的intel-wifibt-firmware软件包。需要下载相应的软件包
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# apt-get update -y root@${props.model}
-:/home/radxa# apt-get install -y broadcom-wifibt-firmware intel-wifibt-firmware`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# apt-get update -y root@${props.model}\n:/home/radxa# apt-get install -y broadcom-wifibt-firmware intel-wifibt-firmware`}</pre>
 
   3. 测试蓝牙模块的状态并检查蓝牙设备
 
@@ -58,17 +54,13 @@ root@${props.model}:~# reboot`}</pre>
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# hciconfig hci0: Type: Primary Bus: UART BD
-Address: 10:2C:6B:49:D5:53 ACL MTU: 1021:8 SCO MTU: 64:1 UP RUNNING RX
-bytes:850 acl:0 sco:0 events:58 errors:0 TX bytes:2814 acl:0 sco:0
-commands:58 errors:0`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# hciconfig hci0: Type: Primary Bus: UART BD\nAddress: 10:2C:6B:49:D5:53 ACL MTU: 1021:8 SCO MTU: 64:1 UP RUNNING RX\nbytes:850 acl:0 sco:0 events:58 errors:0 TX bytes:2814 acl:0 sco:0\ncommands:58 errors:0`}</pre>
 
   6. 测试：连接蓝牙音箱，首先安装 pulseaudio
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# apt-get install -y
-pulseaudio-module-bluetooth pulseaudio`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# apt-get install -y\npulseaudio-module-bluetooth pulseaudio`}</pre>
 
   7. 运行 pulseaudio
 
@@ -80,9 +72,6 @@ pulseaudio-module-bluetooth pulseaudio`}</pre>
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# bluetoothctl [bluetooth]# default-agent
-[bluetooth]# power on [bluetooth]# scan on [bluetooth]# trust
-41:42:1A:8D:A9:65 #BT-280 [bluetooth]# pair 41:42:1A:8D:A9:65 [bluetooth]#
-connect 41:42:1A:8D:A9:65`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# bluetoothctl [bluetooth]# default-agent\n[bluetooth]# power on [bluetooth]# scan on [bluetooth]# trust\n41:42:1A:8D:A9:65 #BT-280 [bluetooth]# pair 41:42:1A:8D:A9:65 [bluetooth]#\nconnect 41:42:1A:8D:A9:65`}</pre>
 
   9. 现在您可以听音乐了

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_wifi-bt.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/accessories/_wifi-bt.mdx
@@ -22,8 +22,7 @@
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# nmcli dev wifi connect "wifi_name" password
-"wifi_password"`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# nmcli dev wifi connect "wifi_name" password\n"wifi_password"`}</pre>
 
 - Bluetooth Usage
 
@@ -31,16 +30,13 @@
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# cat /etc/modprobe.d/blacklist.conf blacklist
-pgdrv blacklist btusb blacklist btrtl blacklist btbcm blacklist btintel
-root@${props.model}:~# reboot`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# cat /etc/modprobe.d/blacklist.conf blacklist\npgdrv blacklist btusb blacklist btrtl blacklist btbcm blacklist btintel\nroot@${props.model}:~# reboot`}</pre>
 
   2. Radxa APT includes the broadcom-wifibt-firmware package for Broadcom wireless modules and the intel-wifibt-firmware package for Intel wireless modules. The corresponding packages need to be downloaded
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# apt-get update -y root@${props.model}
-:/home/radxa# apt-get install -y broadcom-wifibt-firmware intel-wifibt-firmware`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# apt-get update -y root@${props.model}\n:/home/radxa# apt-get install -y broadcom-wifibt-firmware intel-wifibt-firmware`}</pre>
 
   3. Test the status of the Bluetooth module and check the Bluetooth device
 
@@ -58,17 +54,13 @@ root@${props.model}:~# reboot`}</pre>
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# hciconfig hci0: Type: Primary Bus: UART BD
-Address: 10:2C:6B:49:D5:53 ACL MTU: 1021:8 SCO MTU: 64:1 UP RUNNING RX
-bytes:850 acl:0 sco:0 events:58 errors:0 TX bytes:2814 acl:0 sco:0
-commands:58 errors:0`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# hciconfig hci0: Type: Primary Bus: UART BD\nAddress: 10:2C:6B:49:D5:53 ACL MTU: 1021:8 SCO MTU: 64:1 UP RUNNING RX\nbytes:850 acl:0 sco:0 events:58 errors:0 TX bytes:2814 acl:0 sco:0\ncommands:58 errors:0`}</pre>
 
   6. Test: Connect the Bluetooth speaker, first install pulseaudio
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# apt-get install -y
-pulseaudio-module-bluetooth pulseaudio`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# apt-get install -y\npulseaudio-module-bluetooth pulseaudio`}</pre>
 
   7. Run pulseaudio
 
@@ -80,9 +72,6 @@ pulseaudio-module-bluetooth pulseaudio`}</pre>
 
   {" "}
 
-  <pre>{`root@${props.model}:/home/radxa# bluetoothctl [bluetooth]# default-agent
-[bluetooth]# power on [bluetooth]# scan on [bluetooth]# trust
-41:42:1A:8D:A9:65 #BT-280 [bluetooth]# pair 41:42:1A:8D:A9:65 [bluetooth]#
-connect 41:42:1A:8D:A9:65`}</pre>
+  <pre>{`root@${props.model}:/home/radxa# bluetoothctl [bluetooth]# default-agent\n[bluetooth]# power on [bluetooth]# scan on [bluetooth]# trust\n41:42:1A:8D:A9:65 #BT-280 [bluetooth]# pair 41:42:1A:8D:A9:65 [bluetooth]#\nconnect 41:42:1A:8D:A9:65`}</pre>
 
   9. Now you can listen to music


### PR DESCRIPTION
## 背景
PR #2041 合并后 CI 构建失败：`_wifi-bt.mdx` 中跨多行的 `<pre>{`...`}</pre>` 模板字符串位于列表容器内，micromark 触发 `Unexpected lazy line in expression in container`。

## 修复
将跨行模板字符串压成单行，内部换行改用 `\n` 转义，渲染效果与原来一致：
- 消除 lazy-line 解析错误
- 保留 `{props.model}` 动态渲染（引用页面传入 rock-3b / rock-5a / rock-5b / radxa-cm3i-io / rock-4se）
- 中英文同步修改

## 验证
- 用 @mdx-js/mdx 实测编译通过，无 lazy line 错误，props.model 表达式保留
- guard 通过：scope `docs/common/accessories`，zh/en 配对完整