### PR TITLE
docs(cubie/a7z): fix EN UART debug page copy-paste from A7A

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/system-config/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/system-config/README.md
@@ -4,6 +4,6 @@ sidebar_position: 2
 
 # System Usage
 
-This section provides usage instructions for common features in the Radxa Cubie A7A system.
+This section provides usage instructions for common features in the Radxa Cubie A7Z system.
 
 <DocCardList />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/system-config/uart-debug.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/system-config/uart-debug.md
@@ -6,27 +6,27 @@ import UART_DEBUG from '../../../common/radxa-os/system-config/\_uart_debug.mdx'
 
 # Serial Debugging
 
-Serial debugging is a fundamental method for interacting with the Cubie A7A board through a UART (Universal Asynchronous Receiver/Transmitter) interface. It allows you to view system output and perform debugging using serial communication tools.
+Serial debugging is a fundamental method for interacting with the Cubie A7Z board through a UART (Universal Asynchronous Receiver/Transmitter) interface. It allows you to view system output and perform debugging using serial communication tools.
 
 ## Hardware Connection
 
 :::danger
-When using a USB-to-TTL serial adapter with the Cubie A7A for serial debugging, ensure the pins are connected correctly. Incorrect connections may damage the board hardware.
+When using a USB-to-TTL serial adapter with the Cubie A7Z for serial debugging, ensure the pins are connected correctly. Incorrect connections may damage the board hardware.
 
 It is not recommended to connect the VCC pin of the USB-to-TTL adapter, as this could potentially damage the board if connected incorrectly.
 :::
 
-Connect the USB-to-TTL serial adapter to the Cubie A7A's UART0 interface, with the other end connected to your PC's USB port.
+Connect the USB-to-TTL serial adapter to the Cubie A7Z's UART0 interface, with the other end connected to your PC's USB port.
 
 <div style={{textAlign: 'center'}}>
-  <img src="/en/img/cubie/a7a/a7a-uart.webp" alt="Cubie A7A UART Connection Diagram" style={{width: '100%', maxWidth: '1200px'}} />
+  <img src="/en/img/cubie/a7z/a7z-uart-debug.webp" alt="Cubie A7Z UART Connection Diagram" style={{width: '100%', maxWidth: '1200px'}} />
 </div>
 
-| Cubie A7A Pin Function        | Connection Method                        |
+| Cubie A7Z Pin Function        | Connection Method                        |
 | ----------------------------- | ---------------------------------------- |
-| Cubie A7A: GND (Pin 6)        | Connect to GND pin of USB-to-TTL adapter |
-| Cubie A7A: UART0_TXD (Pin 8)  | Connect to RXD pin of USB-to-TTL adapter |
-| Cubie A7A: UART0_RXD (Pin 10) | Connect to TXD pin of USB-to-TTL adapter |
+| Cubie A7Z: GND (Pin 6)        | Connect to GND pin of USB-to-TTL adapter |
+| Cubie A7Z: UART0_TX (Pin 8)   | Connect to RXD pin of USB-to-TTL adapter |
+| Cubie A7Z: UART0_RX (Pin 10)  | Connect to TXD pin of USB-to-TTL adapter |
 
 ## Serial Login
 


### PR DESCRIPTION
## Problem

The English UART debug page under `cubie/a7z/system-config/` was copied from the Cubie A7A page and never fixed:

- The page title and body reference "Cubie A7A" instead of "Cubie A7Z"
- The connection diagram uses the A7A image (`/en/img/cubie/a7a/a7a-uart.webp`)
- The pin table labels use the A7A naming (`UART0_TXD` / `UART0_RXD`)
- The EN `system-config/README.md` also says "Radxa Cubie A7A system"

The Chinese page (`docs/cubie/a7z/system-config/uart-debug.md`) is already correct: it uses "Cubie A7Z", the `a7z-uart-debug.webp` image and `UART0_TX`/`UART0_RX` pin names. This PR aligns the English page with the already-correct Chinese version.

## Fix

- `i18n/en/.../cubie/a7z/system-config/uart-debug.md`: "Cubie A7A" → "Cubie A7Z"; image → `/en/img/cubie/a7z/a7z-uart-debug.webp`; pin labels → `UART0_TX (Pin 8)` / `UART0_RX (Pin 10)`
- `i18n/en/.../cubie/a7z/system-config/README.md`: "Radxa Cubie A7A system" → "Radxa Cubie A7Z system"

No Chinese change is required — the Chinese counterpart already uses the correct content, so this PR aligns the English pages with it.

## Scope

- docs-only, 2 files, single board section
- Discovered while reviewing issue #1932 (user-reported UART device not detected; the copy-paste bug makes the EN instructions point at the wrong board)

## Verification

- `/en/img/cubie/a7z/a7z-uart-debug.webp` returns 200 on docs.radxa.com (image already exists)
- No remaining "Cubie A7A" references in the A7Z EN section except the legitimate download.md product-family mention
