### PR TITLE
docs: update Dragon Q8B system image download links to r5

### DIFF
--- a/docs/dragon/q8b/download.md
+++ b/docs/dragon/q8b/download.md
@@ -16,8 +16,8 @@ sidebar_position: 150
 
 ### Radxa OS
 
-- [radxa-dragon-midstream_noble_gnome_r4.output_512.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_512.img.xz)：适用于 microSD 卡 / NVMe SSD 启动
-- [radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz)：适用于 UFS 启动
+- [radxa-dragon-midstream_resolute_gnome_r5.output_512.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r5/radxa-dragon-midstream_resolute_gnome_r5.output_512.img.xz)：适用于 microSD 卡 / NVMe SSD 启动
+- [radxa-dragon-midstream_resolute_gnome_r5.output_4096.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r5/radxa-dragon-midstream_resolute_gnome_r5.output_4096.img.xz)：适用于 UFS 启动
 
 ## 启动固件
 

--- a/docs/dragon/q8b/getting-started/install-system/nvme-system/no-nvme-reader.md
+++ b/docs/dragon/q8b/getting-started/install-system/nvme-system/no-nvme-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # 从 microSD 卡启动并将系统安装到 NVMe SSD
 
-<InstallSystem tag="m2_2280" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_512.img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_r4.output_512.img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_r4.output_512.img" />
+<InstallSystem tag="m2_2280" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r5/radxa-dragon-midstream_resolute_gnome_r5.output_512.img.xz" path_to_image_unxz="radxa-dragon-midstream_resolute_gnome_r5.output_512.img.xz" path_to_image="radxa-dragon-midstream_resolute_gnome_r5.output_512.img" />
 
 ## 启动系统
 

--- a/docs/dragon/q8b/getting-started/install-system/ufs-system/no-ufs-reader.md
+++ b/docs/dragon/q8b/getting-started/install-system/ufs-system/no-ufs-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # 从 microSD 卡启动并将系统安装到 UFS
 
-<InstallSystem tag="ufs_module" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_r4.output_4096.img" ufs_module_img="/img/dragon/q8b/dragon-q8b-ufs-module-board.webp" />
+<InstallSystem tag="ufs_module" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r5/radxa-dragon-midstream_resolute_gnome_r5.output_4096.img.xz" path_to_image_unxz="radxa-dragon-midstream_resolute_gnome_r5.output_4096.img.xz" path_to_image="radxa-dragon-midstream_resolute_gnome_r5.output_4096.img" ufs_module_img="/img/dragon/q8b/dragon-q8b-ufs-module-board.webp" />
 
 ## 启动系统
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/download.md
@@ -16,8 +16,8 @@ This page publishes the latest stable and test system images. Test releases star
 
 ### Radxa OS
 
-- [radxa-dragon-midstream_noble_gnome_t2.output_512. img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_512.img.xz): Suitable for booting from a microSD card or NVMe SSD
-- [radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz): Suitable for booting from UFS
+- [radxa-dragon-midstream_resolute_gnome_r5.output_512.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r5/radxa-dragon-midstream_resolute_gnome_r5.output_512.img.xz): Suitable for booting from a microSD card or NVMe SSD
+- [radxa-dragon-midstream_resolute_gnome_r5.output_4096.img.xz](https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r5/radxa-dragon-midstream_resolute_gnome_r5.output_4096.img.xz): Suitable for booting from UFS
 
 ## Boot Firmware
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/getting-started/install-system/nvme-system/no-nvme-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/getting-started/install-system/nvme-system/no-nvme-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # Booting from MicroSD Card and Installing System to NVMe SSD
 
-<InstallSystem tag="m2_2280" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_512. img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_r4.output_512. img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_r4.output_512. img" />
+<InstallSystem tag="m2_2280" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r5/radxa-dragon-midstream_resolute_gnome_r5.output_512.img.xz" path_to_image_unxz="radxa-dragon-midstream_resolute_gnome_r5.output_512.img.xz" path_to_image="radxa-dragon-midstream_resolute_gnome_r5.output_512.img" />
 
 ## Booting the System
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/getting-started/install-system/ufs-system/no-ufs-reader.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/getting-started/install-system/ufs-system/no-ufs-reader.md
@@ -6,7 +6,7 @@ import InstallSystem from '../../../../../common/radxa-os/install-system/\_use_d
 
 # Boot from MicroSD Card and Install System to UFS
 
-<InstallSystem tag="ufs_module" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r4/radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz" path_to_image_unxz="radxa-dragon-midstream_noble_gnome_r4.output_4096.img.xz" path_to_image="radxa-dragon-midstream_noble_gnome_r4.output_4096.img" ufs_module_img="/en/img/dragon/q8b/dragon-q8b-ufs-module-board.webp" />
+<InstallSystem tag="ufs_module" board="dragon-q8b" download_page="../../../download" download_url="https://github.com/radxa-build/radxa-dragon-midstream/releases/download/rsdk-r5/radxa-dragon-midstream_resolute_gnome_r5.output_4096.img.xz" path_to_image_unxz="radxa-dragon-midstream_resolute_gnome_r5.output_4096.img.xz" path_to_image="radxa-dragon-midstream_resolute_gnome_r5.output_4096.img" ufs_module_img="/en/img/dragon/q8b/dragon-q8b-ufs-module-board.webp" />
 
 ## Booting the System
 


### PR DESCRIPTION
## Summary

Update the Dragon Q8B Radxa OS system image download links from `rsdk-r4` (`noble_gnome_r4`) to `rsdk-r5` (`resolute_gnome_r5`).

## Changes

- `docs/dragon/q8b/download.md` (zh) & `i18n/en/.../download.md` (en): update both image links (output_512 for microSD/NVMe, output_4096 for UFS)
- `docs/dragon/q8b/getting-started/install-system/nvme-system/no-nvme-reader.md` (zh/en): update `download_url` and image filename to r5
- `docs/dragon/q8b/getting-started/install-system/ufs-system/no-ufs-reader.md` (zh/en): update `download_url` and image filename to r5
- Fix a stray space in the en `no-nvme-reader.md` image filename (`output_512. img.xz` → `output_512.img.xz`)

## New image links

- microSD / NVMe SSD: `radxa-dragon-midstream_resolute_gnome_r5.output_512.img.xz`
- UFS: `radxa-dragon-midstream_resolute_gnome_r5.output_4096.img.xz`

Source: internal request from 售后技术支持 group (2026-08-21). Both links verified reachable.
