### PR TITLE
docs(cubie): bump NPU docker and Model Zoo to v1.0.0, and add CLIP/Zi…

### DIFF
--- a/docs/common/ai/_cubie_acuity_env.mdx
+++ b/docs/common/ai/_cubie_acuity_env.mdx
@@ -92,8 +92,8 @@ unzip docker_images_v1.8.x.zip
 
 ```bash
 cd docker_images_v2.0.x
-unzip ubuntu-npu_v2.0.10.1.tar.zip
-sudo docker load -i ubuntu-npu_v2.0.10.1.tar
+unzip ubuntu-npu_v2.0.10.2.tar.zip
+sudo docker load -i ubuntu-npu_v2.0.10.2.tar
 ```
 
 </NewCodeBlock>
@@ -103,15 +103,15 @@ sudo docker load -i ubuntu-npu_v2.0.10.1.tar
 
 ```bash
 cd docker_images_v1.8.x
-unzip ubuntu-npu_v1.8.11.tar.zip
-sudo docker load -i ubuntu-npu_v1.8.11.tar
+unzip ubuntu-npu_v1.8.13.tar.zip
+sudo docker load -i ubuntu-npu_v1.8.13.tar
 ```
 
 </NewCodeBlock>
 </TabItem>
 </Tabs>
 
-当 docker 镜像载入完成后可以在 `docker images` 中看到此镜像， 名字为 `ubuntu‑npu:v2.0.10.1` (A733) 或 `ubuntu-npu:v1.8.11` (T527)
+当 docker 镜像载入完成后可以在 `docker images` 中看到此镜像， 名字为 `ubuntu‑npu:v2.0.10.2` (A733) 或 `ubuntu-npu:v1.8.13` (T527)
 
 ### 创建 docker 容器
 
@@ -121,7 +121,7 @@ sudo docker load -i ubuntu-npu_v1.8.11.tar
 
 ```bash
 mkdir docker_data && cd docker_data
-sudo docker run --ipc=host -itd -v ${PWD}:/workspace --name allwinner_v2.0.10.1 ubuntu-npu:v2.0.10.1 /bin/bash
+sudo docker run --ipc=host -itd -v ${PWD}:/workspace --name allwinner_v2.0.10.2 ubuntu-npu:v2.0.10.2 /bin/bash
 ```
 
 </NewCodeBlock>
@@ -131,14 +131,14 @@ sudo docker run --ipc=host -itd -v ${PWD}:/workspace --name allwinner_v2.0.10.1 
 
 ```bash
 mkdir docker_data && cd docker_data
-sudo docker run --ipc=host -itd -v ${PWD}:/workspace --name allwinner_v1.8.11 ubuntu-npu:v1.8.11 /bin/bash
+sudo docker run --ipc=host -itd -v ${PWD}:/workspace --name allwinner_v1.8.13 ubuntu-npu:v1.8.13 /bin/bash
 ```
 
 </NewCodeBlock>
 </TabItem>
 </Tabs>
 
-当 docker 容器创建完成后可以在 `docker ps -a` 中看到此容器， 名字为 `allwinner_v2.0.10.1` (A733) 或 `allwinner_v1.8.11` (T527)
+当 docker 容器创建完成后可以在 `docker ps -a` 中看到此容器， 名字为 `allwinner_v2.0.10.2` (A733) 或 `allwinner_v1.8.13` (T527)
 
 ### 进入 docker 容器
 

--- a/docs/common/ai/cubie/_model-zoo-clip.mdx
+++ b/docs/common/ai/cubie/_model-zoo-clip.mdx
@@ -1,0 +1,330 @@
+本文档讲述如何在 NPU 上运行 CLIP。
+
+:::info
+参考 [Model Zoo 下载](./model-zoo-download)获取示例。
+:::
+
+CLIP 示例将图像模型和文本模型分别转换后，在板端计算图文相似度。
+
+CLIP 示例目录结构：
+
+```bash
+$ tree ./
+./
+├── CMakeLists.txt
+├── images_convert_model
+├── text_convert_model
+│   └── python
+├── model
+│   ├── clip-images_uint8_a733.nb
+│   ├── clip-text_int16_a733.nb
+│   ├── demo.png
+│   ├── demo.txt
+│   └── merges.txt
+├── main.cpp
+└── README.md
+```
+
+## 模型转换
+
+需要先进入容器开发环境。可以参考 Model Zoo 下载中[创建容器](./model-zoo-download#创建并启动容器)这一部分。
+
+:::info
+不同平台请使用对应的 Docker 镜像：
+
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
+  :::
+
+ONNX 浮点模型可从全志网盘获取：
+
+- clip-images：[http://netstorage.allwinnertech.com:5000/sharing/DPFhNJzGl](http://netstorage.allwinnertech.com:5000/sharing/DPFhNJzGl)
+- clip-text：[http://netstorage.allwinnertech.com:5000/sharing/neeTHfl6P](http://netstorage.allwinnertech.com:5000/sharing/neeTHfl6P)
+
+将 `clip-images.onnx` 放到 `images_convert_model` 目录，将 `clip-text.onnx` 放到 `text_convert_model` 目录。
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+docker exec -it model-zoo /bin/bash
+```
+
+</NewCodeBlock>
+
+### 转换 clip-images
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/clip/images_convert_model/
+./convert_model_env.sh
+./pegasus_import.sh clip-images
+./pegasus_quantize.sh clip-images uint8 10
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh clip-images uint8 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh clip-images uint8 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+### 转换 clip-text
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/clip/text_convert_model/
+./convert_model_env.sh
+./pegasus_import.sh clip-text
+./pegasus_quantize.sh clip-text int16 10
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh clip-text int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh clip-text int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+导出的模型文件存放在 `../model` 目录。
+
+### 编译示例
+
+接下来可以编译示例，**先 exit 退出容器**，然后执行下面的命令编译示例。
+
+首先需要配置第三方库和交叉编译工具链。
+
+:::info
+如果你已经在其他示例中配置过第三方库和交叉编译工具链则可以跳过这一步。
+:::
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd ../../../3rdparty/opencv/
+unzip opencv-4.9.0-aarch64-linux-sunxi-glibc.zip
+cd ../../0-toolchains/
+```
+
+</NewCodeBlock>
+
+需要先手动[点击链接](http://netstorage.allwinnertech.com:5000/sharing/e2nD8YwB4)下载之后放到 `0-toolchains/` 再执行下面的命令：
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+tar -xvf gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+cd ../examples/clip/
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t a733 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t t527 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+## 模型部署
+
+编译示例完成之后，示例会安装到 install 目录，可以使用 scp 传输到板端。
+
+### 配置 NPU 驱动
+
+:::info
+如果你已经在其他示例中配置过 NPU 驱动则可以跳过这一步。
+:::
+
+将驱动库 scp 传输到板端的 lib 目录。
+
+- A733 对应 common/npuruntime/lib_linux_aarch64/A733 目录
+- T527 对应 common/npuruntime/lib_linux_aarch64/T527 目录
+
+然后执行下面的命令导出到环境变量。
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+echo 'export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+```
+
+</NewCodeBlock>
+
+### 运行示例
+
+配置好驱动之后就可以运行示例了。
+
+:::tip
+对于 T527 平台，你还需要参考 A5E 的`板端启用 NPU`文档先启用 NPU ，然后使用下面的命令增加当前用户使用 /dev/vipcore 的权限。
+:::
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+sudo chmod 777 /dev/vipcore
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd clip_demo_linux_a733/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./clip_demo_a733
+./clip_demo_a733 -ib model/clip-images_uint8_a733.nb -tb model/clip-text_int16_a733.nb -i model/demo.png -t model/demo.txt
+```
+
+</NewCodeBlock>
+
+运行结果如下：
+
+```bash
+$ ./clip_demo_a733 -ib model/clip-images_uint8_a733.nb -tb model/clip-text_int16_a733.nb -i model/demo.png -t model/demo.txt
+text_model_file=model/clip-text_int16_a733.nb, images_model_file=model/clip-images_uint8_a733.nb, input_images_file=model/demo.png, input_text_file=model/demo.txt, loop_count=1, malloc_mbyte=10
+VIPLite driver software version 2.0.3.2-AW-2024-08-30
+nbg name=model/clip-images_uint8_a733.nb, size: 63747488.
+create network 0: 34340 us.
+nbg name=model/clip-text_int16_a733.nb, size: 115039816.
+create network 1: 60155 us.
+prepare network: 2633 us.
+prepare network: 1587 us.
+images: model/demo.png
+text  : a photo of a motorcycle
+score : 0.998
+clip-text total infer time: 35368 us.
+clip-images total infer time: 13695 us.
+destroy npu finished.
+~NpuUint.
+```
+
+此性能数据仅计算模型推理的时间消耗。如无特别说明，不包含预处理和后处理的时间消耗。
+
+| SoC       | NPU             | 模型        | 输入分辨率 | 网络创建耗时 | 网络准备耗时 | 单帧推理耗时 | 后处理耗时 | 总耗时  | 帧率     |
+| :-------- | :-------------- | :---------- | :--------- | :----------- | :----------- | :----------- | :--------- | :------ | :------- |
+| 全志 A733 | Vivante VIP9000 | clip-images | 224×224    | 34.3 ms      | 2.6 ms       | 13.7 ms      |            | 50.6 ms | 73.0 FPS |
+| 全志 A733 | Vivante VIP9000 | clip-text   | 1×20       | 60.2 ms      | 1.6 ms       | 35.4 ms      |            | 97.2 ms | 28.3 FPS |
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd clip_demo_linux_t527/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./clip_demo_t527
+./clip_demo_t527 -ib model/clip-images_uint8_t527.nb -tb model/clip-text_int16_t527.nb -i model/demo.png -t model/demo.txt
+```
+
+</NewCodeBlock>
+
+运行结果如下：
+
+```bash
+$ ./clip_demo_t527 -ib model/clip-images_uint8_t527.nb -tb model/clip-text_int16_t527.nb -i model/demo.png -t model/demo.txt
+text_model_file=model/clip-text_int16_t527.nb, images_model_file=model/clip-images_uint8_t527.nb, input_images_file=model/demo.png, input_text_file=model/demo.txt, loop_count=1, malloc_mbyte=10
+VIPLite driver software version 1.13.0.0-AW-2023-10-19
+nbg name=model/clip-images_uint8_t527.nb, size: 64787840.
+create network 0: 74736 us.
+nbg name=model/clip-text_int16_t527.nb, size: 114667200.
+create network 1: 131392 us.
+prepare network: 8988 us.
+prepare network: 12743 us.
+clip-text total infer time: 113006 us.
+images: model/demo.png
+text  : a photo of a motorcycle
+score : 0.997
+clip-images total infer time: 78735 us.
+destroy npu finished.
+~NpuUint.
+```
+
+此性能数据仅计算模型推理的时间消耗。如无特别说明，不包含预处理和后处理的时间消耗。
+
+| SoC       | NPU             | 模型        | 输入分辨率 | 网络创建耗时 | 网络准备耗时 | 单帧推理耗时 | 后处理耗时 | 总耗时   | 帧率     |
+| :-------- | :-------------- | :---------- | :--------- | :----------- | :----------- | :----------- | :--------- | :------- | :------- |
+| 全志 T527 | Vivante VIP9000 | clip-images | 224×224    | 74.7 ms      | 9.0 ms       | 78.7 ms      |            | 162.4 ms | 12.7 FPS |
+| 全志 T527 | Vivante VIP9000 | clip-text   | 1×20       | 131.4 ms     | 12.7 ms      | 113.0 ms     |            | 257.1 ms | 8.8 FPS  |
+
+</TabItem>
+</Tabs>

--- a/docs/common/ai/cubie/_model-zoo-densenet121-keras.mdx
+++ b/docs/common/ai/cubie/_model-zoo-densenet121-keras.mdx
@@ -47,8 +47,8 @@ $ tree ./
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-download.mdx
+++ b/docs/common/ai/cubie/_model-zoo-download.mdx
@@ -8,7 +8,7 @@
 
 ![点击资源下载](/img/cubie/allwinnertech-model-zoo-download-guide1.webp)
 
-点击左侧工具查询下的 AI 开发 SDK，然后找到 v0.9.0 版本的 Model Zoo 下载到本地即可。
+点击左侧工具查询下的 AI 开发 SDK，然后找到 v1.0.0 版本的 Model Zoo 下载到本地即可。
 
 ![下载 Model Zoo](/img/cubie/allwinnertech-model-zoo-download-guide2.webp)
 
@@ -35,8 +35,8 @@ wget https://dl.radxa.com/cubie/allwinner-model-zoo.tar.gz
 <NewCodeBlock tip="X86 Linux PC" type="PC">
 
 ```bash
-tar -xvf 1768567762439_awnpu_model_zoo-v0.9.0-20260116-83a67d4b.tar.gz
-cd awnpu_model_zoo-v0.9.0-20260116-83a67d4b/
+tar -xvf 1776931919742_awnpu_model_zoo-v1.0.0-20260423-f562dd16.tar.gz
+cd awnpu_model_zoo-v1.0.0-20260423-f562dd16/
 ```
 
 </NewCodeBlock>
@@ -49,7 +49,7 @@ cd awnpu_model_zoo-v0.9.0-20260116-83a67d4b/
 <NewCodeBlock tip="X86 Linux PC" type="PC">
 
 ```bash
-sudo docker run --ipc=host -d -v ${PWD}:/workspace --name model-zoo ubuntu-npu:v2.0.10.1 tail -f /dev/null
+sudo docker run --ipc=host -d -v ${PWD}:/workspace --name model-zoo ubuntu-npu:v2.0.10.2 tail -f /dev/null
 ```
 
 </NewCodeBlock>
@@ -61,7 +61,7 @@ sudo docker run --ipc=host -d -v ${PWD}:/workspace --name model-zoo ubuntu-npu:v
 <NewCodeBlock tip="X86 Linux PC" type="PC">
 
 ```bash
-sudo docker run --ipc=host -d -v ${PWD}:/workspace --name model-zoo ubuntu-npu:v1.8.11 tail -f /dev/null
+sudo docker run --ipc=host -d -v ${PWD}:/workspace --name model-zoo ubuntu-npu:v1.8.13 tail -f /dev/null
 ```
 
 </NewCodeBlock>
@@ -96,17 +96,17 @@ ls -al
 
 ```bash
 /workspace# ls -al
-total 52
-drwxrwxr-x 10 1000 1000 4096 Apr  2 19:09 .
-drwxr-xr-x  1 root root 4096 Apr  2 18:48 ..
-drwxrwxr-x  4 1000 1000 4096 Apr  3 12:03 0-toolchains              # 交叉编译工具链
-drwxrwxr-x  3 1000 1000 4096 Jan 16 20:44 3rdparty                  # 第三方工具链
--rwxrwxr-x  1 1000 1000 4976 Jan 16 20:44 README.md                 # README文档
-drwxrwxr-x  2 1000 1000 4096 Apr  3 12:06 cmake_toolchain           # 编译工具链配置
-drwxrwxr-x  3 1000 1000 4096 Jan 16 20:44 common                    # 通用库
-drwxrwxr-x  2 1000 1000 4096 Jan 16 20:44 docs                      # 文档
-drwxrwxr-x 26 1000 1000 4096 Jan 16 20:44 examples                  # 示例目录
-drwxrwxr-x  6 1000 1000 4096 Jan 16 20:44 functions                 # 特色功能
-drwxrwxr-x  2 1000 1000 4096 Jan 16 20:44 scripts_model_convert     # 转换脚本
--rwxrwxr-x  1 1000 1000    6 Jan 16 20:44 version                   # 版本号
+total 56
+drwxrwxr-x 10 1000 1000 4096 Aug  6 12:05 .
+-rw-rw-r--  1 1000 1000   10 Apr 23 15:56 .gitignore
+drwxrwxr-x  3 1000 1000 4096 Aug  3 11:33 0-toolchains              # 交叉编译工具链
+drwxrwxr-x  4 1000 1000 4096 Apr 23 15:56 3rdparty                  # 第三方工具链
+-rwxrwxr-x  1 1000 1000 5095 Apr 23 15:56 README.md                 # README文档
+drwxrwxr-x  2 1000 1000 4096 Apr 23 15:56 cmake_toolchain           # 编译工具链配置
+drwxrwxr-x  3 1000 1000 4096 Apr 23 15:56 common                    # 通用库
+drwxrwxr-x  2 1000 1000 4096 Apr 23 15:56 docs                      # 文档
+drwxrwxr-x 41 1000 1000 4096 Aug 20 18:11 examples                  # 示例目录
+drwxrwxr-x  6 1000 1000 4096 Apr 23 15:56 functions                 # 特色功能
+drwxrwxr-x  3 1000 1000 4096 Aug  3 15:41 scripts_model_convert     # 转换脚本
+-rwxrwxr-x  1 1000 1000    6 Apr 23 15:56 version                   # 版本号
 ```

--- a/docs/common/ai/cubie/_model-zoo-lenet-caffe.mdx
+++ b/docs/common/ai/cubie/_model-zoo-lenet-caffe.mdx
@@ -50,8 +50,8 @@ cd convert_model/
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-lite-transformer.mdx
+++ b/docs/common/ai/cubie/_model-zoo-lite-transformer.mdx
@@ -1,0 +1,329 @@
+本文档讲述如何在 NPU 上运行 Lite Transformer 英译中示例。
+
+:::info
+参考 [Model Zoo 下载](./model-zoo-download)获取示例。
+:::
+
+Lite Transformer 包含 encoder 和 decoder 两个子模型。
+
+Lite Transformer 示例目录结构：
+
+```bash
+$ tree ./
+./
+├── CMakeLists.txt
+├── convert_model_decoder
+├── convert_model_encoder
+├── include
+├── model
+│   ├── bpe_order.txt
+│   ├── cw_token_map_order.txt
+│   ├── dict_order.txt
+│   ├── lite_transformer_decoder_16_int16_a733.nb
+│   ├── lite_transformer_encoder_16_int16_a733.nb
+│   ├── position_embed.bin
+│   └── token_embed.bin
+├── src
+└── README.md
+```
+
+## 模型转换
+
+需要先进入容器开发环境。可以参考 Model Zoo 下载中[创建容器](./model-zoo-download#创建并启动容器)这一部分。
+
+:::info
+不同平台请使用对应的 Docker 镜像：
+
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
+  :::
+
+ONNX 浮点模型可从全志网盘获取：
+
+- encoder：[http://netstorage.allwinnertech.com:5000/sharing/48BkHmEFh](http://netstorage.allwinnertech.com:5000/sharing/48BkHmEFh)
+- decoder：[http://netstorage.allwinnertech.com:5000/sharing/QHfBh3imH](http://netstorage.allwinnertech.com:5000/sharing/QHfBh3imH)
+- BPE / 字典等：[http://netstorage.allwinnertech.com:5000/sharing/ctkG9jW4t](http://netstorage.allwinnertech.com:5000/sharing/ctkG9jW4t)
+
+将 BPE、字典等文件解压后放到 `lite_transformer` 目录。
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+docker exec -it model-zoo /bin/bash
+```
+
+</NewCodeBlock>
+
+### 转换 encoder
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/lite_transformer/convert_model_encoder/
+./convert_model_env.sh
+./pegasus_import.sh lite_transformer_encoder_16
+./pegasus_quantize.sh lite_transformer_encoder_16 int16 2
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lite_transformer_encoder_16 int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lite_transformer_encoder_16 int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+### 转换 decoder
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/lite_transformer/convert_model_decoder/
+./convert_model_env.sh
+./pegasus_import.sh lite_transformer_decoder_16
+./pegasus_quantize.sh lite_transformer_decoder_16 int16 4
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lite_transformer_decoder_16 int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lite_transformer_decoder_16 int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+导出的模型文件存放在 `../model` 目录。
+
+### 编译示例
+
+接下来可以编译示例，**先 exit 退出容器**，然后执行下面的命令编译示例。
+
+首先需要配置交叉编译工具链。
+
+:::info
+如果你已经在其他示例中配置过交叉编译工具链则可以跳过这一步。
+:::
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd ../../../0-toolchains/
+```
+
+</NewCodeBlock>
+
+需要先手动[点击链接](http://netstorage.allwinnertech.com:5000/sharing/e2nD8YwB4)下载之后放到 `0-toolchains/` 再执行下面的命令：
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+tar -xvf gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+cd ../examples/lite_transformer/
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t a733 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t t527 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+## 模型部署
+
+编译示例完成之后，示例会安装到 install 目录，可以使用 scp 传输到板端。
+
+### 配置 NPU 驱动
+
+:::info
+如果你已经在其他示例中配置过 NPU 驱动则可以跳过这一步。
+:::
+
+将驱动库 scp 传输到板端的 lib 目录。
+
+- A733 对应 common/npuruntime/lib_linux_aarch64/A733 目录
+- T527 对应 common/npuruntime/lib_linux_aarch64/T527 目录
+
+然后执行下面的命令导出到环境变量。
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+echo 'export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+```
+
+</NewCodeBlock>
+
+### 运行示例
+
+配置好驱动之后就可以运行示例了。
+
+:::tip
+对于 T527 平台，你还需要参考 A5E 的`板端启用 NPU`文档先启用 NPU ，然后使用下面的命令增加当前用户使用 /dev/vipcore 的权限。
+:::
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+sudo chmod 777 /dev/vipcore
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd lite_transformer_demo_linux_a733/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./lite_transformer_demo_a733
+./lite_transformer_demo_a733 -nb0 model/lite_transformer_encoder_16_int16_a733.nb -nb1 model/lite_transformer_decoder_16_int16_a733.nb -i "so big"
+```
+
+</NewCodeBlock>
+
+运行结果如下：
+
+```bash
+$ ./lite_transformer_demo_a733 -nb0 model/lite_transformer_encoder_16_int16_a733.nb -nb1 model/lite_transformer_decoder_16_int16_a733.nb -i "so big"
+encoder_path=model/lite_transformer_encoder_16_int16_a733.nb, decoder_path=model/lite_transformer_decoder_16_int16_a733.nb, input_strings=so big
+VIPLite driver software version 2.0.3.2-AW-2024-08-30
+nbg name=model/lite_transformer_encoder_16_int16_a733.nb, size: 3838272.
+create network 0: 2533 us.
+prepare network: 442 us.
+nbg name=model/lite_transformer_decoder_16_int16_a733.nb, size: 19421952.
+create network 1: 11027 us.
+prepare network: 406 us.
+
+input sentence:so big
+output token: 2 83 139 676 84 2
+output_strings: 如此巨大
+inference time: 24.000 ms
+destroy npu finished.
+~NpuUint.
+```
+
+此性能数据仅计算模型推理的时间消耗。如无特别说明，不包含预处理和后处理的时间消耗。
+
+| SoC       | NPU             | 模型             | 输入分辨率 | 网络创建耗时 | 网络准备耗时 | 单帧推理耗时 | 后处理耗时 | 总耗时  | 帧率     |
+| :-------- | :-------------- | :--------------- | :--------- | :----------- | :----------- | :----------- | :--------- | :------ | :------- |
+| 全志 A733 | Vivante VIP9000 | lite-transformer | 16 tokens  | 13.6 ms      | 0.8 ms       | 24.0 ms      |            | 38.4 ms | 41.7 FPS |
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd lite_transformer_demo_linux_t527/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./lite_transformer_demo_t527
+./lite_transformer_demo_t527 -nb0 model/lite_transformer_encoder_16_int16_t527.nb -nb1 model/lite_transformer_decoder_16_int16_t527.nb -i "so big"
+```
+
+</NewCodeBlock>
+
+运行结果如下：
+
+```bash
+$ ./lite_transformer_demo_t527 -nb0 model/lite_transformer_encoder_16_int16_t527.nb -nb1 model/lite_transformer_decoder_16_int16_t527.nb -i "so big"
+encoder_path=model/lite_transformer_encoder_16_int16_t527.nb, decoder_path=model/lite_transformer_decoder_16_int16_t527.nb, input_strings=so big
+VIPLite driver software version 1.13.0.0-AW-2023-10-19
+nbg name=model/lite_transformer_encoder_16_int16_t527.nb, size: 3755712.
+create network 0: 5054 us.
+prepare network: 836 us.
+nbg name=model/lite_transformer_decoder_16_int16_t527.nb, size: 19121536.
+create network 1: 23573 us.
+prepare network: 2658 us.
+
+input sentence:so big
+output token: 2 83 139 676 84 2
+output_strings: 如此巨大
+inference time: 64.000 ms
+destroy npu finished.
+~NpuUint.
+```
+
+此性能数据仅计算模型推理的时间消耗。如无特别说明，不包含预处理和后处理的时间消耗。
+
+| SoC       | NPU             | 模型             | 输入分辨率 | 网络创建耗时 | 网络准备耗时 | 单帧推理耗时 | 后处理耗时 | 总耗时  | 帧率     |
+| :-------- | :-------------- | :--------------- | :--------- | :----------- | :----------- | :----------- | :--------- | :------ | :------- |
+| 全志 T527 | Vivante VIP9000 | lite-transformer | 16 tokens  | 28.6 ms      | 3.5 ms       | 64.0 ms      |            | 96.1 ms | 15.6 FPS |
+
+</TabItem>
+</Tabs>

--- a/docs/common/ai/cubie/_model-zoo-lstm.mdx
+++ b/docs/common/ai/cubie/_model-zoo-lstm.mdx
@@ -1,0 +1,262 @@
+本文档讲述如何在 NPU 上运行 LSTM 示例。
+
+:::info
+参考 [Model Zoo 下载](./model-zoo-download)获取示例。
+:::
+
+LSTM 示例目录结构：
+
+```bash
+$ tree ./
+./
+├── CMakeLists.txt
+├── convert_model
+│   └── dataset
+├── main.cpp
+├── model
+│   ├── iter_0_c1_26_out0_1_1_128.tensor
+│   ├── iter_0_c2_28_out0_1_1_128.tensor
+│   ├── iter_0_h1_25_out0_1_1_128.tensor
+│   ├── iter_0_h2_27_out0_1_1_128.tensor
+│   ├── iter_0_input_24_out0_1_3_32_32.tensor
+│   └── lstm_model_uint8_a733.nb
+└── README.md
+```
+
+## 模型转换
+
+需要先进入容器开发环境。可以参考 Model Zoo 下载中[创建容器](./model-zoo-download#创建并启动容器)这一部分。
+
+:::info
+不同平台请使用对应的 Docker 镜像：
+
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
+  :::
+
+ONNX 浮点模型可从全志网盘获取：[http://netstorage.allwinnertech.com:5000/sharing/AmbdcCS7O](http://netstorage.allwinnertech.com:5000/sharing/AmbdcCS7O)
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+docker exec -it model-zoo /bin/bash
+cd /workspace/examples/lstm_model/convert_model/
+./convert_model_env.sh
+./pegasus_import.sh lstm_model
+./pegasus_quantize.sh lstm_model uint8 1
+export VIV_VX_ENABLE_WB_SHARE=1
+```
+
+</NewCodeBlock>
+
+`VIV_VX_ENABLE_WB_SHARE=1` 用于 LSTM / RNN 内部权重共享，减小导出的 nb 文件体积。
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lstm_model uint8 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lstm_model uint8 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+导出的模型文件存放在 `../model` 目录。
+
+### 编译示例
+
+接下来可以编译示例，**先 exit 退出容器**，然后执行下面的命令编译示例。
+
+首先需要配置交叉编译工具链。
+
+:::info
+如果你已经在其他示例中配置过交叉编译工具链则可以跳过这一步。
+:::
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd ../../../0-toolchains/
+```
+
+</NewCodeBlock>
+
+需要先手动[点击链接](http://netstorage.allwinnertech.com:5000/sharing/e2nD8YwB4)下载之后放到 `0-toolchains/` 再执行下面的命令：
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+tar -xvf gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+cd ../examples/lstm_model/
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t a733 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t t527 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+## 模型部署
+
+编译示例完成之后，示例会安装到 install 目录，可以使用 scp 传输到板端。
+
+### 配置 NPU 驱动
+
+:::info
+如果你已经在其他示例中配置过 NPU 驱动则可以跳过这一步。
+:::
+
+将驱动库 scp 传输到板端的 lib 目录。
+
+- A733 对应 common/npuruntime/lib_linux_aarch64/A733 目录
+- T527 对应 common/npuruntime/lib_linux_aarch64/T527 目录
+
+然后执行下面的命令导出到环境变量。
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+echo 'export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+```
+
+</NewCodeBlock>
+
+### 运行示例
+
+配置好驱动之后就可以运行示例了。
+
+:::tip
+对于 T527 平台，你还需要参考 A5E 的`板端启用 NPU`文档先启用 NPU ，然后使用下面的命令增加当前用户使用 /dev/vipcore 的权限。
+:::
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+sudo chmod 777 /dev/vipcore
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd lstm_demo_linux_a733/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./lstm_demo_a733
+./lstm_demo_a733 -nb model/lstm_model_uint8_a733.nb -i model/iter_0_input_24_out0_1_3_32_32.tensor,model/iter_0_h1_25_out0_1_1_128.tensor,model/iter_0_c1_26_out0_1_1_128.tensor,model/iter_0_h2_27_out0_1_1_128.tensor,model/iter_0_c2_28_out0_1_1_128.tensor -st 2
+```
+
+</NewCodeBlock>
+
+运行结果如下：
+
+```bash
+$ ./lstm_demo_a733 -nb model/lstm_model_uint8_a733.nb -i model/iter_0_input_24_out0_1_3_32_32.tensor,model/iter_0_h1_25_out0_1_1_128.tensor,model/iter_0_c1_26_out0_1_1_128.tensor,model/iter_0_h2_27_out0_1_1_128.tensor,model/iter_0_c2_28_out0_1_1_128.tensor -st 2
+model_file=model/lstm_model_uint8_a733.nb
+VIPLite driver software version 2.0.3.2-AW-2024-08-30
+nbg name=model/lstm_model_uint8_a733.nb, size: 1068496.
+create network 0: 2785 us.
+prepare network: 742 us.
+network: 0, loop count: 1
+run time for this network 0: 1221 us.
+destroy npu finished.
+~NpuUint.
+```
+
+此性能数据仅计算模型推理的时间消耗。如无特别说明，不包含预处理和后处理的时间消耗。
+
+| SoC       | NPU             | 模型       | 输入分辨率 | 网络创建耗时 | 网络准备耗时 | 单帧推理耗时 | 后处理耗时 | 总耗时 | 帧率      |
+| :-------- | :-------------- | :--------- | :--------- | :----------- | :----------- | :----------- | :--------- | :----- | :-------- |
+| 全志 A733 | Vivante VIP9000 | lstm_model | 32×32      | 2.8 ms       | 0.7 ms       | 1.2 ms       |            | 4.7 ms | 819.0 FPS |
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd lstm_demo_linux_t527/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./lstm_demo_t527
+./lstm_demo_t527 -nb model/lstm_model_uint8_t527.nb -i model/iter_0_input_24_out0_1_3_32_32.tensor,model/iter_0_h1_25_out0_1_1_128.tensor,model/iter_0_c1_26_out0_1_1_128.tensor,model/iter_0_h2_27_out0_1_1_128.tensor,model/iter_0_c2_28_out0_1_1_128.tensor -st 2
+```
+
+</NewCodeBlock>
+
+运行结果如下：
+
+```bash
+$ ./lstm_demo_t527 -nb model/lstm_model_uint8_t527.nb -i model/iter_0_input_24_out0_1_3_32_32.tensor,model/iter_0_h1_25_out0_1_1_128.tensor,model/iter_0_c1_26_out0_1_1_128.tensor,model/iter_0_h2_27_out0_1_1_128.tensor,model/iter_0_c2_28_out0_1_1_128.tensor -st 2
+model_file=model/lstm_model_uint8_t527.nb
+VIPLite driver software version 1.13.0.0-AW-2023-10-19
+nbg name=model/lstm_model_uint8_t527.nb, size: 1864000.
+create network 0: 2375 us.
+prepare network: 235 us.
+network: 0, loop count: 1
+run time for this network 0: 790 us.
+destroy npu finished.
+~NpuUint.
+```
+
+此性能数据仅计算模型推理的时间消耗。如无特别说明，不包含预处理和后处理的时间消耗。
+
+| SoC       | NPU             | 模型       | 输入分辨率 | 网络创建耗时 | 网络准备耗时 | 单帧推理耗时 | 后处理耗时 | 总耗时 | 帧率       |
+| :-------- | :-------------- | :--------- | :--------- | :----------- | :----------- | :----------- | :--------- | :----- | :--------- |
+| 全志 T527 | Vivante VIP9000 | lstm_model | 32×32      | 2.4 ms       | 0.2 ms       | 0.8 ms       |            | 3.4 ms | 1265.8 FPS |
+
+</TabItem>
+</Tabs>

--- a/docs/common/ai/cubie/_model-zoo-mobilenetv1-tensorflow.mdx
+++ b/docs/common/ai/cubie/_model-zoo-mobilenetv1-tensorflow.mdx
@@ -49,8 +49,8 @@ cd convert_model/
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-mobilenetv2.mdx
+++ b/docs/common/ai/cubie/_model-zoo-mobilenetv2.mdx
@@ -48,8 +48,8 @@ cd convert_model/
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-ppseg.mdx
+++ b/docs/common/ai/cubie/_model-zoo-ppseg.mdx
@@ -52,8 +52,8 @@ cd convert_model/
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-resnet50-tflite.mdx
+++ b/docs/common/ai/cubie/_model-zoo-resnet50-tflite.mdx
@@ -52,8 +52,8 @@ wget https://huggingface.co/qualcomm/ResNet50/resolve/18ab0a0ae3c14bc3ee7006c017
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-resnet50v2.mdx
+++ b/docs/common/ai/cubie/_model-zoo-resnet50v2.mdx
@@ -48,8 +48,8 @@ cd convert_model/
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-retinaface.mdx
+++ b/docs/common/ai/cubie/_model-zoo-retinaface.mdx
@@ -58,8 +58,8 @@ $ tree ./
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-squeezenet-pytorch.mdx
+++ b/docs/common/ai/cubie/_model-zoo-squeezenet-pytorch.mdx
@@ -49,8 +49,8 @@ cd convert_model/
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-yolo11-pose.mdx
+++ b/docs/common/ai/cubie/_model-zoo-yolo11-pose.mdx
@@ -82,8 +82,8 @@ cd ..
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-yolo11-seg.mdx
+++ b/docs/common/ai/cubie/_model-zoo-yolo11-seg.mdx
@@ -82,8 +82,8 @@ cd ..
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-yolo11.mdx
+++ b/docs/common/ai/cubie/_model-zoo-yolo11.mdx
@@ -82,8 +82,8 @@ cd ../
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-yolo26.mdx
+++ b/docs/common/ai/cubie/_model-zoo-yolo26.mdx
@@ -85,8 +85,8 @@ cd ..
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-yolov3-darknet.mdx
+++ b/docs/common/ai/cubie/_model-zoo-yolov3-darknet.mdx
@@ -53,8 +53,8 @@ wget https://pjreddie.com/media/files/yolov3.weights
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-yolov5.mdx
+++ b/docs/common/ai/cubie/_model-zoo-yolov5.mdx
@@ -56,8 +56,8 @@ cd convert_model/
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-yolov8-pose.mdx
+++ b/docs/common/ai/cubie/_model-zoo-yolov8-pose.mdx
@@ -91,8 +91,8 @@ cd ..
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-yolov8-seg.mdx
+++ b/docs/common/ai/cubie/_model-zoo-yolov8-seg.mdx
@@ -92,8 +92,8 @@ cd ..
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-yolov8.mdx
+++ b/docs/common/ai/cubie/_model-zoo-yolov8.mdx
@@ -92,8 +92,8 @@ cd ..
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-yolox.mdx
+++ b/docs/common/ai/cubie/_model-zoo-yolox.mdx
@@ -79,8 +79,8 @@ cd ../
 :::info
 不同平台请使用对应的 Docker 镜像：
 
-- A733：ubuntu-npu:v2.0.10.1
-- T527：ubuntu-npu:v1.8.11
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/docs/common/ai/cubie/_model-zoo-zipformer.mdx
+++ b/docs/common/ai/cubie/_model-zoo-zipformer.mdx
@@ -1,0 +1,381 @@
+本文档讲述如何在 NPU 上运行 Zipformer ASR 示例。
+
+:::info
+参考 [Model Zoo 下载](./model-zoo-download)获取示例。
+:::
+
+Zipformer 包含 encoder、decoder、joiner 三个子模型，用于自动语音识别。
+
+Zipformer 示例目录结构：
+
+```bash
+$ tree ./
+./
+├── CMakeLists.txt
+├── convert_model_decoder
+├── convert_model_encoder
+├── convert_model_joiner
+├── model
+│   ├── decoder_int16_a733.nb
+│   ├── encoder_int16_a733.nb
+│   ├── joiner_int16_a733.nb
+│   ├── test.wav
+│   └── tokens.txt
+└── README.md
+```
+
+## 模型转换
+
+需要先进入容器开发环境。可以参考 Model Zoo 下载中[创建容器](./model-zoo-download#创建并启动容器)这一部分。
+
+:::info
+不同平台请使用对应的 Docker 镜像：
+
+- A733：ubuntu-npu:v2.0.10.2
+- T527：ubuntu-npu:v1.8.13
+  :::
+
+ONNX 浮点模型可从全志网盘获取：
+
+- encoder：[http://netstorage.allwinnertech.com:5000/sharing/8WWXoUfoy](http://netstorage.allwinnertech.com:5000/sharing/8WWXoUfoy)
+- decoder：[http://netstorage.allwinnertech.com:5000/sharing/1km0Q1YgK](http://netstorage.allwinnertech.com:5000/sharing/1km0Q1YgK)
+- joiner：[http://netstorage.allwinnertech.com:5000/sharing/GUTAIo774](http://netstorage.allwinnertech.com:5000/sharing/GUTAIo774)
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+docker exec -it model-zoo /bin/bash
+```
+
+</NewCodeBlock>
+
+转换 encoder 前先设置环境变量：
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+export VIV_VX_ENABLE_GRAPH_TRANSFORM="-Dump[transform.rewrite.gather_to_stride_slice=0]"
+```
+
+</NewCodeBlock>
+
+### 转换 encoder
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/zipformer/convert_model_encoder/
+./convert_model_env.sh
+./pegasus_import.sh encoder
+./pegasus_quantize.sh encoder int16 10
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh encoder int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh encoder int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+### 转换 decoder
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/zipformer/convert_model_decoder/
+./convert_model_env.sh
+./pegasus_import.sh decoder
+./pegasus_quantize.sh decoder int16 10
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh decoder int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh decoder int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+### 转换 joiner
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/zipformer/convert_model_joiner/
+./convert_model_env.sh
+./pegasus_import.sh joiner
+./pegasus_quantize.sh joiner int16 10
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh joiner int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh joiner int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+导出的模型文件存放在 `../model` 目录。
+
+### 编译示例
+
+接下来可以编译示例，**先 exit 退出容器**，然后执行下面的命令编译示例。
+
+首先需要配置交叉编译工具链。
+
+:::info
+如果你已经在其他示例中配置过交叉编译工具链则可以跳过这一步。
+:::
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd ../../../0-toolchains/
+```
+
+</NewCodeBlock>
+
+需要先手动[点击链接](http://netstorage.allwinnertech.com:5000/sharing/e2nD8YwB4)下载之后放到 `0-toolchains/` 再执行下面的命令：
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+tar -xvf gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+cd ../examples/zipformer/
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t a733 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t t527 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+## 模型部署
+
+编译示例完成之后，示例会安装到 install 目录，可以使用 scp 传输到板端。
+
+### 配置 NPU 驱动
+
+:::info
+如果你已经在其他示例中配置过 NPU 驱动则可以跳过这一步。
+:::
+
+将驱动库 scp 传输到板端的 lib 目录。
+
+- A733 对应 common/npuruntime/lib_linux_aarch64/A733 目录
+- T527 对应 common/npuruntime/lib_linux_aarch64/T527 目录
+
+然后执行下面的命令导出到环境变量。
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+echo 'export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+```
+
+</NewCodeBlock>
+
+### 运行示例
+
+配置好驱动之后就可以运行示例了。
+
+:::tip
+对于 T527 平台，你还需要参考 A5E 的`板端启用 NPU`文档先启用 NPU ，然后使用下面的命令增加当前用户使用 /dev/vipcore 的权限。
+:::
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+sudo chmod 777 /dev/vipcore
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd zipformer_demo_linux_a733/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./zipformer_demo_a733
+./zipformer_demo_a733 -nb0 model/encoder_int16_a733.nb -nb1 model/decoder_int16_a733.nb -nb2 model/joiner_int16_a733.nb -i model/test.wav
+```
+
+</NewCodeBlock>
+
+运行结果如下：
+
+```bash
+$ ./zipformer_demo_a733 -nb0 model/encoder_int16_a733.nb -nb1 model/decoder_int16_a733.nb -nb2 model/joiner_int16_a733.nb -i model/test.wav
+encoder_path=model/encoder_int16_a733.nb, decoder_path=model/decoder_int16_a733.nb, joiner_path=model/joiner_int16_a733.nb, audio_path=model/test.wav
+VIPLite driver software version 2.0.3.2-AW-2024-08-30
+nbg name=model/encoder_int16_a733.nb, size: 37228136.
+create network 0: 25435 us.
+prepare network: 3858 us.
+nbg name=model/decoder_int16_a733.nb, size: 6973440.
+create network 1: 3971 us.
+prepare network: 244 us.
+nbg name=model/joiner_int16_a733.nb, size: 5509168.
+create network 2: 2820 us.
+prepare network: 56 us.
+
+Real Time Factor(RTF): 0.053 = 0.309s(infer_time) / 5.840s(audio_length)
+
+Timestamp (s): 0.96, 1.04, 1.24, 1.32, 1.44, 1.72, 1.80, 2.04, 2.56, 3.04, 3.08, 3.48, 3.84, 4.68, 4.76, 5.00, 5.24, 5.48
+
+Zipformer output: 这是第一种第二种叫呃嗯与 ALWAYS什么意思啊
+destroy npu finished.
+~NpuUint.
+```
+
+此性能数据仅计算模型推理的时间消耗。如无特别说明，不包含预处理和后处理的时间消耗。
+
+| SoC       | NPU             | 模型      | 输入分辨率 | 网络创建耗时 | 网络准备耗时 | 单帧推理耗时 | 后处理耗时 | 总耗时   | 帧率      |
+| :-------- | :-------------- | :-------- | :--------- | :----------- | :----------- | :----------- | :--------- | :------- | :-------- |
+| 全志 A733 | Vivante VIP9000 | zipformer | 5.84 s     | 32.2 ms      | 4.2 ms       | 309.0 ms     |            | 345.4 ms | RTF 0.053 |
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd zipformer_demo_linux_t527/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./zipformer_demo_t527
+./zipformer_demo_t527 -nb0 model/encoder_int16_t527.nb -nb1 model/decoder_int16_t527.nb -nb2 model/joiner_int16_t527.nb -i model/test.wav
+```
+
+</NewCodeBlock>
+
+运行结果如下：
+
+```bash
+$ ./zipformer_demo_t527 -nb0 model/encoder_int16_t527.nb -nb1 model/decoder_int16_t527.nb -nb2 model/joiner_int16_t527.nb -i model/test.wav
+encoder_path=model/encoder_int16_t527.nb, decoder_path=model/decoder_int16_t527.nb, joiner_path=model/joiner_int16_t527.nb, audio_path=model/test.wav
+VIPLite driver software version 1.13.0.0-AW-2023-10-19
+nbg name=model/encoder_int16_t527.nb, size: 37232320.
+create network 0: 48424 us.
+prepare network: 8934 us.
+nbg name=model/decoder_int16_t527.nb, size: 7010624.
+create network 1: 9543 us.
+prepare network: 1251 us.
+nbg name=model/joiner_int16_t527.nb, size: 5539648.
+create network 2: 5803 us.
+prepare network: 763 us.
+
+Real Time Factor(RTF): 0.161 = 0.942s(infer_time) / 5.840s(audio_length)
+
+Timestamp (s): 0.96, 1.04, 1.24, 1.32, 1.44, 1.72, 1.80, 2.04, 2.56, 3.04, 3.08, 3.48, 3.84, 4.68, 4.76, 5.00, 5.24, 5.48
+
+Zipformer output: 这是第一种第二种叫呃嗯与 ALWAYS什么意思啊
+destroy npu finished.
+~NpuUint.
+```
+
+此性能数据仅计算模型推理的时间消耗。如无特别说明，不包含预处理和后处理的时间消耗。
+
+| SoC       | NPU             | 模型      | 输入分辨率 | 网络创建耗时 | 网络准备耗时 | 单帧推理耗时 | 后处理耗时 | 总耗时    | 帧率      |
+| :-------- | :-------------- | :-------- | :--------- | :----------- | :----------- | :----------- | :--------- | :-------- | :-------- |
+| 全志 T527 | Vivante VIP9000 | zipformer | 5.84 s     | 63.8 ms      | 10.9 ms      | 942.0 ms     |            | 1016.7 ms | RTF 0.161 |
+
+</TabItem>
+</Tabs>

--- a/docs/common/ai/cubie/_voice-assistant.mdx
+++ b/docs/common/ai/cubie/_voice-assistant.mdx
@@ -1,0 +1,176 @@
+本文档介绍如何在全志 A733 的 Cubie 开发板上运行离线中文语音助手：唤醒词检测（KWS）→ 语音识别（ASR）→ 语音合成（TTS）。
+
+示例仓库：[https://github.com/Ronin-1124/cubie-a7a-voice-assistant](https://github.com/Ronin-1124/cubie-a7a-voice-assistant)
+
+该示例在 Cubie A7A 上开发和验证。Cubie A7S / Cubie A7Z 同样搭载 A733 NPU，软件流程相同，麦克风和耳机对应的 ALSA 声卡编号可能不同。
+
+```text
+麦克风 / 离线 wav
+  → 唤醒 KWS（Zipformer，默认 NPU）
+  → 识别 ASR（Zipformer，默认 NPU）
+  → 合成 TTS（Matcha CPU + HiFi-GAN NPU）
+  → 耳机播放
+```
+
+NPU（Vivante VIP9000）同一时间只能加载一个网络。助手在进入识别或 NPU 声码器前会卸掉其它 NBG。
+
+:::info
+Matcha-baker 使用的 Baker 数据集仅限非商用。量产请更换声学模型数据。
+:::
+
+## 准备环境
+
+### 硬件与系统
+
+- 搭载全志 A733 的 Cubie 开发板（推荐 Cubie A7A）
+- 已写入 Radxa OS，并能 SSH 登录
+- 耳机接到板载 3.5 mm 口（不要走 HDMI 声卡）
+
+### NPU 运行库
+
+将 Model Zoo 中 `common/npuruntime/lib_linux_aarch64/A733` 目录的库拷到板端 `~/lib`，并加入动态库搜索路径。若已在其它 NPU 示例中配置过，可跳过。
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+echo 'export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+source ~/.bashrc
+sudo chmod 777 /dev/vipcore
+```
+
+</NewCodeBlock>
+
+NPU 识别默认调用 [Zipformer](./model-zoo/zipformer) 安装目录 `~/npu_demos/zipformer_demo_linux_a733`。请先按该文档编译并部署 A733 版本，且 `./zipformer_demo_a733 -h` 中应包含 `--stdin`（助手按帧喂音频）。
+
+## 获取示例
+
+在板端克隆仓库到 `~/npu_demos/voice_assistant`：
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+mkdir -p ~/npu_demos
+git clone https://github.com/Ronin-1124/cubie-a7a-voice-assistant.git ~/npu_demos/voice_assistant
+cd ~/npu_demos/voice_assistant
+```
+
+</NewCodeBlock>
+
+安装 Python 依赖：
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+pip3 install --user -r requirements.txt
+```
+
+</NewCodeBlock>
+
+`requirements.txt` 中为 `numpy` 和 `onnxruntime`。
+
+## 准备模型
+
+ONNX 体积较大，不在 git 中。在仓库根目录下载 TTS 声学模型（Matcha-baker）：
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+bash scripts/download_models.sh
+```
+
+</NewCodeBlock>
+
+仓库 `prebuilt/` 里是已经转好的 A733 NBG：
+
+| 路径                                     | 用途                                          |
+| ---------------------------------------- | --------------------------------------------- |
+| `prebuilt/kws/encoder_float_a733.nb` 等  | 唤醒 NPU（float 三件套；不要用 int16 joiner） |
+| `prebuilt/vocoder/vocoder_int16_a733.nb` | TTS 声码器（int16；不要用 uint8）             |
+
+将唤醒 NBG 放到助手默认搜索的目录：
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+mkdir -p ~/npu_demos/kws_npu_demo/model
+cp prebuilt/kws/*.nb prebuilt/kws/tokens.txt ~/npu_demos/kws_npu_demo/model/
+```
+
+</NewCodeBlock>
+
+NPU 唤醒还需要可执行文件 `kws_npu_demo_a733`，源码在仓库 `convert/kws/`。编译后与 VIPLite 库一起放到 `~/npu_demos/kws_npu_demo/`。
+
+TTS NPU 声码器会被复制到 `models/tts/vocoder_int16_a733.nb`。
+
+## 运行示例
+
+NPU 唤醒 + NPU 识别 + Matcha NPU 声码器。先用仓库自带的 16 kHz wav 验证软件，不必对着麦克风喊。
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd ~/npu_demos/voice_assistant
+python3 assistant_fast.py --from-wav samples/pipe_nihao_xiaorui_openlight_16k.wav
+```
+
+</NewCodeBlock>
+
+运行结果如下：
+
+```bash
+$ python3 assistant_fast.py --from-wav samples/pipe_nihao_xiaorui_openlight_16k.wav
+[09:45:53] wav 1 file(s) 6.6s
+[09:45:53] kws=npu asr=npu tts=npu  ready 0.1s
+[09:45:53] listening…
+[09:45:53] WAKE 你好小瑞
+[09:46:01] TEXT 帮我打开灯  8.4s
+[09:46:17] TTS 15.3s
+```
+
+麦克风实时运行：
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+python3 assistant_fast.py
+```
+
+</NewCodeBlock>
+
+| 需求              | 参数                              |
+| ----------------- | --------------------------------- |
+| 不播报            | `--no-tts`                        |
+| 离线 wav 测整条链 | `--from-wav <wake.wav> <cmd.wav>` |
+
+单独合成：
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+python3 tools/matcha_npu.py --text "识别完成" --play
+```
+
+</NewCodeBlock>
+
+默认唤醒词在 `keywords_wake.txt`：「你好小瑞」「小瑞小瑞」「小瑞」。没有单独的「你好」，以免短词误唤醒。
+
+## 麦克风和播放
+
+Cubie A7A **没有板载麦克风**。音频输入是 3.5 mm 四段插孔的耳机麦（原理图 HS-MIC → codec **MIC4**）。听筒走同一插孔的 HPOUT。
+
+先确认声卡，使用名称含 `sunxi-ac101b` 的设备，不要用 `allwinner-hdmi`。当前镜像上耳机编解码器通常是 **card 0**，HDMI 是 card 1。
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+aplay -l
+arecord -l
+```
+
+</NewCodeBlock>
+
+插好**四段带麦**耳机，对着**耳机咪头**说话（咪头常在右耳罩上）。I2S 上麦能量可能在左槽，和耳罩左右不是一回事。TTS 合成结果是单声道，助手会复制到左右耳再播放。
+
+不要用会把麦克风实时送回耳机的网页（例如 mictest.com）来调音：咪头贴着喇叭会啸叫，音量可能突然变得很大。
+
+现场喊麦不稳定时，优先用上面的 `--from-wav` 验证软件。详情见示例仓库 `docs/AUDIO_耳机与麦克风.md`。

--- a/docs/cubie/a5e/app-dev/npu-dev/model-zoo/clip.md
+++ b/docs/cubie/a5e/app-dev/npu-dev/model-zoo/clip.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 26
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-clip.mdx
+---
+
+# CLIP
+
+import CLIP from '../../../../../common/ai/cubie/\_model-zoo-clip.mdx';
+
+<CLIP />

--- a/docs/cubie/a5e/app-dev/npu-dev/model-zoo/lite-transformer.md
+++ b/docs/cubie/a5e/app-dev/npu-dev/model-zoo/lite-transformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 28
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lite-transformer.mdx
+---
+
+# Lite Transformer
+
+import LiteTransformer from '../../../../../common/ai/cubie/\_model-zoo-lite-transformer.mdx';
+
+<LiteTransformer />

--- a/docs/cubie/a5e/app-dev/npu-dev/model-zoo/lstm.md
+++ b/docs/cubie/a5e/app-dev/npu-dev/model-zoo/lstm.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 29
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lstm.mdx
+---
+
+# LSTM
+
+import LSTM from '../../../../../common/ai/cubie/\_model-zoo-lstm.mdx';
+
+<LSTM />

--- a/docs/cubie/a5e/app-dev/npu-dev/model-zoo/zipformer.md
+++ b/docs/cubie/a5e/app-dev/npu-dev/model-zoo/zipformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 27
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-zipformer.mdx
+---
+
+# Zipformer
+
+import Zipformer from '../../../../../common/ai/cubie/\_model-zoo-zipformer.mdx';
+
+<Zipformer />

--- a/docs/cubie/a7a/app-dev/npu-dev/model-zoo/clip.md
+++ b/docs/cubie/a7a/app-dev/npu-dev/model-zoo/clip.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 26
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-clip.mdx
+---
+
+# CLIP
+
+import CLIP from '../../../../../common/ai/cubie/\_model-zoo-clip.mdx';
+
+<CLIP />

--- a/docs/cubie/a7a/app-dev/npu-dev/model-zoo/lite-transformer.md
+++ b/docs/cubie/a7a/app-dev/npu-dev/model-zoo/lite-transformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 28
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lite-transformer.mdx
+---
+
+# Lite Transformer
+
+import LiteTransformer from '../../../../../common/ai/cubie/\_model-zoo-lite-transformer.mdx';
+
+<LiteTransformer />

--- a/docs/cubie/a7a/app-dev/npu-dev/model-zoo/lstm.md
+++ b/docs/cubie/a7a/app-dev/npu-dev/model-zoo/lstm.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 29
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lstm.mdx
+---
+
+# LSTM
+
+import LSTM from '../../../../../common/ai/cubie/\_model-zoo-lstm.mdx';
+
+<LSTM />

--- a/docs/cubie/a7a/app-dev/npu-dev/model-zoo/zipformer.md
+++ b/docs/cubie/a7a/app-dev/npu-dev/model-zoo/zipformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 27
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-zipformer.mdx
+---
+
+# Zipformer
+
+import Zipformer from '../../../../../common/ai/cubie/\_model-zoo-zipformer.mdx';
+
+<Zipformer />

--- a/docs/cubie/a7a/app-dev/npu-dev/voice-assistant.md
+++ b/docs/cubie/a7a/app-dev/npu-dev/voice-assistant.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 12
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_voice-assistant.mdx
+---
+
+# 离线语音助手
+
+import VoiceAssistant from '../../../../common/ai/cubie/\_voice-assistant.mdx';
+
+<VoiceAssistant />

--- a/docs/cubie/a7s/app-dev/npu-dev/model-zoo/clip.md
+++ b/docs/cubie/a7s/app-dev/npu-dev/model-zoo/clip.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 26
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-clip.mdx
+---
+
+# CLIP
+
+import CLIP from '../../../../../common/ai/cubie/\_model-zoo-clip.mdx';
+
+<CLIP />

--- a/docs/cubie/a7s/app-dev/npu-dev/model-zoo/lite-transformer.md
+++ b/docs/cubie/a7s/app-dev/npu-dev/model-zoo/lite-transformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 28
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lite-transformer.mdx
+---
+
+# Lite Transformer
+
+import LiteTransformer from '../../../../../common/ai/cubie/\_model-zoo-lite-transformer.mdx';
+
+<LiteTransformer />

--- a/docs/cubie/a7s/app-dev/npu-dev/model-zoo/lstm.md
+++ b/docs/cubie/a7s/app-dev/npu-dev/model-zoo/lstm.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 29
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lstm.mdx
+---
+
+# LSTM
+
+import LSTM from '../../../../../common/ai/cubie/\_model-zoo-lstm.mdx';
+
+<LSTM />

--- a/docs/cubie/a7s/app-dev/npu-dev/model-zoo/zipformer.md
+++ b/docs/cubie/a7s/app-dev/npu-dev/model-zoo/zipformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 27
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-zipformer.mdx
+---
+
+# Zipformer
+
+import Zipformer from '../../../../../common/ai/cubie/\_model-zoo-zipformer.mdx';
+
+<Zipformer />

--- a/docs/cubie/a7s/app-dev/npu-dev/voice-assistant.md
+++ b/docs/cubie/a7s/app-dev/npu-dev/voice-assistant.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 12
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_voice-assistant.mdx
+---
+
+# 离线语音助手
+
+import VoiceAssistant from '../../../../common/ai/cubie/\_voice-assistant.mdx';
+
+<VoiceAssistant />

--- a/docs/cubie/a7z/app-dev/npu-dev/model-zoo/clip.md
+++ b/docs/cubie/a7z/app-dev/npu-dev/model-zoo/clip.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 26
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-clip.mdx
+---
+
+# CLIP
+
+import CLIP from '../../../../../common/ai/cubie/\_model-zoo-clip.mdx';
+
+<CLIP />

--- a/docs/cubie/a7z/app-dev/npu-dev/model-zoo/lite-transformer.md
+++ b/docs/cubie/a7z/app-dev/npu-dev/model-zoo/lite-transformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 28
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lite-transformer.mdx
+---
+
+# Lite Transformer
+
+import LiteTransformer from '../../../../../common/ai/cubie/\_model-zoo-lite-transformer.mdx';
+
+<LiteTransformer />

--- a/docs/cubie/a7z/app-dev/npu-dev/model-zoo/lstm.md
+++ b/docs/cubie/a7z/app-dev/npu-dev/model-zoo/lstm.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 29
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lstm.mdx
+---
+
+# LSTM
+
+import LSTM from '../../../../../common/ai/cubie/\_model-zoo-lstm.mdx';
+
+<LSTM />

--- a/docs/cubie/a7z/app-dev/npu-dev/model-zoo/zipformer.md
+++ b/docs/cubie/a7z/app-dev/npu-dev/model-zoo/zipformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 27
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-zipformer.mdx
+---
+
+# Zipformer
+
+import Zipformer from '../../../../../common/ai/cubie/\_model-zoo-zipformer.mdx';
+
+<Zipformer />

--- a/docs/cubie/a7z/app-dev/npu-dev/voice-assistant.md
+++ b/docs/cubie/a7z/app-dev/npu-dev/voice-assistant.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 12
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_voice-assistant.mdx
+---
+
+# 离线语音助手
+
+import VoiceAssistant from '../../../../common/ai/cubie/\_voice-assistant.mdx';
+
+<VoiceAssistant />

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_cubie_acuity_env.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/_cubie_acuity_env.mdx
@@ -92,8 +92,8 @@ unzip docker_images_v1.8.x.zip
 
 ```bash
 cd docker_images_v2.0.x
-unzip ubuntu-npu_v2.0.10.1.tar.zip
-sudo docker load -i ubuntu-npu_v2.0.10.1.tar
+unzip ubuntu-npu_v2.0.10.2.tar.zip
+sudo docker load -i ubuntu-npu_v2.0.10.2.tar
 ```
 
 </NewCodeBlock>
@@ -103,15 +103,15 @@ sudo docker load -i ubuntu-npu_v2.0.10.1.tar
 
 ```bash
 cd docker_images_v1.8.x
-unzip ubuntu-npu_v1.8.11.tar.zip
-sudo docker load -i ubuntu-npu_v1.8.11.tar
+unzip ubuntu-npu_v1.8.13.tar.zip
+sudo docker load -i ubuntu-npu_v1.8.13.tar
 ```
 
 </NewCodeBlock>
 </TabItem>
 </Tabs>
 
-After the Docker image is loaded, you can see it with `docker images`. The image name is `ubuntu‑npu:v2.0.10.1` (A733) or `ubuntu-npu:v1.8.11` (T527).
+After the Docker image is loaded, you can see it with `docker images`. The image name is `ubuntu‑npu:v2.0.10.2` (A733) or `ubuntu-npu:v1.8.13` (T527).
 
 ### Create a Docker Container
 
@@ -121,7 +121,7 @@ After the Docker image is loaded, you can see it with `docker images`. The image
 
 ```bash
 mkdir docker_data && cd docker_data
-sudo docker run --ipc=host -itd -v ${PWD}:/workspace --name allwinner_v2.0.10.1 ubuntu-npu:v2.0.10.1 /bin/bash
+sudo docker run --ipc=host -itd -v ${PWD}:/workspace --name allwinner_v2.0.10.2 ubuntu-npu:v2.0.10.2 /bin/bash
 ```
 
 </NewCodeBlock>
@@ -131,14 +131,14 @@ sudo docker run --ipc=host -itd -v ${PWD}:/workspace --name allwinner_v2.0.10.1 
 
 ```bash
 mkdir docker_data && cd docker_data
-sudo docker run --ipc=host -itd -v ${PWD}:/workspace --name allwinner_v1.8.11 ubuntu-npu:v1.8.11 /bin/bash
+sudo docker run --ipc=host -itd -v ${PWD}:/workspace --name allwinner_v1.8.13 ubuntu-npu:v1.8.13 /bin/bash
 ```
 
 </NewCodeBlock>
 </TabItem>
 </Tabs>
 
-After the Docker container is created, you can see it with `docker ps -a`. The container name is `allwinner_v2.0.10.1` (A733) or `allwinner_v1.8.11` (T527).
+After the Docker container is created, you can see it with `docker ps -a`. The container name is `allwinner_v2.0.10.2` (A733) or `allwinner_v1.8.13` (T527).
 
 ### Enter the Docker Container
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-clip.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-clip.mdx
@@ -1,0 +1,330 @@
+This document describes how to run CLIP on the NPU.
+
+:::info
+Refer to [Model Zoo Download](./model-zoo-download) for the example.
+:::
+
+The CLIP example converts the image model and the text model separately, then computes image-text similarity on the board.
+
+CLIP example directory structure:
+
+```bash
+$ tree ./
+./
+├── CMakeLists.txt
+├── images_convert_model
+├── text_convert_model
+│   └── python
+├── model
+│   ├── clip-images_uint8_a733.nb
+│   ├── clip-text_int16_a733.nb
+│   ├── demo.png
+│   ├── demo.txt
+│   └── merges.txt
+├── main.cpp
+└── README.md
+```
+
+## Model Conversion
+
+Enter the container development environment first. See [Create and Start Container](./model-zoo-download#create-and-start-container) in the Model Zoo download page.
+
+:::info
+Select the Docker image that matches the NPU:
+
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
+  :::
+
+Download the floating-point ONNX models from the Allwinner netdisk:
+
+- clip-images: [http://netstorage.allwinnertech.com:5000/sharing/DPFhNJzGl](http://netstorage.allwinnertech.com:5000/sharing/DPFhNJzGl)
+- clip-text: [http://netstorage.allwinnertech.com:5000/sharing/neeTHfl6P](http://netstorage.allwinnertech.com:5000/sharing/neeTHfl6P)
+
+Put `clip-images.onnx` in `images_convert_model` and `clip-text.onnx` in `text_convert_model`.
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+docker exec -it model-zoo /bin/bash
+```
+
+</NewCodeBlock>
+
+### Convert clip-images
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/clip/images_convert_model/
+./convert_model_env.sh
+./pegasus_import.sh clip-images
+./pegasus_quantize.sh clip-images uint8 10
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh clip-images uint8 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh clip-images uint8 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+### Convert clip-text
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/clip/text_convert_model/
+./convert_model_env.sh
+./pegasus_import.sh clip-text
+./pegasus_quantize.sh clip-text int16 10
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh clip-text int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh clip-text int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+The exported models are stored in the `../model` directory.
+
+### Build the Example
+
+Then compile the example. **Exit the container first**, then run the commands below.
+
+Configure the third-party library and the cross-compilation toolchain first.
+
+:::info
+Skip this step if you have already configured them in another example.
+:::
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd ../../../3rdparty/opencv/
+unzip opencv-4.9.0-aarch64-linux-sunxi-glibc.zip
+cd ../../0-toolchains/
+```
+
+</NewCodeBlock>
+
+Download the toolchain from this [link](http://netstorage.allwinnertech.com:5000/sharing/e2nD8YwB4), put it in `0-toolchains/`, then run:
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+tar -xvf gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+cd ../examples/clip/
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t a733 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t t527 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+## Model Deployment
+
+After compilation, the example will be installed in the install directory. You can use scp to transfer it to the board.
+
+### Configure NPU Driver
+
+:::info
+You can skip this step if you have already configured NPU driver in other examples.
+:::
+
+Transfer the driver library to the board's lib directory via scp.
+
+- A733 corresponds to the common/npuruntime/lib_linux_aarch64/A733 directory
+- T527 corresponds to the common/npuruntime/lib_linux_aarch64/T527 directory
+
+Then execute the following command to export to environment variables.
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+echo 'export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+```
+
+</NewCodeBlock>
+
+### Run Example
+
+After configuring the driver, you can run the example.
+
+:::tip
+For T527 platform, you need to first enable NPU by referring to the A5E's "Enable NPU on Board" documentation, then use the following command to grant the current user permission to use /dev/vipcore.
+:::
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+sudo chmod 777 /dev/vipcore
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd clip_demo_linux_a733/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./clip_demo_a733
+./clip_demo_a733 -ib model/clip-images_uint8_a733.nb -tb model/clip-text_int16_a733.nb -i model/demo.png -t model/demo.txt
+```
+
+</NewCodeBlock>
+
+The running result is as follows:
+
+```bash
+$ ./clip_demo_a733 -ib model/clip-images_uint8_a733.nb -tb model/clip-text_int16_a733.nb -i model/demo.png -t model/demo.txt
+text_model_file=model/clip-text_int16_a733.nb, images_model_file=model/clip-images_uint8_a733.nb, input_images_file=model/demo.png, input_text_file=model/demo.txt, loop_count=1, malloc_mbyte=10
+VIPLite driver software version 2.0.3.2-AW-2024-08-30
+nbg name=model/clip-images_uint8_a733.nb, size: 63747488.
+create network 0: 34340 us.
+nbg name=model/clip-text_int16_a733.nb, size: 115039816.
+create network 1: 60155 us.
+prepare network: 2633 us.
+prepare network: 1587 us.
+images: model/demo.png
+text  : a photo of a motorcycle
+score : 0.998
+clip-text total infer time: 35368 us.
+clip-images total infer time: 13695 us.
+destroy npu finished.
+~NpuUint.
+```
+
+This performance data only calculates the time consumption of model inference. Unless otherwise specified, it does not include the time consumption of pre-processing and post-processing.
+
+| SoC            | NPU             | Model       | Input Resolution | Network Creation Time | Network Preparation Time | Single Frame Inference Time | Post-processing Time | Total Time | Frame Rate |
+| :------------- | :-------------- | :---------- | :--------------- | :-------------------- | :----------------------- | :-------------------------- | :------------------- | :--------- | :--------- |
+| Allwinner A733 | Vivante VIP9000 | clip-images | 224×224          | 34.3 ms               | 2.6 ms                   | 13.7 ms                     |                      | 50.6 ms    | 73.0 FPS   |
+| Allwinner A733 | Vivante VIP9000 | clip-text   | 1×20             | 60.2 ms               | 1.6 ms                   | 35.4 ms                     |                      | 97.2 ms    | 28.3 FPS   |
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd clip_demo_linux_t527/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./clip_demo_t527
+./clip_demo_t527 -ib model/clip-images_uint8_t527.nb -tb model/clip-text_int16_t527.nb -i model/demo.png -t model/demo.txt
+```
+
+</NewCodeBlock>
+
+The running result is as follows:
+
+```bash
+$ ./clip_demo_t527 -ib model/clip-images_uint8_t527.nb -tb model/clip-text_int16_t527.nb -i model/demo.png -t model/demo.txt
+text_model_file=model/clip-text_int16_t527.nb, images_model_file=model/clip-images_uint8_t527.nb, input_images_file=model/demo.png, input_text_file=model/demo.txt, loop_count=1, malloc_mbyte=10
+VIPLite driver software version 1.13.0.0-AW-2023-10-19
+nbg name=model/clip-images_uint8_t527.nb, size: 64787840.
+create network 0: 74736 us.
+nbg name=model/clip-text_int16_t527.nb, size: 114667200.
+create network 1: 131392 us.
+prepare network: 8988 us.
+prepare network: 12743 us.
+clip-text total infer time: 113006 us.
+images: model/demo.png
+text  : a photo of a motorcycle
+score : 0.997
+clip-images total infer time: 78735 us.
+destroy npu finished.
+~NpuUint.
+```
+
+This performance data only calculates the time consumption of model inference. Unless otherwise specified, it does not include the time consumption of pre-processing and post-processing.
+
+| SoC            | NPU             | Model       | Input Resolution | Network Creation Time | Network Preparation Time | Single Frame Inference Time | Post-processing Time | Total Time | Frame Rate |
+| :------------- | :-------------- | :---------- | :--------------- | :-------------------- | :----------------------- | :-------------------------- | :------------------- | :--------- | :--------- |
+| Allwinner T527 | Vivante VIP9000 | clip-images | 224×224          | 74.7 ms               | 9.0 ms                   | 78.7 ms                     |                      | 162.4 ms   | 12.7 FPS   |
+| Allwinner T527 | Vivante VIP9000 | clip-text   | 1×20             | 131.4 ms              | 12.7 ms                  | 113.0 ms                    |                      | 257.1 ms   | 8.8 FPS    |
+
+</TabItem>
+</Tabs>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-densenet121-keras.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-densenet121-keras.mdx
@@ -47,8 +47,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-download.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-download.mdx
@@ -8,7 +8,7 @@ After successfully registering and logging in, you will enter the dashboard inte
 
 ![Click Resource Download](/img/cubie/allwinnertech-model-zoo-download-guide1.webp)
 
-Click AI Development SDK under Tool Query on the left sidebar, then find the v0.9.0 version of Model Zoo and download it to your local machine.
+Click AI Development SDK under Tool Query on the left sidebar, then find the v1.0.0 version of Model Zoo and download it to your local machine.
 
 ![Download Model Zoo](/img/cubie/allwinnertech-model-zoo-download-guide2.webp)
 
@@ -35,8 +35,8 @@ After downloading both the container development package and Model Zoo, you can 
 <NewCodeBlock tip="X86 Linux PC" type="PC">
 
 ```bash
-tar -xvf 1768567762439_awnpu_model_zoo-v0.9.0-20260116-83a67d4b.tar.gz
-cd awnpu_model_zoo-v0.9.0-20260116-83a67d4b/
+tar -xvf 1776931919742_awnpu_model_zoo-v1.0.0-20260423-f562dd16.tar.gz
+cd awnpu_model_zoo-v1.0.0-20260423-f562dd16/
 ```
 
 </NewCodeBlock>
@@ -49,7 +49,7 @@ cd awnpu_model_zoo-v0.9.0-20260116-83a67d4b/
 <NewCodeBlock tip="X86 Linux PC" type="PC">
 
 ```bash
-sudo docker run --ipc=host -d -v ${PWD}:/workspace --name model-zoo ubuntu-npu:v2.0.10.1 tail -f /dev/null
+sudo docker run --ipc=host -d -v ${PWD}:/workspace --name model-zoo ubuntu-npu:v2.0.10.2 tail -f /dev/null
 ```
 
 </NewCodeBlock>
@@ -61,7 +61,7 @@ sudo docker run --ipc=host -d -v ${PWD}:/workspace --name model-zoo ubuntu-npu:v
 <NewCodeBlock tip="X86 Linux PC" type="PC">
 
 ```bash
-sudo docker run --ipc=host -d -v ${PWD}:/workspace --name model-zoo ubuntu-npu:v1.8.11 tail -f /dev/null
+sudo docker run --ipc=host -d -v ${PWD}:/workspace --name model-zoo ubuntu-npu:v1.8.13 tail -f /dev/null
 ```
 
 </NewCodeBlock>
@@ -96,17 +96,17 @@ You can see the Model Zoo directory structure:
 
 ```bash
 /workspace# ls -al
-total 52
-drwxr-xr-x 10 1000 1000 4096 Apr  2 19:09 .
-drwxr-xr-x  9 root root 4096 Apr  2 18:48 ..
-drwxr-xr-x 10 1000 1000 4096 Jan 16 20:44 0-toolchains              # Cross-compilation toolchain
-drwxr-xr-x  3 1000 1000 4096 Jan 16 20:44 3rdparty                  # Third-party toolchain
--rwxr-xr-x  1 1000 1000 4976 Jan 16 20:44 README.md                 # README document
-drwxr-xr-x  2 1000 1000 4096 Apr  3 12:06 cmake_toolchain           # Compilation toolchain configuration
-drwxr-xr-x  3 1000 1000 4096 Jan 16 20:44 common                    # Common library
-drwxr-xr-x  3 1000 1000 4096 Jan 16 20:44 docs                      # Documentation
-drwxr-xr-x 26 1000 1000 4096 Jan 16 20:44 examples                  # Example directory
-drwxr-xr-x  6 1000 1000 4096 Jan 16 20:44 functions                 # Special features
-drwxr-xr-x  2 1000 1000 4096 Jan 16 20:44 scripts_model_convert     # Conversion scripts
--rwxr-xr-x  1 1000 1000    6 Jan 16 20:44 version                   # Version number
+total 56
+drwxrwxr-x 10 1000 1000 4096 Aug  6 12:05 .
+-rw-rw-r--  1 1000 1000   10 Apr 23 15:56 .gitignore
+drwxrwxr-x  3 1000 1000 4096 Aug  3 11:33 0-toolchains              # Cross-compilation toolchain
+drwxrwxr-x  4 1000 1000 4096 Apr 23 15:56 3rdparty                  # Third-party toolchain
+-rwxrwxr-x  1 1000 1000 5095 Apr 23 15:56 README.md                 # README document
+drwxrwxr-x  2 1000 1000 4096 Apr 23 15:56 cmake_toolchain           # Compilation toolchain configuration
+drwxrwxr-x  3 1000 1000 4096 Apr 23 15:56 common                    # Common library
+drwxrwxr-x  2 1000 1000 4096 Apr 23 15:56 docs                      # Documentation
+drwxrwxr-x 41 1000 1000 4096 Aug 20 18:11 examples                  # Example directory
+drwxrwxr-x  6 1000 1000 4096 Apr 23 15:56 functions                 # Special features
+drwxrwxr-x  3 1000 1000 4096 Aug  3 15:41 scripts_model_convert     # Conversion scripts
+-rwxrwxr-x  1 1000 1000    6 Apr 23 15:56 version                   # Version number
 ```

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-lenet-caffe.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-lenet-caffe.mdx
@@ -50,8 +50,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-lite-transformer.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-lite-transformer.mdx
@@ -1,0 +1,329 @@
+This document describes how to run the Lite Transformer English-to-Chinese example on the NPU.
+
+:::info
+Refer to [Model Zoo Download](./model-zoo-download) for the example.
+:::
+
+Lite Transformer uses encoder and decoder sub-models.
+
+Lite Transformer example directory structure:
+
+```bash
+$ tree ./
+./
+├── CMakeLists.txt
+├── convert_model_decoder
+├── convert_model_encoder
+├── include
+├── model
+│   ├── bpe_order.txt
+│   ├── cw_token_map_order.txt
+│   ├── dict_order.txt
+│   ├── lite_transformer_decoder_16_int16_a733.nb
+│   ├── lite_transformer_encoder_16_int16_a733.nb
+│   ├── position_embed.bin
+│   └── token_embed.bin
+├── src
+└── README.md
+```
+
+## Model Conversion
+
+Enter the container development environment first. See [Create and Start Container](./model-zoo-download#create-and-start-container) in the Model Zoo download page.
+
+:::info
+Select the Docker image that matches the NPU:
+
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
+  :::
+
+Download the floating-point ONNX models from the Allwinner netdisk:
+
+- encoder: [http://netstorage.allwinnertech.com:5000/sharing/48BkHmEFh](http://netstorage.allwinnertech.com:5000/sharing/48BkHmEFh)
+- decoder: [http://netstorage.allwinnertech.com:5000/sharing/QHfBh3imH](http://netstorage.allwinnertech.com:5000/sharing/QHfBh3imH)
+- BPE / dictionary files: [http://netstorage.allwinnertech.com:5000/sharing/ctkG9jW4t](http://netstorage.allwinnertech.com:5000/sharing/ctkG9jW4t)
+
+Extract the BPE and dictionary files into the `lite_transformer` directory.
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+docker exec -it model-zoo /bin/bash
+```
+
+</NewCodeBlock>
+
+### Convert encoder
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/lite_transformer/convert_model_encoder/
+./convert_model_env.sh
+./pegasus_import.sh lite_transformer_encoder_16
+./pegasus_quantize.sh lite_transformer_encoder_16 int16 2
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lite_transformer_encoder_16 int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lite_transformer_encoder_16 int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+### Convert decoder
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/lite_transformer/convert_model_decoder/
+./convert_model_env.sh
+./pegasus_import.sh lite_transformer_decoder_16
+./pegasus_quantize.sh lite_transformer_decoder_16 int16 4
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lite_transformer_decoder_16 int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lite_transformer_decoder_16 int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+The exported models are stored in the `../model` directory.
+
+### Build the Example
+
+Then compile the example. **Exit the container first**, then run the commands below.
+
+Configure the cross-compilation toolchain first.
+
+:::info
+Skip this step if you have already configured it in another example.
+:::
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd ../../../0-toolchains/
+```
+
+</NewCodeBlock>
+
+Download the toolchain from this [link](http://netstorage.allwinnertech.com:5000/sharing/e2nD8YwB4), put it in `0-toolchains/`, then run:
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+tar -xvf gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+cd ../examples/lite_transformer/
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t a733 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t t527 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+## Model Deployment
+
+After compilation, the example will be installed in the install directory. You can use scp to transfer it to the board.
+
+### Configure NPU Driver
+
+:::info
+You can skip this step if you have already configured NPU driver in other examples.
+:::
+
+Transfer the driver library to the board's lib directory via scp.
+
+- A733 corresponds to the common/npuruntime/lib_linux_aarch64/A733 directory
+- T527 corresponds to the common/npuruntime/lib_linux_aarch64/T527 directory
+
+Then execute the following command to export to environment variables.
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+echo 'export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+```
+
+</NewCodeBlock>
+
+### Run Example
+
+After configuring the driver, you can run the example.
+
+:::tip
+For T527 platform, you need to first enable NPU by referring to the A5E's "Enable NPU on Board" documentation, then use the following command to grant the current user permission to use /dev/vipcore.
+:::
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+sudo chmod 777 /dev/vipcore
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd lite_transformer_demo_linux_a733/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./lite_transformer_demo_a733
+./lite_transformer_demo_a733 -nb0 model/lite_transformer_encoder_16_int16_a733.nb -nb1 model/lite_transformer_decoder_16_int16_a733.nb -i "so big"
+```
+
+</NewCodeBlock>
+
+The running result is as follows:
+
+```bash
+$ ./lite_transformer_demo_a733 -nb0 model/lite_transformer_encoder_16_int16_a733.nb -nb1 model/lite_transformer_decoder_16_int16_a733.nb -i "so big"
+encoder_path=model/lite_transformer_encoder_16_int16_a733.nb, decoder_path=model/lite_transformer_decoder_16_int16_a733.nb, input_strings=so big
+VIPLite driver software version 2.0.3.2-AW-2024-08-30
+nbg name=model/lite_transformer_encoder_16_int16_a733.nb, size: 3838272.
+create network 0: 2533 us.
+prepare network: 442 us.
+nbg name=model/lite_transformer_decoder_16_int16_a733.nb, size: 19421952.
+create network 1: 11027 us.
+prepare network: 406 us.
+
+input sentence:so big
+output token: 2 83 139 676 84 2
+output_strings: 如此巨大
+inference time: 24.000 ms
+destroy npu finished.
+~NpuUint.
+```
+
+This performance data only calculates the time consumption of model inference. Unless otherwise specified, it does not include the time consumption of pre-processing and post-processing.
+
+| SoC            | NPU             | Model            | Input Resolution | Network Creation Time | Network Preparation Time | Single Frame Inference Time | Post-processing Time | Total Time | Frame Rate |
+| :------------- | :-------------- | :--------------- | :--------------- | :-------------------- | :----------------------- | :-------------------------- | :------------------- | :--------- | :--------- |
+| Allwinner A733 | Vivante VIP9000 | lite-transformer | 16 tokens        | 13.6 ms               | 0.8 ms                   | 24.0 ms                     |                      | 38.4 ms    | 41.7 FPS   |
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd lite_transformer_demo_linux_t527/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./lite_transformer_demo_t527
+./lite_transformer_demo_t527 -nb0 model/lite_transformer_encoder_16_int16_t527.nb -nb1 model/lite_transformer_decoder_16_int16_t527.nb -i "so big"
+```
+
+</NewCodeBlock>
+
+The running result is as follows:
+
+```bash
+$ ./lite_transformer_demo_t527 -nb0 model/lite_transformer_encoder_16_int16_t527.nb -nb1 model/lite_transformer_decoder_16_int16_t527.nb -i "so big"
+encoder_path=model/lite_transformer_encoder_16_int16_t527.nb, decoder_path=model/lite_transformer_decoder_16_int16_t527.nb, input_strings=so big
+VIPLite driver software version 1.13.0.0-AW-2023-10-19
+nbg name=model/lite_transformer_encoder_16_int16_t527.nb, size: 3755712.
+create network 0: 5054 us.
+prepare network: 836 us.
+nbg name=model/lite_transformer_decoder_16_int16_t527.nb, size: 19121536.
+create network 1: 23573 us.
+prepare network: 2658 us.
+
+input sentence:so big
+output token: 2 83 139 676 84 2
+output_strings: 如此巨大
+inference time: 64.000 ms
+destroy npu finished.
+~NpuUint.
+```
+
+This performance data only calculates the time consumption of model inference. Unless otherwise specified, it does not include the time consumption of pre-processing and post-processing.
+
+| SoC            | NPU             | Model            | Input Resolution | Network Creation Time | Network Preparation Time | Single Frame Inference Time | Post-processing Time | Total Time | Frame Rate |
+| :------------- | :-------------- | :--------------- | :--------------- | :-------------------- | :----------------------- | :-------------------------- | :------------------- | :--------- | :--------- |
+| Allwinner T527 | Vivante VIP9000 | lite-transformer | 16 tokens        | 28.6 ms               | 3.5 ms                   | 64.0 ms                     |                      | 96.1 ms    | 15.6 FPS   |
+
+</TabItem>
+</Tabs>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-lstm.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-lstm.mdx
@@ -1,0 +1,262 @@
+This document describes how to run the LSTM example on the NPU.
+
+:::info
+Refer to [Model Zoo Download](./model-zoo-download) for the example.
+:::
+
+LSTM example directory structure:
+
+```bash
+$ tree ./
+./
+├── CMakeLists.txt
+├── convert_model
+│   └── dataset
+├── main.cpp
+├── model
+│   ├── iter_0_c1_26_out0_1_1_128.tensor
+│   ├── iter_0_c2_28_out0_1_1_128.tensor
+│   ├── iter_0_h1_25_out0_1_1_128.tensor
+│   ├── iter_0_h2_27_out0_1_1_128.tensor
+│   ├── iter_0_input_24_out0_1_3_32_32.tensor
+│   └── lstm_model_uint8_a733.nb
+└── README.md
+```
+
+## Model Conversion
+
+Enter the container development environment first. See [Create and Start Container](./model-zoo-download#create-and-start-container) in the Model Zoo download page.
+
+:::info
+Select the Docker image that matches the NPU:
+
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
+  :::
+
+Download the floating-point ONNX model from the Allwinner netdisk: [http://netstorage.allwinnertech.com:5000/sharing/AmbdcCS7O](http://netstorage.allwinnertech.com:5000/sharing/AmbdcCS7O)
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+docker exec -it model-zoo /bin/bash
+cd /workspace/examples/lstm_model/convert_model/
+./convert_model_env.sh
+./pegasus_import.sh lstm_model
+./pegasus_quantize.sh lstm_model uint8 1
+export VIV_VX_ENABLE_WB_SHARE=1
+```
+
+</NewCodeBlock>
+
+`VIV_VX_ENABLE_WB_SHARE=1` enables LSTM / RNN internal weight sharing and reduces the exported nb file size.
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lstm_model uint8 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh lstm_model uint8 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+The exported model is stored in the `../model` directory.
+
+### Build the Example
+
+Then compile the example. **Exit the container first**, then run the commands below.
+
+Configure the cross-compilation toolchain first.
+
+:::info
+Skip this step if you have already configured it in another example.
+:::
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd ../../../0-toolchains/
+```
+
+</NewCodeBlock>
+
+Download the toolchain from this [link](http://netstorage.allwinnertech.com:5000/sharing/e2nD8YwB4), put it in `0-toolchains/`, then run:
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+tar -xvf gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+cd ../examples/lstm_model/
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t a733 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t t527 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+## Model Deployment
+
+After compilation, the example will be installed in the install directory. You can use scp to transfer it to the board.
+
+### Configure NPU Driver
+
+:::info
+You can skip this step if you have already configured NPU driver in other examples.
+:::
+
+Transfer the driver library to the board's lib directory via scp.
+
+- A733 corresponds to the common/npuruntime/lib_linux_aarch64/A733 directory
+- T527 corresponds to the common/npuruntime/lib_linux_aarch64/T527 directory
+
+Then execute the following command to export to environment variables.
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+echo 'export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+```
+
+</NewCodeBlock>
+
+### Run Example
+
+After configuring the driver, you can run the example.
+
+:::tip
+For T527 platform, you need to first enable NPU by referring to the A5E's "Enable NPU on Board" documentation, then use the following command to grant the current user permission to use /dev/vipcore.
+:::
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+sudo chmod 777 /dev/vipcore
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd lstm_demo_linux_a733/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./lstm_demo_a733
+./lstm_demo_a733 -nb model/lstm_model_uint8_a733.nb -i model/iter_0_input_24_out0_1_3_32_32.tensor,model/iter_0_h1_25_out0_1_1_128.tensor,model/iter_0_c1_26_out0_1_1_128.tensor,model/iter_0_h2_27_out0_1_1_128.tensor,model/iter_0_c2_28_out0_1_1_128.tensor -st 2
+```
+
+</NewCodeBlock>
+
+The running result is as follows:
+
+```bash
+$ ./lstm_demo_a733 -nb model/lstm_model_uint8_a733.nb -i model/iter_0_input_24_out0_1_3_32_32.tensor,model/iter_0_h1_25_out0_1_1_128.tensor,model/iter_0_c1_26_out0_1_1_128.tensor,model/iter_0_h2_27_out0_1_1_128.tensor,model/iter_0_c2_28_out0_1_1_128.tensor -st 2
+model_file=model/lstm_model_uint8_a733.nb
+VIPLite driver software version 2.0.3.2-AW-2024-08-30
+nbg name=model/lstm_model_uint8_a733.nb, size: 1068496.
+create network 0: 2785 us.
+prepare network: 742 us.
+network: 0, loop count: 1
+run time for this network 0: 1221 us.
+destroy npu finished.
+~NpuUint.
+```
+
+This performance data only calculates the time consumption of model inference. Unless otherwise specified, it does not include the time consumption of pre-processing and post-processing.
+
+| SoC            | NPU             | Model      | Input Resolution | Network Creation Time | Network Preparation Time | Single Frame Inference Time | Post-processing Time | Total Time | Frame Rate |
+| :------------- | :-------------- | :--------- | :--------------- | :-------------------- | :----------------------- | :-------------------------- | :------------------- | :--------- | :--------- |
+| Allwinner A733 | Vivante VIP9000 | lstm_model | 32×32            | 2.8 ms                | 0.7 ms                   | 1.2 ms                      |                      | 4.7 ms     | 819.0 FPS  |
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd lstm_demo_linux_t527/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./lstm_demo_t527
+./lstm_demo_t527 -nb model/lstm_model_uint8_t527.nb -i model/iter_0_input_24_out0_1_3_32_32.tensor,model/iter_0_h1_25_out0_1_1_128.tensor,model/iter_0_c1_26_out0_1_1_128.tensor,model/iter_0_h2_27_out0_1_1_128.tensor,model/iter_0_c2_28_out0_1_1_128.tensor -st 2
+```
+
+</NewCodeBlock>
+
+The running result is as follows:
+
+```bash
+$ ./lstm_demo_t527 -nb model/lstm_model_uint8_t527.nb -i model/iter_0_input_24_out0_1_3_32_32.tensor,model/iter_0_h1_25_out0_1_1_128.tensor,model/iter_0_c1_26_out0_1_1_128.tensor,model/iter_0_h2_27_out0_1_1_128.tensor,model/iter_0_c2_28_out0_1_1_128.tensor -st 2
+model_file=model/lstm_model_uint8_t527.nb
+VIPLite driver software version 1.13.0.0-AW-2023-10-19
+nbg name=model/lstm_model_uint8_t527.nb, size: 1864000.
+create network 0: 2375 us.
+prepare network: 235 us.
+network: 0, loop count: 1
+run time for this network 0: 790 us.
+destroy npu finished.
+~NpuUint.
+```
+
+This performance data only calculates the time consumption of model inference. Unless otherwise specified, it does not include the time consumption of pre-processing and post-processing.
+
+| SoC            | NPU             | Model      | Input Resolution | Network Creation Time | Network Preparation Time | Single Frame Inference Time | Post-processing Time | Total Time | Frame Rate |
+| :------------- | :-------------- | :--------- | :--------------- | :-------------------- | :----------------------- | :-------------------------- | :------------------- | :--------- | :--------- |
+| Allwinner T527 | Vivante VIP9000 | lstm_model | 32×32            | 2.4 ms                | 0.2 ms                   | 0.8 ms                      |                      | 3.4 ms     | 1265.8 FPS |
+
+</TabItem>
+</Tabs>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-mobilenetv1-tensorflow.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-mobilenetv1-tensorflow.mdx
@@ -49,8 +49,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-mobilenetv2.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-mobilenetv2.mdx
@@ -48,8 +48,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-ppseg.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-ppseg.mdx
@@ -52,8 +52,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-resnet50-tflite.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-resnet50-tflite.mdx
@@ -52,8 +52,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-resnet50v2.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-resnet50v2.mdx
@@ -48,8 +48,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-retinaface.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-retinaface.mdx
@@ -58,8 +58,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-squeezenet-pytorch.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-squeezenet-pytorch.mdx
@@ -49,8 +49,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolo11-pose.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolo11-pose.mdx
@@ -82,8 +82,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolo11-seg.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolo11-seg.mdx
@@ -82,8 +82,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolo11.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolo11.mdx
@@ -82,8 +82,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolo26.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolo26.mdx
@@ -85,8 +85,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolov3-darknet.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolov3-darknet.mdx
@@ -53,8 +53,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolov5.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolov5.mdx
@@ -56,8 +56,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolov8-pose.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolov8-pose.mdx
@@ -91,8 +91,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolov8-seg.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolov8-seg.mdx
@@ -92,8 +92,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolov8.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolov8.mdx
@@ -92,8 +92,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolox.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-yolox.mdx
@@ -79,8 +79,8 @@ You need to enter the container development environment first. Refer to the [Cre
 :::info
 Different platforms use corresponding Docker images:
 
-- A733: ubuntu-npu:v2.0.10.1
-- T527: ubuntu-npu:v1.8.11
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
   :::
 
 <NewCodeBlock tip="X86 Linux PC" type="PC">

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-zipformer.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_model-zoo-zipformer.mdx
@@ -1,0 +1,381 @@
+This document describes how to run the Zipformer ASR example on the NPU.
+
+:::info
+Refer to [Model Zoo Download](./model-zoo-download) for the example.
+:::
+
+Zipformer uses encoder, decoder, and joiner sub-models for automatic speech recognition.
+
+Zipformer example directory structure:
+
+```bash
+$ tree ./
+./
+├── CMakeLists.txt
+├── convert_model_decoder
+├── convert_model_encoder
+├── convert_model_joiner
+├── model
+│   ├── decoder_int16_a733.nb
+│   ├── encoder_int16_a733.nb
+│   ├── joiner_int16_a733.nb
+│   ├── test.wav
+│   └── tokens.txt
+└── README.md
+```
+
+## Model Conversion
+
+Enter the container development environment first. See [Create and Start Container](./model-zoo-download#create-and-start-container) in the Model Zoo download page.
+
+:::info
+Select the Docker image that matches the NPU:
+
+- A733: ubuntu-npu:v2.0.10.2
+- T527: ubuntu-npu:v1.8.13
+  :::
+
+Download the floating-point ONNX models from the Allwinner netdisk:
+
+- encoder: [http://netstorage.allwinnertech.com:5000/sharing/8WWXoUfoy](http://netstorage.allwinnertech.com:5000/sharing/8WWXoUfoy)
+- decoder: [http://netstorage.allwinnertech.com:5000/sharing/1km0Q1YgK](http://netstorage.allwinnertech.com:5000/sharing/1km0Q1YgK)
+- joiner: [http://netstorage.allwinnertech.com:5000/sharing/GUTAIo774](http://netstorage.allwinnertech.com:5000/sharing/GUTAIo774)
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+docker exec -it model-zoo /bin/bash
+```
+
+</NewCodeBlock>
+
+Set this environment variable before converting the encoder:
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+export VIV_VX_ENABLE_GRAPH_TRANSFORM="-Dump[transform.rewrite.gather_to_stride_slice=0]"
+```
+
+</NewCodeBlock>
+
+### Convert encoder
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/zipformer/convert_model_encoder/
+./convert_model_env.sh
+./pegasus_import.sh encoder
+./pegasus_quantize.sh encoder int16 10
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh encoder int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh encoder int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+### Convert decoder
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/zipformer/convert_model_decoder/
+./convert_model_env.sh
+./pegasus_import.sh decoder
+./pegasus_quantize.sh decoder int16 10
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh decoder int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh decoder int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+### Convert joiner
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd /workspace/examples/zipformer/convert_model_joiner/
+./convert_model_env.sh
+./pegasus_import.sh joiner
+./pegasus_quantize.sh joiner int16 10
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh joiner int16 a733
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+./pegasus_export_ovx_nbg.sh joiner int16 t527
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+The exported models are stored in the `../model` directory.
+
+### Build the Example
+
+Then compile the example. **Exit the container first**, then run the commands below.
+
+Configure the cross-compilation toolchain first.
+
+:::info
+Skip this step if you have already configured it in another example.
+:::
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+cd ../../../0-toolchains/
+```
+
+</NewCodeBlock>
+
+Download the toolchain from this [link](http://netstorage.allwinnertech.com:5000/sharing/e2nD8YwB4), put it in `0-toolchains/`, then run:
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+tar -xvf gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+cd ../examples/zipformer/
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t a733 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="X86 Linux PC" type="PC">
+
+```bash
+../build_linux.sh -t t527 -s debian11
+```
+
+</NewCodeBlock>
+
+</TabItem>
+</Tabs>
+
+## Model Deployment
+
+After compilation, the example will be installed in the install directory. You can use scp to transfer it to the board.
+
+### Configure NPU Driver
+
+:::info
+You can skip this step if you have already configured NPU driver in other examples.
+:::
+
+Transfer the driver library to the board's lib directory via scp.
+
+- A733 corresponds to the common/npuruntime/lib_linux_aarch64/A733 directory
+- T527 corresponds to the common/npuruntime/lib_linux_aarch64/T527 directory
+
+Then execute the following command to export to environment variables.
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+echo 'export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+```
+
+</NewCodeBlock>
+
+### Run Example
+
+After configuring the driver, you can run the example.
+
+:::tip
+For T527 platform, you need to first enable NPU by referring to the A5E's "Enable NPU on Board" documentation, then use the following command to grant the current user permission to use /dev/vipcore.
+:::
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+sudo chmod 777 /dev/vipcore
+```
+
+</NewCodeBlock>
+
+<Tabs groupId="npu-version">
+<TabItem value="A733" label="A733" defaultValue="A733">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd zipformer_demo_linux_a733/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./zipformer_demo_a733
+./zipformer_demo_a733 -nb0 model/encoder_int16_a733.nb -nb1 model/decoder_int16_a733.nb -nb2 model/joiner_int16_a733.nb -i model/test.wav
+```
+
+</NewCodeBlock>
+
+The running result is as follows:
+
+```bash
+$ ./zipformer_demo_a733 -nb0 model/encoder_int16_a733.nb -nb1 model/decoder_int16_a733.nb -nb2 model/joiner_int16_a733.nb -i model/test.wav
+encoder_path=model/encoder_int16_a733.nb, decoder_path=model/decoder_int16_a733.nb, joiner_path=model/joiner_int16_a733.nb, audio_path=model/test.wav
+VIPLite driver software version 2.0.3.2-AW-2024-08-30
+nbg name=model/encoder_int16_a733.nb, size: 37228136.
+create network 0: 25435 us.
+prepare network: 3858 us.
+nbg name=model/decoder_int16_a733.nb, size: 6973440.
+create network 1: 3971 us.
+prepare network: 244 us.
+nbg name=model/joiner_int16_a733.nb, size: 5509168.
+create network 2: 2820 us.
+prepare network: 56 us.
+
+Real Time Factor(RTF): 0.053 = 0.309s(infer_time) / 5.840s(audio_length)
+
+Timestamp (s): 0.96, 1.04, 1.24, 1.32, 1.44, 1.72, 1.80, 2.04, 2.56, 3.04, 3.08, 3.48, 3.84, 4.68, 4.76, 5.00, 5.24, 5.48
+
+Zipformer output: 这是第一种第二种叫呃嗯与 ALWAYS什么意思啊
+destroy npu finished.
+~NpuUint.
+```
+
+This performance data only calculates the time consumption of model inference. Unless otherwise specified, it does not include the time consumption of pre-processing and post-processing.
+
+| SoC            | NPU             | Model     | Input Resolution | Network Creation Time | Network Preparation Time | Single Frame Inference Time | Post-processing Time | Total Time | Frame Rate |
+| :------------- | :-------------- | :-------- | :--------------- | :-------------------- | :----------------------- | :-------------------------- | :------------------- | :--------- | :--------- |
+| Allwinner A733 | Vivante VIP9000 | zipformer | 5.84 s           | 32.2 ms               | 4.2 ms                   | 309.0 ms                    |                      | 345.4 ms   | RTF 0.053  |
+
+</TabItem>
+
+<TabItem value="T527" label="T527">
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd zipformer_demo_linux_t527/
+```
+
+</NewCodeBlock>
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+chmod +x ./zipformer_demo_t527
+./zipformer_demo_t527 -nb0 model/encoder_int16_t527.nb -nb1 model/decoder_int16_t527.nb -nb2 model/joiner_int16_t527.nb -i model/test.wav
+```
+
+</NewCodeBlock>
+
+The running result is as follows:
+
+```bash
+$ ./zipformer_demo_t527 -nb0 model/encoder_int16_t527.nb -nb1 model/decoder_int16_t527.nb -nb2 model/joiner_int16_t527.nb -i model/test.wav
+encoder_path=model/encoder_int16_t527.nb, decoder_path=model/decoder_int16_t527.nb, joiner_path=model/joiner_int16_t527.nb, audio_path=model/test.wav
+VIPLite driver software version 1.13.0.0-AW-2023-10-19
+nbg name=model/encoder_int16_t527.nb, size: 37232320.
+create network 0: 48424 us.
+prepare network: 8934 us.
+nbg name=model/decoder_int16_t527.nb, size: 7010624.
+create network 1: 9543 us.
+prepare network: 1251 us.
+nbg name=model/joiner_int16_t527.nb, size: 5539648.
+create network 2: 5803 us.
+prepare network: 763 us.
+
+Real Time Factor(RTF): 0.161 = 0.942s(infer_time) / 5.840s(audio_length)
+
+Timestamp (s): 0.96, 1.04, 1.24, 1.32, 1.44, 1.72, 1.80, 2.04, 2.56, 3.04, 3.08, 3.48, 3.84, 4.68, 4.76, 5.00, 5.24, 5.48
+
+Zipformer output: 这是第一种第二种叫呃嗯与 ALWAYS什么意思啊
+destroy npu finished.
+~NpuUint.
+```
+
+This performance data only calculates the time consumption of model inference. Unless otherwise specified, it does not include the time consumption of pre-processing and post-processing.
+
+| SoC            | NPU             | Model     | Input Resolution | Network Creation Time | Network Preparation Time | Single Frame Inference Time | Post-processing Time | Total Time | Frame Rate |
+| :------------- | :-------------- | :-------- | :--------------- | :-------------------- | :----------------------- | :-------------------------- | :------------------- | :--------- | :--------- |
+| Allwinner T527 | Vivante VIP9000 | zipformer | 5.84 s           | 63.8 ms               | 10.9 ms                  | 942.0 ms                    |                      | 1016.7 ms  | RTF 0.161  |
+
+</TabItem>
+</Tabs>

--- a/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_voice-assistant.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common/ai/cubie/_voice-assistant.mdx
@@ -1,0 +1,176 @@
+This document describes how to run an offline Chinese voice assistant on Cubie boards with Allwinner A733: keyword spotting (KWS) → automatic speech recognition (ASR) → text-to-speech (TTS).
+
+Example repository: [https://github.com/Ronin-1124/cubie-a7a-voice-assistant](https://github.com/Ronin-1124/cubie-a7a-voice-assistant)
+
+The example is developed and verified on Cubie A7A. Cubie A7S and Cubie A7Z use the same A733 NPU, so the software flow is the same. The ALSA card index for the microphone and headphone jack may differ.
+
+```text
+Microphone / offline wav
+  → Wake-word KWS (Zipformer, NPU by default)
+  → Recognition ASR (Zipformer, NPU by default)
+  → TTS (Matcha on CPU + HiFi-GAN on NPU)
+  → Headphone playback
+```
+
+The NPU (Vivante VIP9000) can load only one network at a time. The assistant unloads other NBG graphs before ASR or the NPU vocoder.
+
+:::info
+Matcha-baker uses the Baker dataset, which is non-commercial. Replace the acoustic data for production use.
+:::
+
+## Prepare the environment
+
+### Hardware and system
+
+- A Cubie board with Allwinner A733 (Cubie A7A recommended)
+- Radxa OS installed, with SSH access
+- Headphones plugged into the onboard 3.5 mm jack (do not use the HDMI sound card)
+
+### NPU runtime
+
+Copy the libraries from Model Zoo `common/npuruntime/lib_linux_aarch64/A733` to `~/lib` on the board and add them to the dynamic linker path. Skip this if you already did it for another NPU example.
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+echo 'export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+source ~/.bashrc
+sudo chmod 777 /dev/vipcore
+```
+
+</NewCodeBlock>
+
+NPU ASR calls the [Zipformer](./model-zoo/zipformer) install directory `~/npu_demos/zipformer_demo_linux_a733` by default. Build and deploy the A733 Zipformer example first. `./zipformer_demo_a733 -h` should list `--stdin` (the assistant feeds audio frame by frame).
+
+## Get the example
+
+Clone the repository to `~/npu_demos/voice_assistant` on the board:
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+mkdir -p ~/npu_demos
+git clone https://github.com/Ronin-1124/cubie-a7a-voice-assistant.git ~/npu_demos/voice_assistant
+cd ~/npu_demos/voice_assistant
+```
+
+</NewCodeBlock>
+
+Install Python dependencies:
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+pip3 install --user -r requirements.txt
+```
+
+</NewCodeBlock>
+
+`requirements.txt` lists `numpy` and `onnxruntime`.
+
+## Prepare models
+
+ONNX files are large and are not stored in git. Download the TTS acoustic model (Matcha-baker) from the repository root:
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+bash scripts/download_models.sh
+```
+
+</NewCodeBlock>
+
+`prebuilt/` contains converted A733 NBG files:
+
+| Path                                                   | Purpose                                                         |
+| ------------------------------------------------------ | --------------------------------------------------------------- |
+| `prebuilt/kws/encoder_float_a733.nb` and related files | KWS NPU (float encoder/decoder/joiner; do not use int16 joiner) |
+| `prebuilt/vocoder/vocoder_int16_a733.nb`               | TTS vocoder (int16; do not use uint8)                           |
+
+Copy the KWS NBG files to the directory the assistant searches by default:
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+mkdir -p ~/npu_demos/kws_npu_demo/model
+cp prebuilt/kws/*.nb prebuilt/kws/tokens.txt ~/npu_demos/kws_npu_demo/model/
+```
+
+</NewCodeBlock>
+
+NPU KWS also needs the `kws_npu_demo_a733` binary. Source is in `convert/kws/`. After building, place it with the VIPLite libraries under `~/npu_demos/kws_npu_demo/`.
+
+The TTS NPU vocoder is copied to `models/tts/vocoder_int16_a733.nb`.
+
+## Run the example
+
+NPU KWS + NPU ASR + Matcha with the NPU vocoder. Verify the software with the bundled 16 kHz wav files first. You do not need to speak into the microphone.
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+cd ~/npu_demos/voice_assistant
+python3 assistant_fast.py --from-wav samples/pipe_nihao_xiaorui_openlight_16k.wav
+```
+
+</NewCodeBlock>
+
+The running result is as follows:
+
+```bash
+$ python3 assistant_fast.py --from-wav samples/pipe_nihao_xiaorui_openlight_16k.wav
+[09:45:53] wav 1 file(s) 6.6s
+[09:45:53] kws=npu asr=npu tts=npu  ready 0.1s
+[09:45:53] listening…
+[09:45:53] WAKE 你好小瑞
+[09:46:01] TEXT 帮我打开灯  8.4s
+[09:46:17] TTS 15.3s
+```
+
+Live microphone:
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+python3 assistant_fast.py
+```
+
+</NewCodeBlock>
+
+| Goal                           | Option                            |
+| ------------------------------ | --------------------------------- |
+| Disable playback               | `--no-tts`                        |
+| Offline full-pipeline wav test | `--from-wav <wake.wav> <cmd.wav>` |
+
+Synthesize speech only:
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+python3 tools/matcha_npu.py --text "识别完成" --play
+```
+
+</NewCodeBlock>
+
+Default wake words in `keywords_wake.txt` are 你好小瑞, 小瑞小瑞, and 小瑞. The short word 你好 is not included, to avoid false wakes.
+
+## Microphone and playback
+
+Cubie A7A has **no onboard MEMS microphone**. Capture is the 3.5 mm 4-pole jack headset mic (schematic HS-MIC → codec **MIC4**). Playback uses the same jack (HPOUT).
+
+List sound cards and use the device whose name contains `sunxi-ac101b`. Do not use `allwinner-hdmi`. On the current image the headphone codec is usually **card 0** and HDMI is card 1.
+
+<NewCodeBlock tip="Radxa SBC" type="device">
+
+```bash
+aplay -l
+arecord -l
+```
+
+</NewCodeBlock>
+
+Plug in a **4-pole headset with a mic** and speak into the **boom mic** (often on the right earcup). The analog mic is mono; on this image its energy shows up on the I2S left slot, which is not the same as “left earcup”. TTS wav files are mono; the assistant duplicates them to both ears before playback.
+
+Do not use sites that monitor the microphone through the headphones (for example mictest.com) to tune levels: the boom sits next to a driver and can howl at high volume.
+
+If live wake is unreliable, use `--from-wav` above to verify the software. Details: `docs/AUDIO_耳机与麦克风.md` in the example repository.

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/app-dev/npu-dev/model-zoo/clip.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/app-dev/npu-dev/model-zoo/clip.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 26
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-clip.mdx
+---
+
+# CLIP
+
+import CLIP from '../../../../../common/ai/cubie/\_model-zoo-clip.mdx';
+
+<CLIP />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/app-dev/npu-dev/model-zoo/lite-transformer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/app-dev/npu-dev/model-zoo/lite-transformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 28
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lite-transformer.mdx
+---
+
+# Lite Transformer
+
+import LiteTransformer from '../../../../../common/ai/cubie/\_model-zoo-lite-transformer.mdx';
+
+<LiteTransformer />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/app-dev/npu-dev/model-zoo/lstm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/app-dev/npu-dev/model-zoo/lstm.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 29
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lstm.mdx
+---
+
+# LSTM
+
+import LSTM from '../../../../../common/ai/cubie/\_model-zoo-lstm.mdx';
+
+<LSTM />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/app-dev/npu-dev/model-zoo/zipformer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a5e/app-dev/npu-dev/model-zoo/zipformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 27
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-zipformer.mdx
+---
+
+# Zipformer
+
+import Zipformer from '../../../../../common/ai/cubie/\_model-zoo-zipformer.mdx';
+
+<Zipformer />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/app-dev/npu-dev/model-zoo/clip.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/app-dev/npu-dev/model-zoo/clip.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 26
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-clip.mdx
+---
+
+# CLIP
+
+import CLIP from '../../../../../common/ai/cubie/\_model-zoo-clip.mdx';
+
+<CLIP />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/app-dev/npu-dev/model-zoo/lite-transformer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/app-dev/npu-dev/model-zoo/lite-transformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 28
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lite-transformer.mdx
+---
+
+# Lite Transformer
+
+import LiteTransformer from '../../../../../common/ai/cubie/\_model-zoo-lite-transformer.mdx';
+
+<LiteTransformer />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/app-dev/npu-dev/model-zoo/lstm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/app-dev/npu-dev/model-zoo/lstm.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 29
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lstm.mdx
+---
+
+# LSTM
+
+import LSTM from '../../../../../common/ai/cubie/\_model-zoo-lstm.mdx';
+
+<LSTM />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/app-dev/npu-dev/model-zoo/zipformer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/app-dev/npu-dev/model-zoo/zipformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 27
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-zipformer.mdx
+---
+
+# Zipformer
+
+import Zipformer from '../../../../../common/ai/cubie/\_model-zoo-zipformer.mdx';
+
+<Zipformer />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/app-dev/npu-dev/voice-assistant.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7a/app-dev/npu-dev/voice-assistant.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 12
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_voice-assistant.mdx
+---
+
+# Offline Voice Assistant
+
+import VoiceAssistant from '../../../../common/ai/cubie/\_voice-assistant.mdx';
+
+<VoiceAssistant />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/app-dev/npu-dev/model-zoo/clip.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/app-dev/npu-dev/model-zoo/clip.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 26
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-clip.mdx
+---
+
+# CLIP
+
+import CLIP from '../../../../../common/ai/cubie/\_model-zoo-clip.mdx';
+
+<CLIP />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/app-dev/npu-dev/model-zoo/lite-transformer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/app-dev/npu-dev/model-zoo/lite-transformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 28
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lite-transformer.mdx
+---
+
+# Lite Transformer
+
+import LiteTransformer from '../../../../../common/ai/cubie/\_model-zoo-lite-transformer.mdx';
+
+<LiteTransformer />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/app-dev/npu-dev/model-zoo/lstm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/app-dev/npu-dev/model-zoo/lstm.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 29
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lstm.mdx
+---
+
+# LSTM
+
+import LSTM from '../../../../../common/ai/cubie/\_model-zoo-lstm.mdx';
+
+<LSTM />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/app-dev/npu-dev/model-zoo/zipformer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/app-dev/npu-dev/model-zoo/zipformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 27
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-zipformer.mdx
+---
+
+# Zipformer
+
+import Zipformer from '../../../../../common/ai/cubie/\_model-zoo-zipformer.mdx';
+
+<Zipformer />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/app-dev/npu-dev/voice-assistant.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7s/app-dev/npu-dev/voice-assistant.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 12
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_voice-assistant.mdx
+---
+
+# Offline Voice Assistant
+
+import VoiceAssistant from '../../../../common/ai/cubie/\_voice-assistant.mdx';
+
+<VoiceAssistant />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/app-dev/npu-dev/model-zoo/clip.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/app-dev/npu-dev/model-zoo/clip.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 26
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-clip.mdx
+---
+
+# CLIP
+
+import CLIP from '../../../../../common/ai/cubie/\_model-zoo-clip.mdx';
+
+<CLIP />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/app-dev/npu-dev/model-zoo/lite-transformer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/app-dev/npu-dev/model-zoo/lite-transformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 28
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lite-transformer.mdx
+---
+
+# Lite Transformer
+
+import LiteTransformer from '../../../../../common/ai/cubie/\_model-zoo-lite-transformer.mdx';
+
+<LiteTransformer />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/app-dev/npu-dev/model-zoo/lstm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/app-dev/npu-dev/model-zoo/lstm.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 29
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-lstm.mdx
+---
+
+# LSTM
+
+import LSTM from '../../../../../common/ai/cubie/\_model-zoo-lstm.mdx';
+
+<LSTM />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/app-dev/npu-dev/model-zoo/zipformer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/app-dev/npu-dev/model-zoo/zipformer.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 27
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_model-zoo-zipformer.mdx
+---
+
+# Zipformer
+
+import Zipformer from '../../../../../common/ai/cubie/\_model-zoo-zipformer.mdx';
+
+<Zipformer />

--- a/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/app-dev/npu-dev/voice-assistant.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cubie/a7z/app-dev/npu-dev/voice-assistant.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 12
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/ai/cubie/_voice-assistant.mdx
+---
+
+# Offline Voice Assistant
+
+import VoiceAssistant from '../../../../common/ai/cubie/\_voice-assistant.mdx';
+
+<VoiceAssistant />


### PR DESCRIPTION
…pformer/LSTM/Lite-Transformer plus A733 voice assistant docs

## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [x] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [x] Changed page docs are not empty, include front matter, and have an H1 heading.
- [x] Code fences in changed docs include language labels.
- [x] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [x] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [x] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [x] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
