### PR TITLE
fix: airbox q900 and dragon q6a yocto link

### DIFF
--- a/docs/dragon/q6a/other-system/yocto-guide.md
+++ b/docs/dragon/q6a/other-system/yocto-guide.md
@@ -14,4 +14,4 @@ sidebar_position: 1
 
 ## Radxa Dragon Q6A Yocto 编译指南
 
-请参考 [Radxa Dragon Q6A Yocto 编译指南](https://github.com/radxa/meta-radxa-dragon/wiki/dragon-q6a)
+请参考 [Radxa Dragon Q6A Yocto 编译指南](https://github.com/radxa/meta-radxa-dragon/wiki)

--- a/docs/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/docs/fogwise/airbox-q900/other-os/qualcomm.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## 瑞莎 AIRbox Q900 Yocto 编译指南
 
-请参考 [瑞莎 AIRbox Q900 Yocto 编译指南](https://github.com/radxa/meta-radxa-dragon/blob/meta-qcom-qli-2.0/README-Radxa-AIRbox-Q900.md)
+请参考 [瑞莎 AIRbox Q900 Yocto 编译指南](https://github.com/radxa/meta-radxa-dragon/wiki)
 
 ## 高通 Linux Yocto 指南
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/other-system/yocto-guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/other-system/yocto-guide.md
@@ -14,4 +14,4 @@ Please refer [Qualcomm Linux Yocto Guide](https://docs.qualcomm.com/bundle/publi
 
 ## Radxa Dragon Q6A Yocto Guide
 
-Please refer [Radxa Dragon Q6A Yocto Guide](https://github.com/radxa/meta-radxa-dragon/wiki/dragon-q6a)
+Please refer [Radxa Dragon Q6A Yocto Guide](https://github.com/radxa/meta-radxa-dragon/wiki)

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/other-os/qualcomm.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## Radxa AIRbox Q900 Yocto Build Guide
 
-Please refer to [Radxa AIRbox Q900 Yocto Build Guide](https://github.com/radxa/meta-radxa-dragon/blob/meta-qcom-qli-2.0/README-Radxa-AIRbox-Q900.md)
+Please refer to [Radxa AIRbox Q900 Yocto Build Guide](https://github.com/radxa/meta-radxa-dragon/wiki)
 
 ## Qualcomm Linux Yocto Guide
 


### PR DESCRIPTION
## Description of changes

Please briefly describe the changes in this PR.

## Agent-doc checklist

- [ ] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [ ] Changed page docs are not empty, include front matter, and have an H1 heading.
- [ ] Code fences in changed docs include language labels.
- [ ] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [ ] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [ ] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [ ] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit:
- additional checks:
