### PR TITLE
docs(dragon q8b): fix stale 260821 BIOS firmware link in EN download page

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/download.md
@@ -53,13 +53,13 @@ Dragon Q8B ships with BIOS firmware preinstalled. Normally you do not need to fl
 
   :::info Latest BIOS Firmware Release Page
 
-  - [BIOS Firmware - 260825](https://dl.radxa.com/dragon/q8b/images/dragon-q8b_flat_build_wp_260825.zip)
+  - [BIOS Firmware](https://dl.radxa.com/dragon/q8b/images/)
 
   This page releases the latest versions of the BIOS firmware. For the changelog, see [BIOS Firmware Changelog](https://dl.radxa.com/dragon/q8b/images/dragon-q8b-bios-changelog.md).
 
   :::
 
-  - [BIOS Firmware](https://dl.radxa.com/dragon/q8b/images/dragon-q8b_flat_build_wp_260821.zip)
+  - [BIOS Firmware - 260825](https://dl.radxa.com/dragon/q8b/images/dragon-q8b_flat_build_wp_260825.zip)
 
 ## Windows Driver
 


### PR DESCRIPTION
## Summary

Fix a stale BIOS firmware link on the English Dragon Q8B download page. The EN page currently shows **two** BIOS firmware links with different versions, which is inconsistent with the Chinese page and misleading for users downloading firmware.

## Problem

- EN info block (`Latest BIOS Firmware Release Page`) contains a direct link to the **260825** build, while the block outside the info box still points to the **260821** build:
  - `[BIOS Firmware - 260825](.../dragon-q8b_flat_build_wp_260825.zip)` (inside info box)
  - `[BIOS Firmware](.../dragon-q8b_flat_build_wp_260821.zip)` (outside info box)
- The Chinese page (`docs/dragon/q8b/download.md`) has the correct structure: the info box links to the release directory, and the outer link points to the **260825** build.
- Root cause: PR #2079 updated the BIOS link to 260825, but on the EN side it modified the line *inside* the info block instead of the outer firmware link, leaving the old 260821 link untouched.

## Fix

Align the EN page with the already-correct ZH structure:
- Info block: link to the release page directory `https://dl.radxa.com/dragon/q8b/images/` (matching ZH)
- Outer link: `BIOS Firmware - 260825` → `dragon-q8b_flat_build_wp_260825.zip` (matching ZH)

This is an **EN-only** change because the Chinese counterpart is already correct — no ZH edit is needed, and editing ZH would only reintroduce divergence.

## Origin

Internal support case (2026-08-28): customer reported the latest Q8B BIOS (260825) was not yet available on the dl server; after it was uploaded, PR #2079 updated the links but left this EN residue. This PR closes that gap so EN users are no longer pointed at the outdated 260821 firmware.

## Impact

- Files changed: 1 (`i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/download.md`, 2 lines)
- Docs-only change; no behavior/API impact.
