### PR TITLE
docs(rock4d): add CANBUS usage guide

### DIFF
--- a/docs/rock4/rock4d/hardware-use/canbus.md
+++ b/docs/rock4/rock4d/hardware-use/canbus.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 6
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - docs/common/dev/_canbus.mdx
+---
+
+# Canbus 使用
+
+import CANBUS from '../../../common/dev/\_canbus.mdx';
+
+<CANBUS rsetup_link="../system-config/rsetup#overlays" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/hardware-use/canbus.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/hardware-use/canbus.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 6
+
+doc_kind: wrapper
+source_of_truth: common
+imports_resolve_to:
+  - i18n/en/docusaurus-plugin-content-docs/current/common/dev/_canbus.mdx
+---
+
+# Canbus Usage
+
+import CANBUS from '../../../common/dev/\_canbus.mdx';
+
+<CANBUS rsetup_link="../system-config/rsetup#overlays" />


### PR DESCRIPTION
## Summary

Add a bilingual (CN + EN) CANBUS usage guide for ROCK 4D under `hardware-use/`.

**Background**: In the last 24h an internal support question asked how to enable the built-in CAN FD on ROCK 4D (RK3576). ROCK 4D supports CANBUS via its 40-pin header (overlays `Enable CAN1-M1` / `Enable CAN1-M3` exist in radxa-overlays for `radxa,rock-4d`), but the docs had no CANBUS page for this board while sibling boards (e.g. ROCK 3A, E25, ZERO 3) all ship one.

## Change

- Add `docs/rock4/rock4d/hardware-use/canbus.md` (CN)
- Add `i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/hardware-use/canbus.md` (EN)

Both are `doc_kind: wrapper` pages importing the shared `common/dev/_canbus.mdx` template, consistent with existing CANBUS wrapper pages (ROCK 3A / E25 / ZERO 3 / CM3I). No new technical claims added.
