### PR TITLE
docs(airbox-q900): clarify OS type of system image downloads

### DIFF
--- a/docs/fogwise/airbox-q900/download.md
+++ b/docs/fogwise/airbox-q900/download.md
@@ -6,9 +6,16 @@ sidebar_position: 150
 
 ## 系统镜像
 
-- [radxa-airbox-q900_noble_gnome_r1](https://dl.radxa.com/fogwise/airbox-q900/images/radxa-airbox-q900_noble_gnome_r1_4096.tar.gz)
+- [radxa-airbox-q900_noble_gnome_r1](https://dl.radxa.com/fogwise/airbox-q900/images/radxa-airbox-q900_noble_gnome_r1_4096.tar.gz)：Ubuntu 24.04（Noble）+ GNOME 桌面系统镜像（r1 稳定版）
 
-- [qcs9075-provision](https://dl.radxa.com/fogwise/airbox-q900/images/qcs9075-provision.tar.gz)
+:::note 镜像命名说明
+
+- `noble` 表示 Ubuntu 24.04（Noble Numbat）操作系统，`gnome` 表示 GNOME 桌面环境
+- 前缀 `r` 表示稳定版（如 r1），前缀 `t` 表示测试版（如 t1）
+
+:::
+
+- [qcs9075-provision](https://dl.radxa.com/fogwise/airbox-q900/images/qcs9075-provision.tar.gz)：UFS 配置工具包（非操作系统镜像），用于安装系统到板载 UFS 前的存储配置步骤。完整安装步骤请参考[安装系统到板载 UFS](./getting-started/install-system/onboard-ufs)
 
 ## 百度网盘下载
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/fogwise/airbox-q900/download.md
@@ -6,9 +6,16 @@ sidebar_position: 150
 
 ## System Images
 
-- [radxa-airbox-q900_noble_gnome_r1](https://dl.radxa.com/fogwise/airbox-q900/images/radxa-airbox-q900_noble_gnome_r1_4096.tar.gz)
+- [radxa-airbox-q900_noble_gnome_r1](https://dl.radxa.com/fogwise/airbox-q900/images/radxa-airbox-q900_noble_gnome_r1_4096.tar.gz): Ubuntu 24.04 (Noble) + GNOME desktop system image (r1 stable release)
 
-- [qcs9075-provision](https://dl.radxa.com/fogwise/airbox-q900/images/qcs9075-provision.tar.gz)
+:::note Image naming convention
+
+- `noble` refers to the Ubuntu 24.04 (Noble Numbat) operating system, `gnome` refers to the GNOME desktop environment
+- The `r` prefix indicates a stable release (e.g. r1), while the `t` prefix indicates a test release (e.g. t1)
+
+:::
+
+- [qcs9075-provision](https://dl.radxa.com/fogwise/airbox-q900/images/qcs9075-provision.tar.gz): UFS provisioning toolkit (not an OS image), used for the storage provisioning step before installing the system to the onboard UFS. For the full installation steps, see [Install System to Onboard UFS](./getting-started/install-system/onboard-ufs)
 
 ## Software Tools
 


### PR DESCRIPTION
## Background

Triggered by a real support question (2026-09-03): an internal colleague looking at the AIRbox Q900 download page asked *"Q900 的这两个系统是 Debian 吗？有 Ubuntu 系统吗？"* — the page listed two files under **System Images** with zero explanation of what they are.

## Problem

The Q900 download page (`download.md`, CN + EN) shows:

- `radxa-airbox-q900_noble_gnome_r1` — no OS/desktop explanation; the Radxa image naming (`noble` = Ubuntu 24.04 Noble Numbat, `gnome` = GNOME desktop) is not self-evident to users.
- `qcs9075-provision` — listed as a "system image", but it is actually a **UFS provisioning toolkit** (370 KiB), not an OS. Users may mistake it for a bootable system.

## Change (docs-only)

- Annotate `radxa-airbox-q900_noble_gnome_r1` as *Ubuntu 24.04 (Noble) + GNOME desktop system image (r1 stable)*.
- Add a `:::note` explaining the image naming convention (`noble` = Ubuntu 24.04, `gnome` = GNOME desktop, `r`/`t` prefix = stable/test).
- Annotate `qcs9075-provision` as *UFS provisioning toolkit (not an OS image)* and cross-link the [Install System to Onboard UFS](./getting-started/install-system/onboard-ufs) guide.

Both CN (`docs/fogwise/airbox-q900/download.md`) and EN (`i18n/.../fogwise/airbox-q900/download.md`) updated in sync.

## Validation

- Naming verified against `dl.radxa.com/fogwise/airbox-q900/images/` (older artifact `radxa-airbox-q900-ubuntu-noble-gnome-t4.tar.gz`) and `radxa-build/radxa-airbox-q900` releases (`noble_gnome_r1/r2`, `noble_kde_t*`).
- `qcs9075-provision` usage verified in `getting-started/install-system/onboard-ufs.md` (UFS provisioning step).
- pre-commit hooks all pass (incl. doc translation guard).

## Impact

Reduces confusion for users and staff when choosing the correct image/tool from the Q900 download page.