### PR TITLE
docs(rock4): clarify boot-from-emmc scope for ROCK 4A+/4B+ onboard eMMC

### DIFF
--- a/docs/rock4/rock4ab-se/getting-started/install-os/boot-from-emmc.md
+++ b/docs/rock4/rock4ab-se/getting-started/install-os/boot-from-emmc.md
@@ -13,6 +13,14 @@ import Etcher from '../../../../common/general/\_etcherV2.mdx';
 
 本文介绍如何在 ROCK 4A/4B/4SE 上将系统安装到 eMMC Module 中，并通过 eMMC Module 启动系统。
 
+:::tip 适用型号
+
+本页流程适用于 **ROCK 4A/4B/4SE**，这三款型号通过主板上的 eMMC Module 插槽使用可拆卸的 eMMC Module。
+
+**ROCK 4A+/4B+** 为板载 eMMC（无 eMMC Module 插槽），不支持按本页方式拆装 eMMC Module。请参考[通过 USB 刷机（Maskrom 模式）](/rock4/rock4ab-se/low-level-dev/maskrom)将系统安装到板载 eMMC。
+
+:::
+
 ## 文件下载
 
 到资源下载汇总页面下载 [ROCK 4A/4B/4SE 系统镜像](../../download)

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4ab-se/getting-started/install-os/boot-from-emmc.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4ab-se/getting-started/install-os/boot-from-emmc.md
@@ -8,6 +8,14 @@ import Etcher from '../../../../common/general/\_etcherV2.mdx';
 
 This article explains how to install the operating system to an eMMC Module and boot the system from it on ROCK 4A/4B/4SE.
 
+:::tip Supported models
+
+This page applies to **ROCK 4A/4B/4SE**, which use a removable eMMC Module through the eMMC Module slot on the board.
+
+**ROCK 4A+/4B+** feature onboard eMMC (no eMMC Module slot), so the module removal/installation steps on this page do not apply. To install the system to the onboard eMMC, please refer to [Flashing via USB (Maskrom mode)](/rock4/rock4ab-se/low-level-dev/maskrom).
+
+:::
+
 ## File Download
 
 Download the [ROCK 4A/4B/4SE system image](../../download) from the resource download page.


### PR DESCRIPTION
## Summary

The `boot-from-emmc` page for ROCK 4A/4B/4SE only described installing the OS to a **removable eMMC Module**. The ROCK 4A+/4B+ models feature **onboard eMMC** (no eMMC Module slot), so the module-based steps on this page do not apply to them — but the page gave no guidance for those models.

This PR:
- Adds a "supported models" tip clarifying the page scope: removable eMMC Module flow applies to ROCK 4A/4B/4SE.
- Explicitly states ROCK 4A+/4B+ use onboard eMMC (no module slot) and cross-links to the existing [Maskrom USB flashing guide](/rock4/rock4ab-se/low-level-dev/maskrom) for installing the system to the onboard eMMC.
- Keeps the existing wrapper structure and frontmatter untouched; both Chinese and English versions updated in parallel.

## Verification

- `scripts/agent-doc-lint.sh` passed for both changed files
- `scripts/agent-doc-translation-guard.sh` passed
- No new zh/en path drift introduced (drift-guard only reports pre-existing `linkr/` baseline items)
- Cross-link uses the same absolute-path convention as the sibling `erase-spi-flash.md` (confirmed rendered locale-correct on docs.radxa.com for both zh and en)

Fixes #2071
