### PR TITLE
docs(dragon-q8b): add BIOS reset recovery FAQ

### DIFF
--- a/docs/dragon/q8b/faq.md
+++ b/docs/dragon/q8b/faq.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 145
+---
+
+# 常见问题
+
+## 启动第三方系统后，无法正常启动 Radxa OS？
+
+此前为了启动 Ubuntu、Debian 等第三方系统，修改了 BIOS 兼容性配置。切换回 Radxa OS 后，系统可能无法正常启动。
+
+请按照以下步骤将 BIOS 配置恢复为默认设置：
+
+1. 开机时按 **F2** 键进入 BIOS 主界面。
+2. 选择 **Reset BIOS to default settings** 选项恢复默认配置。
+3. 重启设备。
+
+有关 BIOS 配置的详细说明，请参考 [BIOS 说明](./low-level-dev/bios)。

--- a/docs/dragon/q8b/low-level-dev/bios.md
+++ b/docs/dragon/q8b/low-level-dev/bios.md
@@ -167,6 +167,10 @@ Snapdragon (TM) 8cx Gen 3 @ 3.0 GHz                              2.99 GHz
 └──────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+:::note
+切换回 Radxa OS 前，请将上述功能恢复为默认配置。若未逐项复原，可以进入 BIOS 主界面，选择 **Reset BIOS to default settings** 选项恢复默认配置。
+:::
+
 ### Device Manager
 
 ```biosscreen

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/faq.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 145
+---
+
+# Frequently Asked Questions (FAQ)
+
+## Why Does Radxa OS Fail to Boot After Using a Third-party Operating System?
+
+If you changed the BIOS compatibility settings to boot a third-party operating system such as Ubuntu or Debian, Radxa OS may fail to boot after you switch back to it.
+
+Follow these steps to restore the default BIOS settings:
+
+1. Press **F2** during startup to enter the BIOS main screen.
+2. Select **Reset BIOS to default settings** to restore the default configuration.
+3. Restart the device.
+
+For more information about BIOS settings, see [BIOS Instructions](./low-level-dev/bios).

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/bios.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/bios.md
@@ -167,6 +167,10 @@ To boot third-party operating systems such as Ubuntu 26 ISO, Fedora ISO, or Debi
 └──────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+:::note
+Before switching back to Radxa OS, restore the options above to their default settings. If you have not reverted them individually, enter the BIOS main screen and select **Reset BIOS to default settings** to restore the default configuration.
+:::
+
 ### Device Manager
 
 ```biosscreen


### PR DESCRIPTION
## Summary

- add a bilingual Dragon Q8B FAQ for Radxa OS boot failures after using a third-party operating system
- document how to restore the default BIOS configuration
- add a bilingual warning to the third-party OS compatibility settings section

## Source

Based on an internally confirmed support case.

## Validation

- `./scripts/agent-doc-lint.sh` passed for all four changed files
- `git diff --check` passed
- local PR guard passed, including bilingual coverage
