### PR TITLE
docs: add path parameter note to Dragon Q6A/Q8B BIOS flashing guide

### DIFF
--- a/docs/dragon/q6a/low-level-dev/spi-fw.md
+++ b/docs/dragon/q6a/low-level-dev/spi-fw.md
@@ -33,6 +33,10 @@ BIOS 固件（BootROM + 引导程序）的核心任务是分阶段初始化硬�
 
     </NewCodeBlock>
 
+    参数说明：
+
+    - `C:\path\to\` : 需要替换成解压后的 BIOS 固件实际路径
+
   </TabItem>
   <TabItem value="Linux" label="Linux">
 

--- a/docs/dragon/q8b/low-level-dev/spi-fw.md
+++ b/docs/dragon/q8b/low-level-dev/spi-fw.md
@@ -33,6 +33,10 @@ BIOS 固件（BootROM + 引导程序）的核心任务是分阶段初始化硬�
 
     </NewCodeBlock>
 
+    参数说明：
+
+    - `C:\path\to\` : 需要替换成解压后的 BIOS 固件实际路径
+
   </TabItem>
   <TabItem value="Linux" label="Linux">
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/low-level-dev/spi-fw.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q6a/low-level-dev/spi-fw.md
@@ -33,6 +33,10 @@ Go to the [Resource Download](../download) page, download the `edl-ng` package a
 
     </NewCodeBlock>
 
+    Parameter description:
+
+    - `C:\path\to\` : Replace with the actual path of the extracted BIOS firmware
+
   </TabItem>
   <TabItem value="Linux" label="Linux">
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/spi-fw.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/low-level-dev/spi-fw.md
@@ -33,6 +33,10 @@ Go to the [Resource Downloads](../download) page, download and extract the `edl-
 
     </NewCodeBlock>
 
+    Parameter description:
+
+    - `C:\path\to\` : Replace with the actual path of the extracted BIOS firmware
+
   </TabItem>
   <TabItem value="Linux" label="Linux">
 


### PR DESCRIPTION
## 变更内容

为 Dragon Q6A / Dragon Q8B 的 BIOS 固件烧录教程（`spi-fw.md`）补充 Windows 烧录命令中 `C:\path\to\` 占位符的参数说明，明确该路径需要替换成解压后的 BIOS 固件实际路径。

## 背景

用户在按教程执行 Windows 烧录命令时，对 `C:\path\to\` 占位符含义不明确，容易直接复制执行导致失败。教程中 Linux 部分已有 `[edl-ng path]` 参数说明，本次为 Windows 部分补齐同等说明。

## 变更文件

- docs/dragon/q6a/low-level-dev/spi-fw.md
- docs/dragon/q8b/low-level-dev/spi-fw.md
- i18n/en/.../dragon/q6a/low-level-dev/spi-fw.md
- i18n/en/.../dragon/q8b/low-level-dev/spi-fw.md

中英文同步更新。
