### PR TITLE
docs(rock5/rock5c): add ROCK 5C V2.1 hardware design downloads

### DIFF
--- a/docs/rock5/rock5c/download.md
+++ b/docs/rock5/rock5c/download.md
@@ -56,11 +56,20 @@ Armbian 的默认凭据如下：
 
 ## 硬件设计
 
+### V2.1
+
+- [位号图 V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_components_placement_map_v2.10.pdf)
+- [原理图 V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_schematic_v2.10.pdf)
+- [尺寸标注图 V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_2d_dimensions_v2.10.pdf)
+- [2D DXF 模型文件（顶部）V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_2d_top_v2.10.dxf.zip)
+- [2D DXF 模型文件（底部）V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_2d_bottom_v2.10.dxf.zip)
+- [3D 模型 V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_3d_stp_v2.10.stp.zip)
+
 ### V1.1
 
-- [v1.1 schematic pdf](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_schematic_v1100.pdf)
-- [v1.1 SMD pdf](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_components_placement_map_v1100.pdf)
-- [v1.1 2D Top&Bottom dxf](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_2d_dxf_v1100.zip)
-- [5C PCBA_3D](https://dl.radxa.com/rock5/5c/docs/hw/dimension/5c_pcba.stp.zip)
-- [底部尺寸](https://dl.radxa.com/rock5/5c/docs/hw/dimension/BOT_%5bRS131%5dRadxa%20ROCK%205C_V1.pdf)
-- [顶部尺寸](https://dl.radxa.com/rock5/5c/docs/hw/dimension/TOP_%5bRS131%5dRadxa%20ROCK%205C_V1.pdf)
+- [位号图 V1.1](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_components_placement_map_v1100.pdf)
+- [原理图 V1.1](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_schematic_v1100.pdf)
+- [2D DXF 模型文件（顶部和底部）V1.1](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_2d_dxf_v1100.zip)
+- [3D 模型 V1.1](https://dl.radxa.com/rock5/5c/docs/hw/dimension/5c_pcba.stp.zip)
+- [底部尺寸标注图 V1.1](https://dl.radxa.com/rock5/5c/docs/hw/dimension/BOT_%5bRS131%5dRadxa%20ROCK%205C_V1.pdf)
+- [顶部尺寸标注图 V1.1](https://dl.radxa.com/rock5/5c/docs/hw/dimension/TOP_%5bRS131%5dRadxa%20ROCK%205C_V1.pdf)

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/download.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/download.md
@@ -45,11 +45,20 @@ Kaihong OS Beta version firmware as follows:
 
 ## Hardware Design
 
+### V2.1
+
+- [Component Placement Map V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_components_placement_map_v2.10.pdf)
+- [Schematic V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_schematic_v2.10.pdf)
+- [2D Dimensions Diagram V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_2d_dimensions_v2.10.pdf)
+- [2D DXF Model File (Top) V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_2d_top_v2.10.dxf.zip)
+- [2D DXF Model File (Bottom) V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_2d_bottom_v2.10.dxf.zip)
+- [3D Model V2.10](https://dl.radxa.com/rock5/5c/docs/radxa_rock_5c_3d_stp_v2.10.stp.zip)
+
 ### V1.1
 
-- [v1.1 Schematic pdf](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_schematic_v1100.pdf)
-- [v1.1 SMD pdf](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_components_placement_map_v1100.pdf)
-- [v1.1 2D Top&Bottom dxf](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_2d_dxf_v1100.zip)
-- [5C PCBA_3D](https://dl.radxa.com/rock5/5c/docs/hw/dimension/5c_pcba.stp.zip)
-- [BOT Size](https://dl.radxa.com/rock5/5c/docs/hw/dimension/BOT_%5bRS131%5dRadxa%20ROCK%205C_V1.pdf)
-- [TOP Size](https://dl.radxa.com/rock5/5c/docs/hw/dimension/TOP_%5bRS131%5dRadxa%20ROCK%205C_V1.pdf)
+- [Component Placement Map V1.1](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_components_placement_map_v1100.pdf)
+- [Schematic V1.1](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_schematic_v1100.pdf)
+- [2D DXF Model File (Top & Bottom) V1.1](https://dl.radxa.com/rock5/5c/docs/hw/v1100/radxa_rock_5c_2d_dxf_v1100.zip)
+- [3D Model V1.1](https://dl.radxa.com/rock5/5c/docs/hw/dimension/5c_pcba.stp.zip)
+- [Bottom Dimensions Diagram V1.1](https://dl.radxa.com/rock5/5c/docs/hw/dimension/BOT_%5bRS131%5dRadxa%20ROCK%205C_V1.pdf)
+- [Top Dimensions Diagram V1.1](https://dl.radxa.com/rock5/5c/docs/hw/dimension/TOP_%5bRS131%5dRadxa%20ROCK%205C_V1.pdf)


### PR DESCRIPTION
docs(rock5/rock5c): add ROCK 5C V2.1 hardware design downloads to the download page

## What
- Add a new **V2.1** subsection under Hardware Design on the ROCK 5C download page with the V2.10 hardware design files (component placement map, schematic, 2D dimensions diagram, 2D DXF top & bottom).
- Reformat the existing **V1.1** subsection to the same naming style (Chinese/English item name + version) while keeping all existing file links unchanged.

## Why
- Requested by internal hardware team: the ROCK 5C V2.1 hardware design files are now available on dl.radxa.com and should be linked from the docs download page.
- Unified formatting keeps both hardware revisions consistent and easier to scan.
- Related to #2087: customers with V2.1 boards now have matching hardware design documents.

## Files changed
- docs/rock5/rock5c/download.md (zh)
- i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5c/download.md (en)
