### PR TITLE
docs(dragon-q8b): expand M.2 E Key card compatibility

### DIFF
--- a/docs/dragon/q8b/hardware-use/m2-e-key.md
+++ b/docs/dragon/q8b/hardware-use/m2-e-key.md
@@ -23,17 +23,25 @@ sidebar_position: 10
 
 以下型号已在瑞莎 Dragon Q8B 上完成验证，可正常使用：
 
-| 型号 | 类型 / 芯片 | Wi-Fi | 蓝牙 | 备注 |
-| --- | --- | --- | --- | --- |
-| Foxconn T99H432.12 | NCM865A (WCN7851) | Wi-Fi 7 | BT 5.4 | 蓝牙通过 UART 连接 |
-| Quectel QCNCM865AAMD-865A | NCM865A (WCN7851) | Wi-Fi 7 | BT 5.4 | 蓝牙通过 UART 连接 |
-| Foxconn T99H432.05 | NCM865 (WCN7851) | Wi-Fi 7 | BT 5.4 | 蓝牙通过 USB 连接 |
-| LITE-ON WCBN814A | NFA765A (QCA2066) | Wi-Fi 6E | BT 5.3 | 蓝牙通过 UART 连接<br/>蓝牙音频使用一段时间后可能意外断开，建议使用其他型号 |
-| Foxconn T99H294 U98H139.00 | NFA765 (WCN6856) | Wi-Fi 6E | BT 5.3 | 蓝牙通过 USB 连接 |
+| 型号                       | 类型 / 芯片       | Wi-Fi    | 蓝牙   | 已测试平台      | 备注                                                                        |
+| -------------------------- | ----------------- | -------- | ------ | --------------- | --------------------------------------------------------------------------- |
+| Foxconn T99H432.12         | NCM865A (WCN7851) | Wi-Fi 7  | BT 5.4 | Windows / Linux | 蓝牙通过 UART 连接                                                          |
+| Quectel QCNCM865AAMD-865A  | NCM865A (WCN7851) | Wi-Fi 7  | BT 5.4 | Windows / Linux | 蓝牙通过 UART 连接                                                          |
+| Foxconn T99H432.05         | NCM865 (WCN7851)  | Wi-Fi 7  | BT 5.4 | Windows / Linux | 蓝牙通过 USB 连接                                                           |
+| LITE-ON WCBN814A           | NFA765A (QCA2066) | Wi-Fi 6E | BT 5.3 | Windows / Linux | 蓝牙通过 UART 连接<br/>蓝牙音频使用一段时间后可能意外断开，建议使用其他型号 |
+| Foxconn T99H294 U98H139.00 | NFA765 (WCN6856)  | Wi-Fi 6E | BT 5.3 | Windows / Linux | 蓝牙通过 USB 连接                                                           |
+| MediaTek MT7921            | MT7921            | Wi-Fi 6  | BT 5.2 | Linux           | Wi-Fi 通过 PCIe 连接，蓝牙通过 USB 连接                                     |
+| MediaTek MT7922            | MT7922            | Wi-Fi 6E | BT 5.2 | Linux           | Wi-Fi 通过 PCIe 连接，蓝牙通过 USB 连接                                     |
+| Realtek RTL8852CE          | RTL8852CE         | Wi-Fi 6E | BT 5.3 | Linux           | Wi-Fi 通过 PCIe 连接，蓝牙通过 USB 连接                                     |
+| Intel BE200                | BE200             | Wi-Fi 7  | BT 5.4 | Linux           | Wi-Fi 通过 PCIe 连接，蓝牙通过 USB 连接                                     |
+| Intel AX210                | AX210             | Wi-Fi 6E | BT 5.4 | Linux           | Wi-Fi 通过 PCIe 连接，蓝牙通过 USB 连接                                     |
+| Intel 8260                 | 8260              | Wi-Fi 5  | BT 4.2 | Linux           | Wi-Fi 通过 PCIe 连接，蓝牙通过 USB 连接                                     |
 
 :::caution 购买提示
-- 上表为当前已验证支持的型号列表。
-- Realtek / Intel 全系无线网卡暂无可用驱动支持，请勿选购。
-- MediaTek MT7925 / MT7927 可能支持，尚待进一步验证。
+
+- 上表为当前已验证支持的型号列表，具体支持平台以“已测试平台”列为准。
+- Realtek / Intel 全系无线网卡暂无可用驱动支持，请勿选购（仅反映 Q8B Windows 平台下的测试情况）。
+- MediaTek MT7925 / MT7927 可能支持，尚待进一步验证（仅反映 Q8B Windows 平台下的测试情况）。
 - 如需使用其他型号，建议先联系瑞莎技术支持确认兼容性。
+
 :::

--- a/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/hardware-use/m2-e-key.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dragon/q8b/hardware-use/m2-e-key.md
@@ -23,17 +23,25 @@ After the system boots, you can connect to Wi-Fi in the system settings, or use 
 
 The following models have been verified on the Radxa Dragon Q8B:
 
-| Model | Type / Chipset | Wi-Fi | Bluetooth | Notes |
-| --- | --- | --- | --- | --- |
-| Foxconn T99H432.12 | NCM865A (WCN7851) | Wi-Fi 7 | BT 5.4 | Bluetooth over UART |
-| Quectel QCNCM865AAMD-865A | NCM865A (WCN7851) | Wi-Fi 7 | BT 5.4 | Bluetooth over UART |
-| Foxconn T99H432.05 | NCM865 (WCN7851) | Wi-Fi 7 | BT 5.4 | Bluetooth over USB |
-| LITE-ON WCBN814A | NFA765A (QCA2066) | Wi-Fi 6E | BT 5.3 | Bluetooth over UART<br/>Bluetooth audio may disconnect unexpectedly after some time of use; we recommend using other models |
-| Foxconn T99H294 U98H139.00 | NFA765 (WCN6856) | Wi-Fi 6E | BT 5.3 | Bluetooth over USB |
+| Model                      | Type / Chipset    | Wi-Fi    | Bluetooth | Tested Platform | Notes                                                                                                                       |
+| -------------------------- | ----------------- | -------- | --------- | --------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Foxconn T99H432.12         | NCM865A (WCN7851) | Wi-Fi 7  | BT 5.4    | Windows / Linux | Bluetooth over UART                                                                                                         |
+| Quectel QCNCM865AAMD-865A  | NCM865A (WCN7851) | Wi-Fi 7  | BT 5.4    | Windows / Linux | Bluetooth over UART                                                                                                         |
+| Foxconn T99H432.05         | NCM865 (WCN7851)  | Wi-Fi 7  | BT 5.4    | Windows / Linux | Bluetooth over USB                                                                                                          |
+| LITE-ON WCBN814A           | NFA765A (QCA2066) | Wi-Fi 6E | BT 5.3    | Windows / Linux | Bluetooth over UART<br/>Bluetooth audio may disconnect unexpectedly after some time of use; we recommend using other models |
+| Foxconn T99H294 U98H139.00 | NFA765 (WCN6856)  | Wi-Fi 6E | BT 5.3    | Windows / Linux | Bluetooth over USB                                                                                                          |
+| MediaTek MT7921            | MT7921            | Wi-Fi 6  | BT 5.2    | Linux           | Wi-Fi over PCIe; Bluetooth over USB                                                                                         |
+| MediaTek MT7922            | MT7922            | Wi-Fi 6E | BT 5.2    | Linux           | Wi-Fi over PCIe; Bluetooth over USB                                                                                         |
+| Realtek RTL8852CE          | RTL8852CE         | Wi-Fi 6E | BT 5.3    | Linux           | Wi-Fi over PCIe; Bluetooth over USB                                                                                         |
+| Intel BE200                | BE200             | Wi-Fi 7  | BT 5.4    | Linux           | Wi-Fi over PCIe; Bluetooth over USB                                                                                         |
+| Intel AX210                | AX210             | Wi-Fi 6E | BT 5.4    | Linux           | Wi-Fi over PCIe; Bluetooth over USB                                                                                         |
+| Intel 8260                 | 8260              | Wi-Fi 5  | BT 4.2    | Linux           | Wi-Fi over PCIe; Bluetooth over USB                                                                                         |
 
 :::caution Purchase Notes
-- The table above is the list of currently verified supported models.
-- Realtek / Intel series wireless network cards do not have available driver support; please do not purchase them.
-- MediaTek MT7925 / MT7927 may be supported, but are still under further validation.
+
+- The table above lists the currently verified models. Refer to the "Tested Platform" column for platform support.
+- Realtek / Intel series wireless network cards do not have available driver support; please do not purchase them (based only on testing on the Q8B Windows platform).
+- MediaTek MT7925 / MT7927 may be supported, but are still under further validation (based only on testing on the Q8B Windows platform).
 - If you want to use other models, please contact Radxa technical support to confirm compatibility before purchasing.
+
 :::


### PR DESCRIPTION
## Description of changes

- Add a Tested Platform column to the Dragon Q8B M.2 E Key compatibility table.
- Mark the existing verified cards as tested on Windows and Linux.
- Add MediaTek MT7921/MT7922, Realtek RTL8852CE, Intel BE200/AX210/8260 as Linux-tested models.
- Clarify that the Realtek/Intel and MediaTek MT7925/MT7927 driver notes apply only to Q8B Windows testing.
- Keep the Chinese and English pages synchronized.

The compatibility updates are based on internal hardware validation results.

## Agent-doc checklist

- [x] I ran `scripts/agent-doc-lint.sh` on changed doc files.
- [x] Changed page docs are not empty, include front matter, and have an H1 heading.
- [x] Code fences in changed docs include language labels.
- [x] I removed `TODO`/`TBD`/`XXX` placeholders from non-template docs.
- [x] I reviewed whether `docs/` and `i18n/en/...` need to be synced.
- [x] I did not introduce new docs/i18n path drift, or I updated `.github/agent-doc-drift-baseline.md` intentionally.
- [x] I did not introduce new translation placeholders, or I updated `.github/agent-doc-translation-baseline.md` and `.github/agent-doc-translation-backlog.md` intentionally.

## Validation notes

- pre-commit: passed for both changed files
- additional checks: `agent-doc-lint.sh`, `agent-doc-drift-guard.sh`, `agent-doc-translation-guard.sh`, product-index check, and local PR scope guard passed
