### PR TITLE
docs: fix software support matrix overview link and sidebar context

### DIFF
--- a/docs/software-support-matrix/README.md
+++ b/docs/software-support-matrix/README.md
@@ -1,6 +1,5 @@
 ---
-sidebar_position: 4
-displayed_sidebar: home
+sidebar_position: 1
 ---
 
 # 系统软件支持矩阵
@@ -9,6 +8,6 @@ displayed_sidebar: home
 
 ## 已收录平台
 
-- **Rockchip（瑞芯微）**：[瑞芯微软件支持矩阵](./rockchip) — 覆盖 Yocto、Radxa OS（Debian）、OpenWrt、Armbian、Android 与 FnOS
+- **Rockchip（瑞芯微）**：[瑞芯微软件支持矩阵](./rockchip.md) — 覆盖 Yocto、Radxa OS（Debian）、OpenWrt、Armbian、Android 与 FnOS
 
 更多平台（如 Allwinner、Qualcomm 等）将陆续补充。

--- a/docs/software-support-matrix/rockchip.md
+++ b/docs/software-support-matrix/rockchip.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # 瑞芯微软件支持矩阵

--- a/i18n/en/docusaurus-plugin-content-docs/current/software-support-matrix/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/software-support-matrix/README.md
@@ -1,6 +1,5 @@
 ---
-sidebar_position: 4
-displayed_sidebar: home
+sidebar_position: 1
 ---
 
 # Software Support Matrix
@@ -9,6 +8,6 @@ This page summarizes operating system support across Radxa platforms, with a ded
 
 ## Covered platforms
 
-- **Rockchip**: [Rockchip Software Support Matrix](./rockchip) — covering Yocto, Radxa OS (Debian), OpenWrt, Armbian, Android and FnOS
+- **Rockchip**: [Rockchip Software Support Matrix](./rockchip.md) — covering Yocto, Radxa OS (Debian), OpenWrt, Armbian, Android and FnOS
 
 More platforms (e.g. Allwinner, Qualcomm) will be added over time.

--- a/i18n/en/docusaurus-plugin-content-docs/current/software-support-matrix/rockchip.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/software-support-matrix/rockchip.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # Rockchip Software Support Matrix


### PR DESCRIPTION
## What

Fixes two issues on the published Software Support Matrix pages:

1. **Overview page shows no sub-navigation and the link is broken**
   - The overview (`/software-support-matrix`) previously set `displayed_sidebar: home`, so it stayed on the global home sidebar instead of switching to the matrix's own autogenerated sidebar (where the Rockchip sub-page lives). Other top-level sections (e.g. compliance) don't set `displayed_sidebar`, so their overview page shows the section sidebar with children. Removed it.
   - The in-page link used `./rockchip` without the `.md` suffix. Docusaurus treats it as a plain relative URL; from `/software-support-matrix` (no trailing slash) it resolves to `/rockchip` → 404. Correct target is `/software-support-matrix/rockchip`. Changed to `./rockchip.md` so Docusaurus resolves it to the real permalink.

2. **Ordering within the section sidebar**
   - Overview now has `sidebar_position: 1`, Rockchip sub-matrix `sidebar_position: 2`, so the overview appears first in the autogenerated sidebar.

zh/en updated in sync.
