### PR TITLE
docs(penta-sata-hat): document onboard 2-pin 5V fan header spec

### DIFF
--- a/docs/accessories/storage/penta-sata-hat/README.md
+++ b/docs/accessories/storage/penta-sata-hat/README.md
@@ -122,9 +122,24 @@ Penta SATA HAT 系列通常由以下部分组成：
 | 9   | GND      | 10  | NC         |
 
 **技术规格：**
+
 - **连接器类型：** 2x5 针座子
 - **针距 (Pitch)：** 2.0mm
 - **兼容连接器：** 标准 2.0mm 间距 2x5 针排针 (2x5 pin header, 2.0mm pitch)
+
+## 板载风扇接口
+
+Penta SATA HAT 底板在 12V DC 电源座旁提供了一个 2-pin 风扇接口（位于板底），规格如下：
+
+- **连接器类型：** JST GH 1.25mm 2-pin 公座
+- **针距 (Pitch)：** 1.25mm
+- **兼容连接器：** JST GH 1.25mm 2-pin 母座（线对板连接器）
+- **输出电压：** 固定 5V（5V + GND），请使用 5V 风扇，上电前注意极性
+- **控制方式：** 非 PWM，上电即常转；如需 PWM 调速，请使用可选的 [Penta SATA HAT TOP 板](./sata-hat-top-board.md)（通过 2x5 座子上的 PWM 信号控制）
+
+:::caution
+请不要强行插入 2.0mm 间距（如 JST PH）的插头，1.25mm 与 2.0mm 不兼容。
+:::
 
 ## 用户指南
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/accessories/storage/penta-sata-hat/README.md
@@ -122,9 +122,24 @@ If you run into installation or boot problems, identify which combination you ar
 | 9   | GND      | 10  | NC         |
 
 **Technical Specifications:**
+
 - **Connector Type:** 2x5 pin header
 - **Pitch:** 2.0mm
 - **Compatible Connectors:** Standard 2.0mm pitch 2x5 pin header (2x5 pin header, 2.0mm pitch)
+
+## Onboard Fan Header
+
+The Penta SATA HAT base board provides a 2-pin fan header right next to the 12V DC power jack (on the underside of the board). Its specification is as follows:
+
+- **Connector Type:** JST GH 1.25mm 2-pin male header
+- **Pitch:** 1.25mm
+- **Compatible Connector:** JST GH 1.25mm 2-pin female connector (wire-to-board)
+- **Output Voltage:** Fixed 5V (5V + GND) - use a 5V fan and check polarity before powering on
+- **Control:** Non-PWM, always on when powered; for PWM fan speed control, use the optional [Penta SATA HAT top board](./sata-hat-top-board.md) (PWM signal via the 2x5 header)
+
+:::caution
+Do not force a 2.0mm pitch plug (e.g. JST PH) into this header - 1.25mm and 2.0mm are not interchangeable.
+:::
 
 ## User Guide
 


### PR DESCRIPTION
## Summary

Document the onboard **2-pin fan header** on the Penta SATA HAT base board, located right next to the 12V DC power jack (underside).

## Source

- 2026-09-09 customer question (Daniel Rodriguez, support thread `1a083121a95e954b`): asked for the connector type of the small 2-pin fan header next to the DC power plug so he could buy a matching plug.
- Confirmed by Radxa Team forum staff posts (setq): [fan header size](https://forum.radxa.com/t/penta-sata-hat-fan-header-size/21078) — "JST GH 1.25mm 2pin"; [5V fan header on Penta Hat](https://forum.radxa.com/t/5v-fan-header-on-penta-hat-for-raspberry-5-model/24689) — "JST 1.25mm 2pin", 5V.
- The docs previously did not record this connector spec anywhere on the Penta SATA HAT page, so customers had to ask / guess (risk of forcing an incompatible 2.0mm JST PH plug).

## Change

- zh + en: add an "板载风扇接口 / Onboard Fan Header" section listing connector type (JST GH 1.25mm 2-pin), fixed 5V output, non-PWM always-on, and a caution that 1.25mm and 2.0mm (JST PH) are not interchangeable; PWM control available via the optional top board.
- No behavior/product claims beyond what Radxa Team staff confirmed on the forum.
