### PR TITLE
docs(rock4d): note CAN FD support and external CAN transceiver requirement

### DIFF
--- a/docs/rock4/rock4d/hardware-use/canbus.md
+++ b/docs/rock4/rock4d/hardware-use/canbus.md
@@ -12,3 +12,9 @@ imports_resolve_to:
 import CANBUS from '../../../common/dev/\_canbus.mdx';
 
 <CANBUS rsetup_link="../system-config/rsetup#overlays" />
+
+:::tip
+ROCK 4D 的 CAN 控制器支持 CAN FD（CAN with Flexible Data-Rate），可以使用示例命令中的 `fd on` 与 `dbitrate` 配置数据段波特率。
+
+ROCK 4D 主板**不板载 CAN 收发器**，需要外接 CAN 收发器模块；如果要使用 CAN FD 较高的数据段速率，请确认外接的收发器模块本身支持 CAN FD。
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/hardware-use/canbus.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/rock4/rock4d/hardware-use/canbus.md
@@ -12,3 +12,9 @@ imports_resolve_to:
 import CANBUS from '../../../common/dev/\_canbus.mdx';
 
 <CANBUS rsetup_link="../system-config/rsetup#overlays" />
+
+:::tip
+The CAN controller on ROCK 4D supports CAN FD (CAN with Flexible Data-Rate), and you can use `fd on` and `dbitrate` in the example commands to configure the data phase bitrate.
+
+ROCK 4D **does not have an on-board CAN transceiver**, so an external CAN transceiver module is required. If you need the higher data phase bitrates of CAN FD, make sure the external transceiver module itself supports CAN FD.
+:::


### PR DESCRIPTION
## Summary

- 在 ROCK 4D 的 CANBUS 使用页（`hardware-use/canbus.md`）补一条 tip，说明两点：
  - ROCK 4D 的 CAN 控制器支持 CAN FD，可直接使用共享模板示例里的 `fd on` / `dbitrate` 配置数据段波特率；
  - ROCK 4D 主板不板载 CAN 收发器，需要外接 CAN 收发器模块；若使用 CAN FD 较高的数据段速率，外接模块自身也要支持 CAN FD。
- 中英文同步：`docs/rock4/rock4d/hardware-use/canbus.md` + `i18n/en/.../rock4/rock4d/hardware-use/canbus.md`，各新增 6 行说明，不改动共享模板 `common/dev/_canbus.mdx`。

## Why

来源：一条内部技术支持问询「ROCK 4D 支持 canfd 吗？」。

ROCK 4D 的 CANBUS 页面目前只导入共享模板，页面本身没有说明 FD 支持，也没有提示板载没有 CAN 收发器。这容易造成两类误解：

1. 以为 ROCK 4D 只支持经典 CAN，不敢按示例使用 `fd on` / `dbitrate`；
2. 忽略板载无 CAN 收发器，外接时选了只支持经典 CAN 的收发器模块，CAN FD 高数据段速率实际跑不起来。

## Evidence

- Radxa 内核 `linux-6.1-stan-rkr5` 中，RK3576 的 CAN 控制器是 CAN FD 控制器：驱动 `drivers/net/can/rockchip/rk3576_canfd.c`，`of_device_id` 为 `rockchip,rk3576-canfd`，`ctrlmode_supported` 包含 `CAN_CTRLMODE_FD`（数据段位定时 `data_bittiming_const` / `CAN_DBTP`）。
- ROCK 4D 通过 40-pin 排针引出 CAN1（M1 / M3），radxa-overlays 已提供 `Enable CAN1-M1` / `Enable CAN1-M3`。
- ROCK 4D 无板载 CAN 收发器，CAN 信号由 SoC 直接引出到 40-pin；使用 CAN（FD）需要外接收发器模块。

## Verification

- `git diff --check` 通过。
- `pre-commit run --files <两个文件>` 全部通过（含 prettier、agent doc lint、agent doc drift guard、agent doc translation guard）。
- `scripts/github_pr_guard.py check` → `ok=true`（1 commit / 2 files，中英文配对完整）。
